### PR TITLE
FIX: remove docker-build related code from install_infra

### DIFF
--- a/scripts/install_infra.sh
+++ b/scripts/install_infra.sh
@@ -18,7 +18,6 @@ else
 fi
 
 build_infra() {
-    echo "[*] Building fendermint..."
     cd $PWD
 
     echo "[*] Updating infra scripts..."
@@ -46,51 +45,19 @@ if [ ! -d "$infra_path" ]; then
 fi
 
 
+if [[ "$#" -gt 0 && "$1" == "-f" ]]; then
+    echo "[*] -f is set. Force pulling the Fendermint repo again, and pulling latest scripts"
+    rm -rf $infra_path/fendermint
+fi
+
+
 # Check if fendermint exists
 if [ ! -d "$infra_path/fendermint" ]; then
     cd "$infra_path"
     echo "[*] Fendermint directory doesn't exist, cloning code"
     git clone https://github.com/consensus-shipyard/fendermint.git fendermint
-    echo "[*] Building infrastructure assets"
-    cd "fendermint"
     build_infra
     exit 0
 else
-    echo "[*] Fendermint code already pulled"
-fi
-
-image_name="fendermint"
-cd "$infra_path/fendermint"
-
-
-if [[ "$#" -gt 0 && "$1" == "-f" ]]; then
-    echo "[*] -f is set. Forcing new build"
-    build_infra
-    exit 0
-fi
-
-if docker inspect "$image_name" &> /dev/null ; then
-    echo "[*] Docker image '$image_name' already exists."
-else
-    build_infra
-    exit 0
-fi
-
-# Perform a Git pull to update the repository
-git_output=$(git pull)
-
-# Check if there are changes
-git fetch
-if [[ "$(git rev-list HEAD...origin/master --count)" -gt 0  ]]; then
-    echo "[*] No changes in the repository."
-else
-    build_infra
-    exit 0
-fi
-
-# Check if there are changes
-if [ -n "$(git status --porcelain)" ]; then
-    build_infra
-else
-    echo "[*] No changes detected in the repository. Doing nothing!"
+    echo "[*] Infra scripts already installed."
 fi


### PR DESCRIPTION
Remove `docker-build` related reference from the code. `install_infra` should only pull `fendermint` to get the latest `cargo make` recipes for the infrastructure.