### PR TITLE
[PARKED] BUILD: Use the stipper trick locally

### DIFF
--- a/fendermint/Makefile
+++ b/fendermint/Makefile
@@ -74,14 +74,14 @@ docker-deps: $(BUILTIN_ACTORS_BUNDLE) $(IPC_ACTORS_GEN)
 # it can handle for anyone with `DOCKER_BUILDKIT=1`.
 docker-build: docker-deps $(FENDERMINT_CODE)
 	if [ "$(PROFILE)" = "ci" ]; then \
-		cat docker/builder.ci.Dockerfile docker/runner.Dockerfile > docker/Dockerfile ; \
+		cat docker/stripper.Dockerfile docker/builder.ci.Dockerfile docker/runner.Dockerfile > docker/Dockerfile ; \
 		docker buildx build \
 			$(BUILDX_STORE) \
 			$(BUILDX_FLAGS) \
 			-f docker/Dockerfile \
 			-t $(BUILDX_TAG) $(PWD)/..; \
 	else \
-		cat docker/builder.local.Dockerfile docker/runner.Dockerfile > docker/Dockerfile ; \
+		cat docker/stripper.Dockerfile docker/builder.local.Dockerfile docker/runner.Dockerfile > docker/Dockerfile ; \
 		DOCKER_BUILDKIT=1 \
 		docker build \
 			$(BUILDX_STORE) \

--- a/fendermint/docker/stripper.Dockerfile
+++ b/fendermint/docker/stripper.Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+# The goal of this step is to copy the `Cargo.toml` and `Cargo.lock` files _without_ the source code,
+# so that we can run a step in `builder` that compiles the dependencies only. To do so we first
+# copy the whole codebase then get rid of everything except the dependencies and do a build.
+FROM --platform=$BUILDPLATFORM ubuntu:latest as stripper
+
+WORKDIR /app
+
+# Copy everything, even though we only need Cargo.* artifacts and Rust sources.
+# COPY Cargo.toml Cargo.lock ./
+COPY . .
+
+# Delete anything other than cargo files: Rust sources, config files, Markdown, etc.
+RUN find . -type f \! -name "Cargo.*" | xargs rm -rf
+
+# Construct dummy sources. Add a print to help debug the case if we failed to properly replace the file.
+RUN echo "fn main() { println!(\"I'm the dummy.\"); }" > fendermint/fendermint/app/src/main.rs && \
+  for crate in $(find . -name "Cargo.toml" | xargs dirname | grep -v infra | grep -v node_modules | grep /); do \
+  touch $crate/src/lib.rs; \
+  done


### PR DESCRIPTION
Changes the `local` version of the docker build to use the `stripper` stage like on CI to build first the dependencies, then the application code, so that the dependencies can be cached.

This is motivated by the observation that sometimes switching between branches results in a full compilation, even if seemingly not much changed, which takes ~10 minutes. Other times, after some changes in the application, it's done much quicker because of the caching done by docker buildkit, rebuilding just `fendermint_app` for example. 

There is a trade-off with this, however, because this way it will _always_ recompile all of our own crates, resulting in a 2 minute build. Ostensibly this could be faster if the previous output would be cached.

I'm putting it out here for reference, and then see if people see the reason for it to be merged.