### PR TITLE
Add Mycelium to default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,27 @@ If it is the first time that you use your `ipc-cli`, to initialize cli configura
 The suggested configuration for the `ipc-cli` is:
 
 ```
-# Default configuration for Filecoin Calibration
 keystore_path = "~/.ipc"
 
+# Filecoin Calibration
 [[subnets]]
 id = "/r314159"
 
 [subnets.config]
-gateway_addr = "0x0341fA160C66aBB112195192aE359a6D61df45cd"
 network_type = "fevm"
 provider_http = "https://api.calibration.node.glif.io/rpc/v1"
+gateway_addr = "0x0341fA160C66aBB112195192aE359a6D61df45cd"
 registry_addr = "0xc7068Cea947035560128a6a6F4c8913523A5A44C"
+
+# Mycelium Calibration
+[[subnets]]
+id = "/r314159/t410fug7q7fgzeehfgr6qlubzs45z2sjzcbw3nbhpiyi"
+
+[subnets.config]
+network_type = "fevm"
+provider_http = "https://api.mycelium.calibration.node.glif.io/"
+gateway_addr = "0x77aa40b105843728088c0132e43fc44348881da8"
+registry_addr = "0x74539671a1d2f1c8f200826baba665179f53a1b7"
 ```
 
 To be able to interact with Calibration and run new subnets, some FIL should be provided to, at least, the wallet that will be used by the `ipc-cli` to interact with IPC. You can request some tFIL for your address through the [Calibration Faucet](https://faucet.calibration.fildev.network/funds.html).

--- a/docs/quickstart-calibration.md
+++ b/docs/quickstart-calibration.md
@@ -149,7 +149,17 @@ Before running our validators, at least one bootstrap needs to be deployed and a
 
 * We can deploy a new bootstrap node in the subnet by running: 
 ```bash
-cargo make --makefile bin/ipc-infra/Makefile.toml -e CMT_P2P_HOST_PORT=26650 bootstrap
+cargo make --makefile infra/Makefile.toml \
+    -e PRIVATE_KEY_PATH=<VALIDATOR_PRIV_KEY> \
+    -e SUBNET_ID=<SUBNET_ID> \
+    -e CMT_P2P_HOST_PORT=<COMETBFT_P2P_PORT> \
+    -e CMT_RPC_HOST_PORT=<COMETBFT_RPC_PORT> \
+    -e ETHAPI_HOST_PORT=<ETH_RPC_PORT> \
+    -e BOOTSTRAPS=<BOOTSTRAP_ENDPOINT>
+    -e PARENT_REGISTRY=<PARENT_REGISTRY_CONTRACT_ADDR> \
+    -e PARENT_GATEWAY=<GATEWAY_REGISTRY_CONTRACT_ADDR> \
+    -e CMT_EXTERNAL_ADDR=<COMETBFT_EXTERNAL_ENDPOINT> \
+    bootstrap
 ```
 
 At the end of the output, this command should return the ID of your new bootstrap node:
@@ -160,7 +170,7 @@ At the end of the output, this command should return the ID of your new bootstra
 2b23b8298dff7711819172252f9df3c84531b1d9@172.26.0.2:26650
 [cargo-make] INFO - Build Done in 13.38 seconds.
 ```
-Remember the address of your bootstrap for the next step. This address has the following format `id@ip:port`, and by default shows the public IP of your network interface. Feel free to adjust the `ip` to use a reachable IP for your deployment so other nodes can contact it (in our case our localhost IP, `127.0.0.1`).
+Remember the address of your bootstrap for the next step. This address has the following format `id@ip:port`. Feel free to adjust the `ip` to use a reachable IP for your deployment so other nodes can contact it (in our case our localhost IP, `127.0.0.1`) and to use as `CMT_EXTERNAL_ADDR` a reachable IP by other peers, and the port configured in `CMT_EXTERNAL_ADDR`.
 
 * We can get the address of the deployed bootstrap node by running:
 ```bash

--- a/ipc/provider/src/config/mod.rs
+++ b/ipc/provider/src/config/mod.rs
@@ -31,6 +31,7 @@ pub const JSON_RPC_VERSION: &str = "2.0";
 pub const DEFAULT_CONFIG_TEMPLATE: &str = r#"
 keystore_path = "~/.ipc"
 
+# Filecoin Calibration
 [[subnets]]
 id = "/r314159"
 
@@ -40,13 +41,23 @@ provider_http = "https://api.calibration.node.glif.io/rpc/v1"
 gateway_addr = "0x0341fA160C66aBB112195192aE359a6D61df45cd"
 registry_addr = "0xc7068Cea947035560128a6a6F4c8913523A5A44C"
 
+# Mycelium Calibration
+[[subnets]]
+id = "/r314159/t410fug7q7fgzeehfgr6qlubzs45z2sjzcbw3nbhpiyi"
+
+[subnets.config]
+network_type = "fevm"
+provider_http = "https://api.mycelium.calibration.node.glif.io/"
+gateway_addr = "0x77aa40b105843728088c0132e43fc44348881da8"
+registry_addr = "0x74539671a1d2f1c8f200826baba665179f53a1b7"
+
 # Subnet template - uncomment and adjust before using
 # [[subnets]]
 # id = "/r314159/<SUBNET_ID>"
 
 # [subnets.config]
 # network_type = "fevm"
-# provider_http = "https://api.calibration.node.glif.io/rpc/v1"
+# provider_http = "https://<RPC_ADDR>/"
 # gateway_addr = "0x77aa40b105843728088c0132e43fc44348881da8"
 # registry_addr = "0x74539671a1d2f1c8f200826baba665179f53a1b7"
 "#;


### PR DESCRIPTION
Adds the Myeclium subnet with remote glif endpoint to both the default config and the readme. This would make the ipc-cli work out of the box and avoid step 3 in the [quickstart](https://app.gitbook.com/o/DdhSSU8GveMWTVvBCegp/s/tw05J6huF10RyduiiqIu/quickstarts/deploy-smart-contracts-to-mycelium#3.-configure-ipc-cli-to-connect-to-the-mycelium-calibration). We could also leave it commented out, but this seems strictly better.

Closes #389 

@trruckerfling We'll need to update the docs once this makes it to main. 

