### PR TITLE
Propagate nov changes to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,27 @@ If it is the first time that you use your `ipc-cli`, to initialize cli configura
 The suggested configuration for the `ipc-cli` is:
 
 ```
-# Default configuration for Filecoin Calibration
 keystore_path = "~/.ipc"
 
+# Filecoin Calibration
 [[subnets]]
 id = "/r314159"
 
 [subnets.config]
-gateway_addr = "0x0341fA160C66aBB112195192aE359a6D61df45cd"
 network_type = "fevm"
 provider_http = "https://api.calibration.node.glif.io/rpc/v1"
+gateway_addr = "0x0341fA160C66aBB112195192aE359a6D61df45cd"
 registry_addr = "0xc7068Cea947035560128a6a6F4c8913523A5A44C"
+
+# Mycelium Calibration
+[[subnets]]
+id = "/r314159/t410fug7q7fgzeehfgr6qlubzs45z2sjzcbw3nbhpiyi"
+
+[subnets.config]
+network_type = "fevm"
+provider_http = "https://api.mycelium.calibration.node.glif.io/"
+gateway_addr = "0x77aa40b105843728088c0132e43fc44348881da8"
+registry_addr = "0x74539671a1d2f1c8f200826baba665179f53a1b7"
 ```
 
 To be able to interact with Calibration and run new subnets, some FIL should be provided to, at least, the wallet that will be used by the `ipc-cli` to interact with IPC. You can request some tFIL for your address through the [Calibration Faucet](https://faucet.calibration.fildev.network/funds.html).

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ registry_addr = "0xc7068Cea947035560128a6a6F4c8913523A5A44C"
 
 # Mycelium Calibration
 [[subnets]]
-id = "/r314159/t410fug7q7fgzeehfgr6qlubzs45z2sjzcbw3nbhpiyi"
+id = "/r314159/t410fnotsxwgnxcjp5phjmgp6n3lnhxvrf3pncnm3oxq"
 
 [subnets.config]
 network_type = "fevm"

--- a/docs/quickstart-calibration.md
+++ b/docs/quickstart-calibration.md
@@ -174,7 +174,7 @@ Remember the address of your bootstrap for the next step. This address has the f
 
 * We can get the address of the deployed bootstrap node by running:
 ```bash
-cargo make --makefile bin/ipc-infra/Makefile.toml bootstrap-id
+cargo make --makefile bin/ipc-infra/Makefile.toml bootstrap-node-id
 ```
 
 * To shut down the bootstrap node run:

--- a/docs/quickstart-calibration.md
+++ b/docs/quickstart-calibration.md
@@ -149,7 +149,17 @@ Before running our validators, at least one bootstrap needs to be deployed and a
 
 * We can deploy a new bootstrap node in the subnet by running: 
 ```bash
-cargo make --makefile bin/ipc-infra/Makefile.toml -e CMT_P2P_HOST_PORT=26650 bootstrap
+cargo make --makefile infra/Makefile.toml \
+    -e PRIVATE_KEY_PATH=<VALIDATOR_PRIV_KEY> \
+    -e SUBNET_ID=<SUBNET_ID> \
+    -e CMT_P2P_HOST_PORT=<COMETBFT_P2P_PORT> \
+    -e CMT_RPC_HOST_PORT=<COMETBFT_RPC_PORT> \
+    -e ETHAPI_HOST_PORT=<ETH_RPC_PORT> \
+    -e BOOTSTRAPS=<BOOTSTRAP_ENDPOINT>
+    -e PARENT_REGISTRY=<PARENT_REGISTRY_CONTRACT_ADDR> \
+    -e PARENT_GATEWAY=<GATEWAY_REGISTRY_CONTRACT_ADDR> \
+    -e CMT_EXTERNAL_ADDR=<COMETBFT_EXTERNAL_ENDPOINT> \
+    bootstrap
 ```
 
 At the end of the output, this command should return the ID of your new bootstrap node:
@@ -160,7 +170,7 @@ At the end of the output, this command should return the ID of your new bootstra
 2b23b8298dff7711819172252f9df3c84531b1d9@172.26.0.2:26650
 [cargo-make] INFO - Build Done in 13.38 seconds.
 ```
-Remember the address of your bootstrap for the next step. This address has the following format `id@ip:port`, and by default shows the public IP of your network interface. Feel free to adjust the `ip` to use a reachable IP for your deployment so other nodes can contact it (in our case our localhost IP, `127.0.0.1`).
+Remember the address of your bootstrap for the next step. This address has the following format `id@ip:port`. Feel free to adjust the `ip` to use a reachable IP for your deployment so other nodes can contact it (in our case our localhost IP, `127.0.0.1`) and to use as `CMT_EXTERNAL_ADDR` a reachable IP by other peers, and the port configured in `CMT_EXTERNAL_ADDR`.
 
 * We can get the address of the deployed bootstrap node by running:
 ```bash

--- a/ipc/cli/src/commands/mod.rs
+++ b/ipc/cli/src/commands/mod.rs
@@ -54,7 +54,7 @@ enum Commands {
     about = "The IPC agent command line tool",
     version = "v0.0.1"
 )]
-#[command(propagate_version = true)]
+#[command(propagate_version = true, arg_required_else_help = true)]
 struct IPCAgentCliCommands {
     // If provided, outputs the completion file for given shell
     #[arg(long = "cli-autocomplete-gen", value_enum)]

--- a/ipc/cli/src/commands/wallet/import.rs
+++ b/ipc/cli/src/commands/wallet/import.rs
@@ -3,7 +3,7 @@
 //! Wallet import cli handler
 
 use async_trait::async_trait;
-use clap::Args;
+use clap::{ArgGroup, Args};
 use ipc_identity::WalletType;
 use std::fmt::Debug;
 use std::str::FromStr;
@@ -57,14 +57,25 @@ impl CommandLineHandler for WalletImport {
 
 #[derive(Debug, Args)]
 #[command(about = "Import a key into the agent's wallet")]
+#[clap(group(ArgGroup::new("key_source")
+.required(true)
+.multiple(false)
+.args(&["path", "private_key"]),
+))]
 pub(crate) struct WalletImportArgs {
     #[arg(long, short, help = "The type of the wallet, i.e. fvm, evm")]
     pub wallet_type: String,
-    #[arg(long, short, help = "Path of key info file for the key to import")]
+    #[arg(
+        long,
+        short,
+        group = "key_source",
+        help = "Path of key info file for the key to import"
+    )]
     pub path: Option<String>,
     #[arg(
         long,
         short,
+        group = "key_source",
         help = "The evm private key to import if path is not specified"
     )]
     pub private_key: Option<String>,

--- a/ipc/provider/src/config/mod.rs
+++ b/ipc/provider/src/config/mod.rs
@@ -31,6 +31,7 @@ pub const JSON_RPC_VERSION: &str = "2.0";
 pub const DEFAULT_CONFIG_TEMPLATE: &str = r#"
 keystore_path = "~/.ipc"
 
+# Filecoin Calibration
 [[subnets]]
 id = "/r314159"
 
@@ -40,13 +41,23 @@ provider_http = "https://api.calibration.node.glif.io/rpc/v1"
 gateway_addr = "0x0341fA160C66aBB112195192aE359a6D61df45cd"
 registry_addr = "0xc7068Cea947035560128a6a6F4c8913523A5A44C"
 
+# Mycelium Calibration
+[[subnets]]
+id = "/r314159/t410fug7q7fgzeehfgr6qlubzs45z2sjzcbw3nbhpiyi"
+
+[subnets.config]
+network_type = "fevm"
+provider_http = "https://api.mycelium.calibration.node.glif.io/"
+gateway_addr = "0x77aa40b105843728088c0132e43fc44348881da8"
+registry_addr = "0x74539671a1d2f1c8f200826baba665179f53a1b7"
+
 # Subnet template - uncomment and adjust before using
 # [[subnets]]
 # id = "/r314159/<SUBNET_ID>"
 
 # [subnets.config]
 # network_type = "fevm"
-# provider_http = "https://api.calibration.node.glif.io/rpc/v1"
+# provider_http = "https://<RPC_ADDR>/"
 # gateway_addr = "0x77aa40b105843728088c0132e43fc44348881da8"
 # registry_addr = "0x74539671a1d2f1c8f200826baba665179f53a1b7"
 "#;

--- a/ipc/provider/src/config/mod.rs
+++ b/ipc/provider/src/config/mod.rs
@@ -43,7 +43,7 @@ registry_addr = "0xc7068Cea947035560128a6a6F4c8913523A5A44C"
 
 # Mycelium Calibration
 [[subnets]]
-id = "/r314159/t410fug7q7fgzeehfgr6qlubzs45z2sjzcbw3nbhpiyi"
+id = "/r314159/t410fnotsxwgnxcjp5phjmgp6n3lnhxvrf3pncnm3oxq"
 
 [subnets.config]
 network_type = "fevm"

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
@@ -1272,8 +1272,8 @@ fn is_valid_bootstrap_addr(input: &str) -> Option<(String, IpAddr, u16)> {
 fn into_genesis_balance_map(
     addrs: Vec<ethers::types::Address>,
     balances: Vec<ethers::types::U256>,
-) -> Result<HashMap<Address, TokenAmount>> {
-    let mut map = HashMap::new();
+) -> Result<BTreeMap<Address, TokenAmount>> {
+    let mut map = BTreeMap::new();
     for (a, b) in addrs.into_iter().zip(balances) {
         map.insert(ethers_address_to_fil_address(&a)?, eth_to_fil_amount(&b)?);
     }

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -157,7 +157,7 @@ pub struct SubnetGenesisInfo {
     pub min_collateral: TokenAmount,
     pub genesis_epoch: ChainEpoch,
     pub validators: Vec<Validator>,
-    pub genesis_balances: HashMap<Address, TokenAmount>,
+    pub genesis_balances: BTreeMap<Address, TokenAmount>,
 }
 
 /// The generic payload that returns the block hash of the data returning block with the actual


### PR DESCRIPTION
Propagates last week of changes, including changes to:
* Genesis non-determinism
* Dockerfile
* Log filtering
* Default config
* Help messages
* Docs

The main goal is avoiding stale references to old calibration network. I've been running the dev branch with no issues.