### PR TITLE
IPC-347: add pre-fund command and genesis balances in GenesisInfo call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2697,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=fm-347-subnet-prefund#55f427ba3f786db6c5463f28061d2ea25a12e292"
+source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#cec4e7ede1e16589b86da91b18d197601c90d14b"
 dependencies = [
  "anyhow",
  "ethers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2697,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#3f72d21d0ad601fbb673b6a9bc650d14f7be9c9f"
+source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=fm-347-subnet-prefund#55f427ba3f786db6c5463f28061d2ea25a12e292"
 dependencies = [
  "anyhow",
  "ethers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2697,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#cec4e7ede1e16589b86da91b18d197601c90d14b"
+source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#b4c23f216b813f10dfa6fa54ea4cb248012cf312"
 dependencies = [
  "anyhow",
  "ethers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
 resolver = "2"
 members = [
-	# "ipc/daemon", 
+	# "ipc/daemon",
 	"ipc/cli",
-	# "ipc/testing/e2e", 
+	# "ipc/testing/e2e",
 	# "ipc/testing/*",
 	"ipc/provider",
-	"ipc/identity", 
+	"ipc/identity",
 	"ipc/sdk"
 ]
 
@@ -42,7 +42,7 @@ hex = "0.4.3"
 tempfile = "3.4.0"
 serde_json = { version = "1.0.91", features = ["raw_value"] }
 
-ipc_actors_abis = { git = "https://github.com/consensus-shipyard/ipc-solidity-actors.git", branch = "dev" }
+ipc_actors_abis = { git = "https://github.com/consensus-shipyard/ipc-solidity-actors.git", branch = "fm-347-subnet-prefund" }
 
 libipld = { version = "0.14", default-features = false, features = ["dag-cbor"] }
 libsecp256k1 = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ hex = "0.4.3"
 tempfile = "3.4.0"
 serde_json = { version = "1.0.91", features = ["raw_value"] }
 
-ipc_actors_abis = { git = "https://github.com/consensus-shipyard/ipc-solidity-actors.git", branch = "fm-347-subnet-prefund" }
+ipc_actors_abis = { git = "https://github.com/consensus-shipyard/ipc-solidity-actors.git", branch = "dev" }
 
 libipld = { version = "0.14", default-features = false, features = ["dag-cbor"] }
 libsecp256k1 = "0.7"

--- a/ipc/cli/src/commands/crossmsg/fund.rs
+++ b/ipc/cli/src/commands/crossmsg/fund.rs
@@ -96,7 +96,7 @@ impl CommandLineHandler for PreFund {
                 f64_to_token_amount(arguments.initial_balance)?,
             )
             .await?;
-        println!("address pre-funded successfully");
+        log::info!("address pre-funded successfully");
 
         Ok(())
     }

--- a/ipc/cli/src/commands/crossmsg/fund.rs
+++ b/ipc/cli/src/commands/crossmsg/fund.rs
@@ -73,3 +73,45 @@ pub(crate) struct FundArgs {
     #[arg(help = "The amount to fund in FIL, in whole FIL")]
     pub amount: f64,
 }
+
+pub struct PreFund;
+
+#[async_trait]
+impl CommandLineHandler for PreFund {
+    type Arguments = PreFundArgs;
+
+    async fn handle(global: &GlobalArguments, arguments: &Self::Arguments) -> anyhow::Result<()> {
+        log::debug!("pre-fund subnet with args: {:?}", arguments);
+
+        let mut provider = get_ipc_provider(global)?;
+        let subnet = SubnetID::from_str(&arguments.subnet)?;
+        let from = match &arguments.from {
+            Some(address) => Some(require_fil_addr_from_str(address)?),
+            None => None,
+        };
+        provider
+            .pre_fund(
+                subnet.clone(),
+                from,
+                f64_to_token_amount(arguments.initial_balance)?,
+            )
+            .await?;
+        println!("address pre-funded successfully");
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Args)]
+#[command(
+    name = "pre-fund",
+    about = "Add some funds in genesis to an address in a child-subnet"
+)]
+pub struct PreFundArgs {
+    #[arg(long, short, help = "The address funded in the subnet")]
+    pub from: Option<String>,
+    #[arg(long, short, help = "The subnet to add balance to")]
+    pub subnet: String,
+    #[arg(help = "Add an initial balance for the address in genesis in the subnet")]
+    pub initial_balance: f64,
+}

--- a/ipc/cli/src/commands/crossmsg/mod.rs
+++ b/ipc/cli/src/commands/crossmsg/mod.rs
@@ -1,5 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
+use self::fund::{PreFund, PreFundArgs};
+use self::release::{PreRelease, PreReleaseArgs};
 use self::topdown_cross::{ListTopdownMsgs, ListTopdownMsgsArgs};
 use crate::commands::crossmsg::fund::Fund;
 use crate::commands::crossmsg::propagate::Propagate;
@@ -28,7 +30,9 @@ impl CrossMsgsCommandsArgs {
     pub async fn handle(&self, global: &GlobalArguments) -> anyhow::Result<()> {
         match &self.command {
             Commands::Fund(args) => Fund::handle(global, args).await,
+            Commands::PreFund(args) => PreFund::handle(global, args).await,
             Commands::Release(args) => Release::handle(global, args).await,
+            Commands::PreRelease(args) => PreRelease::handle(global, args).await,
             Commands::Propagate(args) => Propagate::handle(global, args).await,
             Commands::ListTopdownMsgs(args) => ListTopdownMsgs::handle(global, args).await,
         }
@@ -38,7 +42,9 @@ impl CrossMsgsCommandsArgs {
 #[derive(Debug, Subcommand)]
 pub(crate) enum Commands {
     Fund(FundArgs),
+    PreFund(PreFundArgs),
     Release(ReleaseArgs),
+    PreRelease(PreReleaseArgs),
     Propagate(PropagateArgs),
     ListTopdownMsgs(ListTopdownMsgsArgs),
 }

--- a/ipc/cli/src/commands/crossmsg/release.rs
+++ b/ipc/cli/src/commands/crossmsg/release.rs
@@ -98,7 +98,7 @@ impl CommandLineHandler for PreRelease {
         provider
             .pre_release(subnet.clone(), from, f64_to_token_amount(arguments.amount)?)
             .await?;
-        println!("address pre-release successfully");
+        log::info!("address pre-release successfully");
 
         Ok(())
     }

--- a/ipc/cli/src/commands/subnet/join.rs
+++ b/ipc/cli/src/commands/subnet/join.rs
@@ -179,13 +179,13 @@ impl CommandLineHandler for PreFundSubnet {
 #[derive(Debug, Args)]
 #[command(
     name = "pre-fund",
-    about = "Pre fund with some funds in genesis in a child-subnet"
+    about = "Add some funds in genesis to an address in a child-subnet"
 )]
 pub struct PreFundSubnetArgs {
     #[arg(long, short, help = "The address funded in the subnet")]
     pub from: Option<String>,
     #[arg(long, short, help = "The subnet to add balance to")]
     pub subnet: String,
-    #[arg(help = "Optionally add an initial balance to the validator in genesis in the subnet")]
+    #[arg(help = "Add an initial balance for the address in genesis in the subnet")]
     pub initial_balance: f64,
 }

--- a/ipc/cli/src/commands/subnet/join.rs
+++ b/ipc/cli/src/commands/subnet/join.rs
@@ -32,7 +32,7 @@ impl CommandLineHandler for JoinSubnet {
         if let Some(initial_balance) = arguments.initial_balance {
             println!("pre-funding address with {initial_balance}");
             provider
-                .prefund_subnet(subnet.clone(), from, f64_to_token_amount(initial_balance)?)
+                .pre_fund(subnet.clone(), from, f64_to_token_amount(initial_balance)?)
                 .await?;
         }
         let epoch = provider
@@ -146,46 +146,4 @@ pub struct UnstakeSubnetArgs {
         help = "The collateral to unstake from the subnet (in whole FIL units)"
     )]
     pub collateral: f64,
-}
-
-pub struct PreFundSubnet;
-
-#[async_trait]
-impl CommandLineHandler for PreFundSubnet {
-    type Arguments = PreFundSubnetArgs;
-
-    async fn handle(global: &GlobalArguments, arguments: &Self::Arguments) -> anyhow::Result<()> {
-        log::debug!("pre-fund subnet with args: {:?}", arguments);
-
-        let mut provider = get_ipc_provider(global)?;
-        let subnet = SubnetID::from_str(&arguments.subnet)?;
-        let from = match &arguments.from {
-            Some(address) => Some(require_fil_addr_from_str(address)?),
-            None => None,
-        };
-        provider
-            .prefund_subnet(
-                subnet.clone(),
-                from,
-                f64_to_token_amount(arguments.initial_balance)?,
-            )
-            .await?;
-        println!("address pre-funded successfully");
-
-        Ok(())
-    }
-}
-
-#[derive(Debug, Args)]
-#[command(
-    name = "pre-fund",
-    about = "Add some funds in genesis to an address in a child-subnet"
-)]
-pub struct PreFundSubnetArgs {
-    #[arg(long, short, help = "The address funded in the subnet")]
-    pub from: Option<String>,
-    #[arg(long, short, help = "The subnet to add balance to")]
-    pub subnet: String,
-    #[arg(help = "Add an initial balance for the address in genesis in the subnet")]
-    pub initial_balance: f64,
 }

--- a/ipc/cli/src/commands/subnet/join.rs
+++ b/ipc/cli/src/commands/subnet/join.rs
@@ -30,7 +30,7 @@ impl CommandLineHandler for JoinSubnet {
         };
         let public_key = hex::decode(&arguments.public_key)?;
         if let Some(initial_balance) = arguments.initial_balance {
-            println!("pre-funding address with {initial_balance}");
+            log::info!("pre-funding address with {initial_balance}");
             provider
                 .pre_fund(subnet.clone(), from, f64_to_token_amount(initial_balance)?)
                 .await?;

--- a/ipc/cli/src/commands/subnet/join.rs
+++ b/ipc/cli/src/commands/subnet/join.rs
@@ -32,11 +32,7 @@ impl CommandLineHandler for JoinSubnet {
         if let Some(initial_balance) = arguments.initial_balance {
             println!("pre-funding address with {initial_balance}");
             provider
-                .prefund_subnet(
-                    subnet.clone(),
-                    from,
-                    f64_to_token_amount(initial_balance.clone())?,
-                )
+                .prefund_subnet(subnet.clone(), from, f64_to_token_amount(initial_balance)?)
                 .await?;
         }
         let epoch = provider

--- a/ipc/cli/src/commands/subnet/mod.rs
+++ b/ipc/cli/src/commands/subnet/mod.rs
@@ -13,10 +13,7 @@ use crate::{CommandLineHandler, GlobalArguments};
 use clap::{Args, Subcommand};
 
 use self::bootstrap::{AddBootstrap, AddBootstrapArgs, ListBootstraps, ListBootstrapsArgs};
-use self::join::{
-    PreFundSubnet, PreFundSubnetArgs, StakeSubnet, StakeSubnetArgs, UnstakeSubnet,
-    UnstakeSubnetArgs,
-};
+use self::join::{StakeSubnet, StakeSubnetArgs, UnstakeSubnet, UnstakeSubnetArgs};
 use self::leave::{Claim, ClaimArgs};
 use self::rpc::{ChainIdSubnet, ChainIdSubnetArgs};
 
@@ -58,7 +55,6 @@ impl SubnetCommandsArgs {
             Commands::AddBootstrap(args) => AddBootstrap::handle(global, args).await,
             Commands::ListBootstraps(args) => ListBootstraps::handle(global, args).await,
             Commands::GenesisEpoch(args) => GenesisEpoch::handle(global, args).await,
-            Commands::PreFund(args) => PreFundSubnet::handle(global, args).await,
         }
     }
 }
@@ -79,5 +75,4 @@ pub(crate) enum Commands {
     AddBootstrap(AddBootstrapArgs),
     ListBootstraps(ListBootstrapsArgs),
     GenesisEpoch(GenesisEpochArgs),
-    PreFund(PreFundSubnetArgs),
 }

--- a/ipc/cli/src/commands/subnet/mod.rs
+++ b/ipc/cli/src/commands/subnet/mod.rs
@@ -13,7 +13,10 @@ use crate::{CommandLineHandler, GlobalArguments};
 use clap::{Args, Subcommand};
 
 use self::bootstrap::{AddBootstrap, AddBootstrapArgs, ListBootstraps, ListBootstrapsArgs};
-use self::join::{StakeSubnet, StakeSubnetArgs, UnstakeSubnet, UnstakeSubnetArgs};
+use self::join::{
+    PreFundSubnet, PreFundSubnetArgs, StakeSubnet, StakeSubnetArgs, UnstakeSubnet,
+    UnstakeSubnetArgs,
+};
 use self::leave::{Claim, ClaimArgs};
 use self::rpc::{ChainIdSubnet, ChainIdSubnetArgs};
 
@@ -55,6 +58,7 @@ impl SubnetCommandsArgs {
             Commands::AddBootstrap(args) => AddBootstrap::handle(global, args).await,
             Commands::ListBootstraps(args) => ListBootstraps::handle(global, args).await,
             Commands::GenesisEpoch(args) => GenesisEpoch::handle(global, args).await,
+            Commands::PreFund(args) => PreFundSubnet::handle(global, args).await,
         }
     }
 }
@@ -75,4 +79,5 @@ pub(crate) enum Commands {
     AddBootstrap(AddBootstrapArgs),
     ListBootstraps(ListBootstrapsArgs),
     GenesisEpoch(GenesisEpochArgs),
+    PreFund(PreFundSubnetArgs),
 }

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -298,7 +298,7 @@ impl IpcProvider {
             .await
     }
 
-    pub async fn prefund_subnet(
+    pub async fn pre_fund(
         &mut self,
         subnet: SubnetID,
         from: Option<Address>,
@@ -314,6 +314,24 @@ impl IpcProvider {
         let sender = self.check_sender(subnet_config, from)?;
 
         conn.manager().pre_fund(subnet, sender, balance).await
+    }
+
+    pub async fn pre_release(
+        &mut self,
+        subnet: SubnetID,
+        from: Option<Address>,
+        amount: TokenAmount,
+    ) -> anyhow::Result<()> {
+        let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
+        let conn = match self.connection(&parent) {
+            None => return Err(anyhow!("target parent subnet not found")),
+            Some(conn) => conn,
+        };
+
+        let subnet_config = conn.subnet();
+        let sender = self.check_sender(subnet_config, from)?;
+
+        conn.manager().pre_release(subnet, sender, amount).await
     }
 
     pub async fn stake(

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -316,7 +316,7 @@ impl SubnetManager for EthSubnetManager {
         let balance = balance
             .atto()
             .to_u128()
-            .ok_or_else(|| anyhow!("invalid min validator stake"))?;
+            .ok_or_else(|| anyhow!("invalid initial balance"))?;
 
         let address = contract_address_from_subnet(&subnet)?;
         log::info!("interacting with evm subnet contract: {address:} with balance: {balance:}");

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -312,6 +312,27 @@ impl SubnetManager for EthSubnetManager {
         block_number_from_receipt(receipt)
     }
 
+    async fn pre_fund(&self, subnet: SubnetID, from: Address, balance: TokenAmount) -> Result<()> {
+        let balance = balance
+            .atto()
+            .to_u128()
+            .ok_or_else(|| anyhow!("invalid min validator stake"))?;
+
+        let address = contract_address_from_subnet(&subnet)?;
+        log::info!("interacting with evm subnet contract: {address:} with balance: {balance:}");
+
+        let signer = Arc::new(self.get_signer(&from)?);
+        let contract =
+            subnet_actor_manager_facet::SubnetActorManagerFacet::new(address, signer.clone());
+
+        let mut txn = contract.pre_fund();
+        txn.tx.set_value(balance);
+        let txn = call_with_premium_estimation(signer, txn).await?;
+
+        txn.send().await?;
+        Ok(())
+    }
+
     async fn stake(&self, subnet: SubnetID, from: Address, collateral: TokenAmount) -> Result<()> {
         let collateral = collateral
             .atto()
@@ -642,6 +663,9 @@ impl SubnetManager for EthSubnetManager {
             address,
             Arc::new(self.ipc_contract_info.provider.clone()),
         );
+
+        let genesis_balances = contract.genesis_balances().await?;
+
         Ok(SubnetGenesisInfo {
             // Active validators limit set for the child subnet.
             active_validators_limit: contract.active_validators_limit().call().await?,
@@ -656,6 +680,7 @@ impl SubnetManager for EthSubnetManager {
             // Custom message fee that the child subnet wants to set for cross-net messages
             msg_fee: eth_to_fil_amount(&contract.min_cross_msg_fee().call().await?)?,
             validators: from_contract_validators(contract.genesis_validators().call().await?)?,
+            genesis_balances: into_genesis_balance_map(genesis_balances.0, genesis_balances.1)?,
         })
     }
 
@@ -1160,6 +1185,17 @@ fn is_valid_bootstrap_addr(input: &str) -> Option<(String, IpAddr, u16)> {
     }
 
     None
+}
+
+fn into_genesis_balance_map(
+    addrs: Vec<ethers::types::Address>,
+    balances: Vec<ethers::types::U256>,
+) -> Result<HashMap<Address, TokenAmount>> {
+    let mut map = HashMap::new();
+    for (a, b) in addrs.into_iter().zip(balances) {
+        map.insert(ethers_address_to_fil_address(&a)?, eth_to_fil_amount(&b)?);
+    }
+    Ok(map)
 }
 
 /// Convert the ipc SubnetID type to an evm address. It extracts the last address from the Subnet id

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -37,12 +37,16 @@ pub trait SubnetManager: Send + Sync + TopDownCheckpointQuery + BottomUpCheckpoi
         metadata: Vec<u8>,
     ) -> Result<ChainEpoch>;
 
+    /// Adds some initial balance to an address before a child subnet bootstraps to make
+    /// it available in the subnet at genesis.
+    async fn pre_fund(&self, subnet: SubnetID, from: Address, balance: TokenAmount) -> Result<()>;
+
     /// Allows validators that have already joined the subnet to stake more collateral
-    /// and increase their power in the subnet
+    /// and increase their power in the subnet.
     async fn stake(&self, subnet: SubnetID, from: Address, collateral: TokenAmount) -> Result<()>;
 
     /// Allows validators that have already joined the subnet to unstake collateral
-    /// and reduce their power in the subnet
+    /// and reduce their power in the subnet.
     async fn unstake(&self, subnet: SubnetID, from: Address, collateral: TokenAmount)
         -> Result<()>;
 
@@ -142,6 +146,7 @@ pub struct SubnetGenesisInfo {
     pub min_collateral: TokenAmount,
     pub genesis_epoch: ChainEpoch,
     pub validators: Vec<Validator>,
+    pub genesis_balances: HashMap<Address, TokenAmount>,
 }
 
 /// The generic payload that returns the block hash of the data returning block with the actual

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -41,6 +41,10 @@ pub trait SubnetManager: Send + Sync + TopDownCheckpointQuery + BottomUpCheckpoi
     /// it available in the subnet at genesis.
     async fn pre_fund(&self, subnet: SubnetID, from: Address, balance: TokenAmount) -> Result<()>;
 
+    /// Releases initial funds from an address for a subnet that has not yet been bootstrapped
+    async fn pre_release(&self, subnet: SubnetID, from: Address, amount: TokenAmount)
+        -> Result<()>;
+
     /// Allows validators that have already joined the subnet to stake more collateral
     /// and increase their power in the subnet.
     async fn stake(&self, subnet: SubnetID, from: Address, collateral: TokenAmount) -> Result<()>;


### PR DESCRIPTION
`ipc-cli` implementation for https://github.com/consensus-shipyard/fendermint/issues/347

Depends on: https://github.com/consensus-shipyard/ipc-solidity-actors/pull/267

This PR:
* Adds a flag to include genesis balance for a validator when it joins. 
* Adds a `pre-fund` command for users to be able to add genesis balance in a child subnet before it is bootsrapped.
* It includes the genesis balance information in the `GenesisInfo` call made through the provider so Fendermint can use it to generate its genesis with this initial balance information.
* Adds a `pre-release` command to recover funds from the initial balance of a subnet before it bootstraps.