### PR TITLE
FIX: accept 0x address as submitter in relayer

### DIFF
--- a/ipc/cli/src/commands/checkpoint/bottomup_height.rs
+++ b/ipc/cli/src/commands/checkpoint/bottomup_height.rs
@@ -35,7 +35,7 @@ impl CommandLineHandler for LastBottomUpCheckpointHeight {
 }
 
 #[derive(Debug, Args)]
-#[command(about = "Last bottom up checkpoint height committed in a child subnet")]
+#[command(about = "Last bottom up checkpoint height committed for a child subnet in the parent")]
 pub(crate) struct LastBottomUpCheckpointHeightArgs {
     #[arg(long, short, help = "The target subnet to perform query")]
     pub subnet: String,

--- a/ipc/cli/src/commands/checkpoint/relayer.rs
+++ b/ipc/cli/src/commands/checkpoint/relayer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use crate::commands::get_subnet_config;
-use crate::{CommandLineHandler, GlobalArguments};
+use crate::{require_fil_addr_from_str, CommandLineHandler, GlobalArguments};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use clap::Args;
@@ -33,7 +33,7 @@ impl CommandLineHandler for BottomUpRelayer {
         let config = Arc::new(Config::from_file(&config_path)?);
         let mut keystore = new_evm_keystore_from_config(config)?;
         let submitter = match (arguments.submitter.as_ref(), keystore.get_default()?) {
-            (Some(submitter), _) => Address::from_str(submitter)?,
+            (Some(submitter), _) => require_fil_addr_from_str(submitter)?,
             (None, Some(addr)) => {
                 log::info!("using default address: {addr:?}");
                 Address::try_from(addr)?


### PR DESCRIPTION
Simple fix to accept `0x` as part of the relayer command in `--submitter` such as: 
```
./bin/ipc-cli checkpoint relayer --subnet /r314159/t410ffumhfeppdjixhkxtgagowxkdu77j7xz5aaa52vy --submitter 0x6be1ccf648c74800380d0520d797a170c808b624
```