### PR TITLE
IPC-304: add permissioned flag for new contract version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,7 +2708,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#6f812b55a717a8b148c1b1b2b7db12aa330d5d84"
+source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#ae9edfbf9ca41fbf31f28b8428229f091ada0917"
 dependencies = [
  "anyhow",
  "ethers",

--- a/ipc/cli/src/commands/subnet/create.rs
+++ b/ipc/cli/src/commands/subnet/create.rs
@@ -41,6 +41,7 @@ impl CreateSubnet {
                     .active_validators_limit
                     .unwrap_or(DEFAULT_ACTIVE_VALIDATORS),
                 f64_to_token_amount(arguments.min_cross_msg_fee)?,
+                arguments.permissioned,
             )
             .await?;
 
@@ -96,4 +97,9 @@ pub struct CreateSubnetArgs {
         help = "Minimum fee for cross-net messages in subnet (in whole FIL)"
     )]
     pub min_cross_msg_fee: f64,
+    #[arg(
+        long,
+        help = "Deploy static network where validators can't join in a permissionless manner"
+    )]
+    pub permissioned: bool,
 }

--- a/ipc/cli/src/lib.rs
+++ b/ipc/cli/src/lib.rs
@@ -40,7 +40,7 @@ pub struct GlobalArguments {
     config_path: Option<String>,
 
     /// Set the FVM Address Network. It's value affects whether `f` (main) or `t` (test) prefixed addresses are accepted.
-    #[arg(short, long, default_value = "mainnet", env = "NETWORK", value_parser = parse_network)]
+    #[arg(short, long, default_value = "testnet", env = "NETWORK", value_parser = parse_network)]
     pub network: Network,
 }
 

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -239,6 +239,7 @@ impl IpcProvider {
         bottomup_check_period: ChainEpoch,
         active_validators_limit: u16,
         min_cross_msg_fee: TokenAmount,
+        permissioned: bool,
     ) -> anyhow::Result<Address> {
         let conn = match self.connection(&parent) {
             None => return Err(anyhow!("target parent subnet not found")),
@@ -251,12 +252,13 @@ impl IpcProvider {
         let constructor_params = ConstructParams {
             parent,
             ipc_gateway_addr: subnet_config.gateway_addr(),
-            consensus: ConsensusType::Mir,
+            consensus: ConsensusType::Fendermint,
             min_validators,
             min_validator_stake,
             bottomup_check_period,
             active_validators_limit,
             min_cross_msg_fee,
+            permissioned,
         };
 
         conn.manager()

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -262,6 +262,7 @@ impl SubnetManager for EthSubnetManager {
             active_validators_limit: params.active_validators_limit,
             power_scale: 3,
             min_cross_msg_fee: ethers::types::U256::from(min_cross_msg_fee),
+            permissioned: params.permissioned,
         };
 
         log::info!("creating subnet on evm with params: {params:?}");

--- a/ipc/sdk/src/subnet.rs
+++ b/ipc/sdk/src/subnet.rs
@@ -24,16 +24,12 @@ pub struct ConstructParams {
     pub bottomup_check_period: ChainEpoch,
     pub active_validators_limit: u16,
     pub min_cross_msg_fee: TokenAmount,
+    pub permissioned: bool,
 }
 
 /// Consensus types supported by hierarchical consensus
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Deserialize_repr, Serialize_repr)]
 #[repr(u64)]
 pub enum ConsensusType {
-    Mir,
-}
-
-#[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple, PartialEq, Eq)]
-pub struct JoinParams {
-    pub validator_net_addr: String,
+    Fendermint,
 }


### PR DESCRIPTION
Depends on: https://github.com/consensus-shipyard/ipc-solidity-actors/pull/305
Upgrades contract version and introduces a `permissioned` flag to address https://github.com/consensus-shipyard/ipc-solidity-actors/issue/304