### PR TITLE
FIX: use BTreeMap instead of HashMap in GenesisInfo to remove non-determinism

### DIFF
--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
@@ -1272,8 +1272,8 @@ fn is_valid_bootstrap_addr(input: &str) -> Option<(String, IpAddr, u16)> {
 fn into_genesis_balance_map(
     addrs: Vec<ethers::types::Address>,
     balances: Vec<ethers::types::U256>,
-) -> Result<HashMap<Address, TokenAmount>> {
-    let mut map = HashMap::new();
+) -> Result<BTreeMap<Address, TokenAmount>> {
+    let mut map = BTreeMap::new();
     for (a, b) in addrs.into_iter().zip(balances) {
         map.insert(ethers_address_to_fil_address(&a)?, eth_to_fil_amount(&b)?);
     }

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -157,7 +157,7 @@ pub struct SubnetGenesisInfo {
     pub min_collateral: TokenAmount,
     pub genesis_epoch: ChainEpoch,
     pub validators: Vec<Validator>,
-    pub genesis_balances: HashMap<Address, TokenAmount>,
+    pub genesis_balances: BTreeMap<Address, TokenAmount>,
 }
 
 /// The generic payload that returns the block hash of the data returning block with the actual


### PR DESCRIPTION
We were having some issues in multi-validator deployments because each validator was generating a different genesis, and leading to a different initial state. The source of the non-determinism was the use of a `HashMap` for the initial balances that was causing each validator to have these accounts in their genesis in a different order, so when the init state was being generated in Fendermint, it was causing them to be assigned a different ID address.