### PR TITLE
align topdown and validator changes query pattern

### DIFF
--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -649,17 +649,14 @@ impl IpcProvider {
         &self,
         subnet: &SubnetID,
         epoch: ChainEpoch,
-        block_hash: &[u8],
-    ) -> anyhow::Result<Vec<CrossMsg>> {
+    ) -> anyhow::Result<TopDownQueryPayload<Vec<CrossMsg>>> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
         let conn = match self.connection(&parent) {
             None => return Err(anyhow!("target parent subnet not found")),
             Some(conn) => conn,
         };
 
-        conn.manager()
-            .get_top_down_msgs(subnet, epoch, block_hash)
-            .await
+        conn.manager().get_top_down_msgs(subnet, epoch).await
     }
 
     pub async fn get_block_hash(

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -186,8 +186,7 @@ pub trait TopDownFinalityQuery: Send + Sync {
         &self,
         subnet_id: &SubnetID,
         epoch: ChainEpoch,
-        block_hash: &[u8],
-    ) -> Result<Vec<CrossMsg>>;
+    ) -> Result<TopDownQueryPayload<Vec<CrossMsg>>>;
     /// Get the block hash
     async fn get_block_hash(&self, height: ChainEpoch) -> Result<GetBlockHashResult>;
     /// Get the validator change set from start to end block.


### PR DESCRIPTION
Align the query pattern of validator change set and top down messages, so that their querying pattern is consistent, easier to maintain. 

Instead of passing in a block hash to check for top down messages query (we had to do this because previously we were using getters to do the querying), we are querying top down messages with block hash returned from events and let caller do the check (we can do this now because we are using events). This is aligned with validator change set query pattern and it's more flexible. 