### PR TITLE
IPC-354: update infra scripts to use FM-329

### DIFF
--- a/docs/quickstart-calibration.md
+++ b/docs/quickstart-calibration.md
@@ -168,7 +168,7 @@ Remember the address of your bootstrap for the next step. This address has the f
 ./bin/ipc-cli subnet add-bootstrap --subnet=<SUBNET_ID> --endpoint=<BOOTSRAP_ENDPOINT>
 ```
 
-* The bootstrap nodes currently deployed in the network can be queried through the following command: 
+* The bootstrap nodes currently deployed in the network can be queried through the following command:
 ```bash
 ./bin/ipc-cli subnet list-bootstraps --subnet=<SUBNET_ID>
 ```
@@ -178,9 +178,9 @@ With the bootstrap node deployed and advertised to the network, we are now ready
 
 * First we need to export the private keys of our validators from the addresses that we created with our `ipc-cli wallet` to a known path so they can be picked by Fendermint to sign blocks. We can use the default repo of IPC for this, `~/.ipc`.
 ```bash
-./bin/ipc-cli wallet export -w evm -a <WALLET_ADDR1> --fendermint -o ~/.ipc/<PRIV_KEY_VALIDATOR_1>
-./bin/ipc-cli wallet export -w evm -a <WALLET_ADDR1> --fendermint -o ~/.ipc/<PRIV_KEY_VALIDATOR_1>
-./bin/ipc-cli wallet export -w evm -a <WALLET_ADDR1> --fendermint -o ~/.ipc/<PRIV_KEY_VALIDATOR_1>
+./bin/ipc-cli wallet export -w evm -a <WALLET_ADDR1> --hex -o ~/.ipc/<PRIV_KEY_VALIDATOR_1>
+./bin/ipc-cli wallet export -w evm -a <WALLET_ADDR1> --hex -o ~/.ipc/<PRIV_KEY_VALIDATOR_1>
+./bin/ipc-cli wallet export -w evm -a <WALLET_ADDR1> --hex -o ~/.ipc/<PRIV_KEY_VALIDATOR_1>
 ```
 
 * Now we have all that we need to deploy the three validators using the following command (configured for each of the validators, i.e. replace the arguments with `<..-n>` to fit that of the specific validator).
@@ -188,7 +188,7 @@ With the bootstrap node deployed and advertised to the network, we are now ready
 ```bash
 cargo make --makefile /bin/ipc-infra/Makefile.toml \
     -e NODE_NAME=validator-<n> \
-    -e VALIDATOR_PRIV_KEY=<PATH_PRIV_KEY_VALIDATOR_n> \
+    -e PRIVATE_KEY_PATH=<PATH_PRIV_KEY_VALIDATOR_n> \
     -e SUBNET_ID=<SUBNET_ID> \
     -e CMT_P2P_HOST_PORT=<COMETBFT_P2P_PORT_n> -e CMT_RPC_HOST_PORT=<COMETBFT_RPC_PORT_n> \
     -e ETHAPI_HOST_PORT=<ETH_RPC_PORT_n> \

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,12 +20,19 @@ The `ipc-cli` has internally an EVM wallet that it uses to sign transactions and
 ```
 ```console
 # Sample execution
-./bin/ipc-cli wallet export -w evm -a 0x406a7a1d002b71ece175cc7e067620ae5b58e9ec -o /tmp/priv.key                                                                                     ✔  12:21:38 
-exported new wallet with address 0x406a7a1d002b71ece175cc7e067620ae5b58e9ec in file "/tmp/priv.key"```
+./bin/ipc-cli wallet export -w evm -a 0x406a7a1d002b71ece175cc7e067620ae5b58e9ec -o /tmp/priv.key
+exported new wallet with address 0x406a7a1d002b71ece175cc7e067620ae5b58e9ec in file "/tmp/priv.key"
+```
 
-* You can also export your private key in a format that can be consumed by Fendermint by adding the `--fendermint` flag.
+* You can also export your private key encoded in base64 in a format that can be consumed by Fendermint by adding the `--fendermint` flag.
 ```bash
 ./bin/ipc-cli wallet export -w evm -a <EVM-ADDRESS> -o <OUTPUT_FILE> --fendermint
+```
+
+* Or hex encoded as expected by Ethereum tooling (like Metamask or hardhat).
+```bash
+./bin/ipc-cli wallet export -w evm -a <EVM-ADDRESS> -o <OUTPUT_FILE> --hex
+```
 
 * Importing a key from a file
 ```bash

--- a/ipc/cli/src/commands/wallet/export.rs
+++ b/ipc/cli/src/commands/wallet/export.rs
@@ -27,6 +27,10 @@ impl WalletExport {
             .get(&address.into())?
             .ok_or_else(|| anyhow!("key does not exists"))?;
 
+        if arguments.hex {
+            return Ok(hex::encode(key_info.private_key()));
+        }
+
         if arguments.fendermint {
             return Ok(BASE64_STANDARD.encode(key_info.private_key()));
         }
@@ -43,9 +47,15 @@ impl WalletExport {
 
         let addr = Address::from_str(&arguments.address)?;
         let key_info = wallet.write().unwrap().export(&addr)?;
+
+        if arguments.hex {
+            return Ok(hex::encode(key_info.private_key()));
+        }
+
         if arguments.fendermint {
             return Ok(BASE64_STANDARD.encode(key_info.private_key()));
         }
+
         Ok(serde_json::to_string(&LotusJsonKeyType {
             r#type: WalletKeyType::try_from(*key_info.key_type())?.to_string(),
             private_key: BASE64_STANDARD.encode(key_info.private_key()),
@@ -87,7 +97,7 @@ impl CommandLineHandler for WalletExport {
 }
 
 #[derive(Debug, Args)]
-#[command(about = "Export the key from a wallet address")]
+#[command(about = "Export the key from a wallet address in JSON format")]
 pub(crate) struct WalletExportArgs {
     #[arg(long, short, help = "Address of the key to export")]
     pub address: String,
@@ -102,9 +112,11 @@ pub(crate) struct WalletExportArgs {
     #[arg(
         long,
         short,
-        help = "Only returns the secret key in base64 as Fendermint expects"
+        help = "Exports the secret key encoded in base64 as Fendermint expects"
     )]
     pub fendermint: bool,
+    #[arg(long, short, help = "Export the hex encoded secret key")]
+    pub hex: bool,
 }
 
 pub(crate) struct WalletPublicKey;

--- a/scripts/install_infra.sh
+++ b/scripts/install_infra.sh
@@ -19,15 +19,10 @@ fi
 
 build_infra() {
     echo "[*] Building fendermint..."
-    make build docker-build
     cd $PWD
 
     echo "[*] Updating infra scripts..."
     cp -r $infra_path/fendermint/infra/* $infra_path
-    # TODO: This will no longer be necessary once https://github.com/consensus-shipyard/fendermint/pull/329
-    # is merged
-    mkdir -p ./target/release
-    mv $infra_path/fendermint/target/release/fendermint $PWD/target/release
 }
 
 # Function to display help message


### PR DESCRIPTION
Depends on https://github.com/consensus-shipyard/fendermint/pull/329
Closes #351 #354

- Updates the infra scripts to use the latest version from https://github.com/consensus-shipyard/fendermint/pull/329 that removes the need to build `fendermint` and the docker image as it picks it up from the docker registry.
- It adds an `--hex` flag to `ipc-cli wallet export` to return the hex encoded private key of an address in wallet (expected by the new scripts).
- Updates docs accordingly.