### PR TITLE
Fix gateway address conversion

### DIFF
--- a/ipc/cli/src/commands/crossmsg/fund.rs
+++ b/ipc/cli/src/commands/crossmsg/fund.rs
@@ -34,7 +34,7 @@ impl CommandLineHandler for Fund {
             None => None,
         };
         let gateway_addr = match &arguments.gateway_address {
-            Some(address) => Some(Address::from_str(address)?),
+            Some(address) => Some(require_fil_addr_from_str(address)?),
             None => None,
         };
 


### PR DESCRIPTION
Fix https://github.com/consensus-shipyard/ipc/issues/391. This PR with parse the fvm address first, if cannot then try use evm address.