### PR TITLE
FIX: release, default IPC addresses in child subnet, minor fixes

### DIFF
--- a/docs/quickstart-calibration.md
+++ b/docs/quickstart-calibration.md
@@ -68,9 +68,9 @@ keystore_path = "~/.ipc"
 id = "/r314159"
 
 [subnets.config]
-gateway_addr = "0x56948d2CFaa2EF355B8C08Ac925202db212146D1"
 network_type = "fevm"
 provider_http = "https://api.calibration.node.glif.io/rpc/v1"
+gateway_addr = "0x56948d2CFaa2EF355B8C08Ac925202db212146D1"
 registry_addr = "0x6A4884D2B6A597792dC68014D4B7C117cca5668e"
 
 # Subnet template - uncomment and adjust before using
@@ -78,10 +78,10 @@ registry_addr = "0x6A4884D2B6A597792dC68014D4B7C117cca5668e"
 # id = "/r314159/<SUBNET_ID>"
 
 # [subnets.config]
-# gateway_addr = "t064"
-# jsonrpc_api_http = "http://127.0.0.1:1251/rpc/v1"
-# auth_token = "<AUTH_TOKEN_1>"
-# network_type = "fvm"
+# network_type = "fevm"
+# provider_http = "https://api.calibration.node.glif.io/rpc/v1"
+# gateway_addr = "0x77aa40b105843728088c0132e43fc44348881da8"
+# registry_addr = "0x74539671a1d2f1c8f200826baba665179f53a1b7"
 ```
 
 ## Step 3: Set up your wallets
@@ -214,10 +214,10 @@ nano ~/.ipc/config.toml
 id = "/r314159"
 
 [subnets.config]
-gateway_addr = "0xff00000000000000000000000000000000000064"
 network_type = "fevm"
 provider_http = "http://127.0.0.1:<ETH_RPC_PORT>"
-registry_addr = "0xff00000000000000000000000000000000000065"
+gateway_addr = "0x77aa40b105843728088c0132e43fc44348881da8"
+registry_addr = "0x74539671a1d2f1c8f200826baba665179f53a1b7"
 ```
 
 With this you should be able to start interacting with your local subnet directly through your `ipc-cli`. You can try to fetch the balances of your wallets through:
@@ -225,12 +225,13 @@ With this you should be able to start interacting with your local subnet directl
 ./bin/ipc-cli wallet balances -w evm --subnet=<SUBNET_ID>
 ```
 
+> The ETH addresses for `gateway_addr` and `registry_addr` used when they are deployed in genesis in a child subnet by Fendermint are `0x77aa40b105843728088c0132e43fc44348881da8` and `0x74539671a1d2f1c8f200826baba665179f53a1b7, respectively.
+
 ## Step 8: Interact with your the ETH RPC
 
 For information about how to connect your Ethereum tooling with your subnet refer to the [following docs](./contracts.md).
 
 ## Step 9: What now?
-> WIP: Docs in progress
-<!-- * Proceed to the [usage](usage.md) guide to learn how you can test your new subnet. -->
-<!-- * If something went wrong, please have a look at the [README](https://github.com/consensus-shipyard/ipc-agent). If it doesn't help, please join us in #ipc-help. In either case, let us know your experience! -->
-<!-- * Please note that to repeat this guide or spawn a new subnet, you may need to change the parameters or reset your system. -->
+* Proceed to the [usage](usage.md) guide to learn how you can test your new subnet.
+* If something went wrong, please have a look at the [README](https://github.com/consensus-shipyard/ipc). If it doesn't help, please join us in #ipc-help. In either case, let us know your experience!
+* Please note that to repeat this guide or spawn a new subnet, you may need to change the parameters or reset your system.

--- a/ipc/cli/src/commands/crossmsg/release.rs
+++ b/ipc/cli/src/commands/crossmsg/release.rs
@@ -74,8 +74,8 @@ pub(crate) struct ReleaseArgs {
     pub to: Option<String>,
     #[arg(long, short, help = "The subnet to release funds from")]
     pub subnet: String,
+    #[arg(long, help = "The fee to pay for the cross-net message, in whole FIL")]
+    pub fee: Option<f64>,
     #[arg(help = "The amount to release in FIL, in whole FIL")]
     pub amount: f64,
-    #[arg(help = "The fee to pay for the cross-net message, in whole FIL")]
-    pub fee: Option<f64>,
 }

--- a/ipc/cli/src/commands/wallet/balances.rs
+++ b/ipc/cli/src/commands/wallet/balances.rs
@@ -30,6 +30,7 @@ impl CommandLineHandler for WalletBalances {
             WalletType::Evm => {
                 let wallet = provider.evm_wallet()?;
                 let addresses = wallet.read().unwrap().list()?;
+                let mut no_balance = addresses.clone();
                 let r = addresses
                     .iter()
                     .map(|addr| {
@@ -52,8 +53,12 @@ impl CommandLineHandler for WalletBalances {
                 for r in v.into_iter().filter_map(|r| r.ok()) {
                     let (balance, addr) = r;
                     if addr.to_string() != "default-key" {
-                        println!("{:?} - Balance: {}", addr.to_string(), balance);
+                        println!("{} - Balance: {}", addr.to_string(), balance);
+                        no_balance.retain(|a| a != addr);
                     }
+                }
+                for addr in no_balance {
+                    println!("{} - Balance: 0", addr.to_string());
                 }
             }
             WalletType::Fvm => {

--- a/ipc/provider/src/config/mod.rs
+++ b/ipc/provider/src/config/mod.rs
@@ -35,9 +35,9 @@ keystore_path = "~/.ipc"
 id = "/r314159"
 
 [subnets.config]
-gateway_addr = "0x56948d2CFaa2EF355B8C08Ac925202db212146D1"
 network_type = "fevm"
 provider_http = "https://api.calibration.node.glif.io/rpc/v1"
+gateway_addr = "0x56948d2CFaa2EF355B8C08Ac925202db212146D1"
 registry_addr = "0x6A4884D2B6A597792dC68014D4B7C117cca5668e"
 
 # Subnet template - uncomment and adjust before using
@@ -45,10 +45,10 @@ registry_addr = "0x6A4884D2B6A597792dC68014D4B7C117cca5668e"
 # id = "/r314159/<SUBNET_ID>"
 
 # [subnets.config]
-# gateway_addr = "t064"
-# jsonrpc_api_http = "http://127.0.0.1:1251/rpc/v1"
-# auth_token = "<AUTH_TOKEN_1>"
-# network_type = "fvm"
+# network_type = "fevm"
+# provider_http = "https://api.calibration.node.glif.io/rpc/v1"
+# gateway_addr = "0x77aa40b105843728088c0132e43fc44348881da8"
+# registry_addr = "0x74539671a1d2f1c8f200826baba665179f53a1b7"
 "#;
 
 /// The top-level struct representing the config. Calls to [`Config::from_file`] deserialize into

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -514,6 +514,7 @@ impl SubnetManager for EthSubnetManager {
                     self.ipc_contract_info.gateway_addr,
                     Arc::new(self.ipc_contract_info.provider.clone()),
                 );
+                // use default cross-message fee if not set.
                 gateway_getter.cross_msg_fee().call().await?
             }
         };

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use ethers::types::H256;
+use fvm_shared::BLOCK_GAS_LIMIT;
 use ipc_actors_abis::{
     gateway_getter_facet, gateway_manager_facet, gateway_messenger_facet, lib_staking_change_log,
     subnet_actor_getter_facet, subnet_actor_manager_facet, subnet_registry,
@@ -485,6 +486,7 @@ impl SubnetManager for EthSubnetManager {
             gateway_manager_facet::FvmAddress::try_from(to)?,
         );
         txn.tx.set_value(value);
+        txn.tx.set_gas(BLOCK_GAS_LIMIT);
         let txn = call_with_premium_estimation(signer, txn).await?;
 
         let pending_tx = txn.send().await?;
@@ -494,7 +496,6 @@ impl SubnetManager for EthSubnetManager {
 
     async fn release(
         &self,
-        _subnet: SubnetID,
         gateway_addr: Address,
         from: Address,
         to: Address,

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -6,7 +6,6 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use ethers::types::H256;
-use fvm_shared::BLOCK_GAS_LIMIT;
 use ipc_actors_abis::{
     gateway_getter_facet, gateway_manager_facet, gateway_messenger_facet, lib_staking_change_log,
     subnet_actor_getter_facet, subnet_actor_manager_facet, subnet_registry,
@@ -486,7 +485,6 @@ impl SubnetManager for EthSubnetManager {
             gateway_manager_facet::FvmAddress::try_from(to)?,
         );
         txn.tx.set_value(value);
-        txn.tx.set_gas(BLOCK_GAS_LIMIT);
         let txn = call_with_premium_estimation(signer, txn).await?;
 
         let pending_tx = txn.send().await?;

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -82,7 +82,6 @@ pub trait SubnetManager: Send + Sync + TopDownCheckpointQuery + BottomUpCheckpoi
     /// Returns the epoch that the released is executed in the child.
     async fn release(
         &self,
-        subnet: SubnetID,
         gateway_addr: Address,
         from: Address,
         to: Address,


### PR DESCRIPTION
This PR includes several minor fixes.

- It adds the new default addresses for the IPC contracts when deployed in genesis by Fendermint in child subnets: https://github.com/consensus-shipyard/fendermint/pull/338
- It re-arranges the fields of the config in the template. 
- It fixes the `release` command so it passes the `fee` correctly.
- It updates the docs and adds additional logs.