### PR TITLE
Adding msg batch handling in fendermint

### DIFF
--- a/contracts/src/gateway/router/BottomUpRouterFacet.sol
+++ b/contracts/src/gateway/router/BottomUpRouterFacet.sol
@@ -108,6 +108,15 @@ contract BottomUpRouterFacet is GatewayActorModifiers {
             membershipWeight: membershipWeight,
             majorityPercentage: s.majorityPercentage
         });
+
+        if (LibGateway.bottomUpBatchMsgsExists(batch.blockHeight)) {
+            return;
+        }
+
+        if (batch.blockHeight % s.bottomUpMsgBatchPeriod != 0) {
+            revert InvalidBatchEpoch();
+        }
+        LibGateway.storeBottomUpMsgBatch(batch);
     }
 
     /// @notice Set a new batch retention height and garbage collect all batches in range [`retentionHeight`, `newRetentionHeight`)

--- a/contracts/src/gateway/router/BottomUpRouterFacet.sol
+++ b/contracts/src/gateway/router/BottomUpRouterFacet.sol
@@ -100,10 +100,6 @@ contract BottomUpRouterFacet is GatewayActorModifiers {
             revert InvalidBatchEpoch();
         }
 
-        if (LibGateway.bottomUpBatchMsgsExists(batch.blockHeight)) {
-            revert BatchAlreadyExists();
-        }
-
         LibQuorum.createQuorumInfo({
             self: s.bottomUpMsgBatchQuorumMap,
             objHeight: batch.blockHeight,
@@ -112,7 +108,6 @@ contract BottomUpRouterFacet is GatewayActorModifiers {
             membershipWeight: membershipWeight,
             majorityPercentage: s.majorityPercentage
         });
-        LibGateway.storeBottomUpMsgBatch(batch);
     }
 
     /// @notice Set a new batch retention height and garbage collect all batches in range [`retentionHeight`, `newRetentionHeight`)

--- a/contracts/src/gateway/router/BottomUpRouterFacet.sol
+++ b/contracts/src/gateway/router/BottomUpRouterFacet.sol
@@ -96,7 +96,7 @@ contract BottomUpRouterFacet is GatewayActorModifiers {
         // of messages for the batch hasn't been reached.
         // We also check that we are not trying to create a batch from
         // the future
-        if (batch.blockHeight % s.bottomUpMsgBatchPeriod != 0 || block.number <= batch.blockHeight) {
+        if (block.number < batch.blockHeight) {
             revert InvalidBatchEpoch();
         }
 

--- a/contracts/src/lib/LibGateway.sol
+++ b/contracts/src/lib/LibGateway.sol
@@ -398,8 +398,5 @@ library LibGateway {
         if (batch.msgs.length > s.maxMsgsPerBottomUpBatch) {
             revert MaxMsgsPerBatchExceeded();
         }
-        if (batch.msgs.length == 0) {
-            revert BatchWithNoMessages();
-        }
     }
 }

--- a/fendermint/fendermint/vm/actor_interface/src/ipc.rs
+++ b/fendermint/fendermint/vm/actor_interface/src/ipc.rs
@@ -269,6 +269,7 @@ macro_rules! abi_hash {
 }
 
 abi_hash!(struct ipc_actors_abis::checkpointing_facet::BottomUpCheckpoint);
+abi_hash!(struct ipc_actors_abis::bottom_up_router_facet::BottomUpMsgBatch);
 abi_hash!(struct ipc_actors_abis::subnet_actor_manager_facet::BottomUpCheckpoint);
 abi_hash!(Vec<ipc_actors_abis::gateway_getter_facet::CrossMsg>);
 abi_hash!(Vec<ipc_actors_abis::subnet_actor_manager_facet::CrossMsg>);

--- a/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -78,7 +78,7 @@ where
             None
         } else {
             tracing::debug!(
-                batch = ?height,
+                batch = ?batch,
                 "creating bottom up msg batch at height"
             );
 

--- a/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -71,7 +71,7 @@ where
         .try_into()
         .context("block height is not u64")?;
 
-    let batch = gateway.bottom_up_batch(state, height.into())?;
+    let mut batch = gateway.bottom_up_batch(state, height.into())?;
     Ok(
         // block height is 0 means the batch does not exists
         if batch.block_height.as_u64() == 0
@@ -88,6 +88,7 @@ where
             let (_, curr_power_table) =
                 ipc_power_table(gateway, state).context("failed to get the current power table")?;
 
+            batch.block_height = ethers::types::U256::from(height.value());
             let router_batch =
                 bottom_up_router_facet::BottomUpMsgBatch::from_tokens(batch.clone().into_tokens())?;
 

--- a/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -285,7 +285,7 @@ where
 {
     // Make sure that these had time to be added to the ledger.
     if let Some(highest) = incomplete_batches.iter().map(|cp| cp.block_height).max() {
-        tracing::info!(block = highest.as_u64(), "waiting for block to be committed(msg batch)");
+        tracing::debug!(block = highest.as_u64(), "waiting for block to be committed(msg batch)");
         wait_for_commit(
             client,
             highest.as_u64() + 1,
@@ -322,10 +322,8 @@ where
             )
             .await
             .context("failed to broadcast checkpoint signature")?;
-
-            tracing::info!(?height, "submitted bottom up batch signature");
         } else {
-            tracing::info!(
+            tracing::debug!(
                 height = batch.block_height.as_u64(),
                 "validator not in active list, not signing for batch"
             );
@@ -428,7 +426,7 @@ where
         .context("failed to broadcast signature")?;
 
     // The transaction should be in the mempool now.
-    tracing::info!(tx_hash = tx_hash.to_string(), "broadcasted signature");
+    tracing::info!(tx_hash = tx_hash.to_string(), "broadcasted msg batch signature");
 
     Ok(())
 }
@@ -457,7 +455,7 @@ where
         .context("failed to broadcast signature")?;
 
     // The transaction should be in the mempool now.
-    tracing::info!(tx_hash = tx_hash.to_string(), "broadcasted signature");
+    tracing::info!(tx_hash = tx_hash.to_string(), "broadcasted checkpoint signature");
 
     Ok(())
 }

--- a/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -74,7 +74,10 @@ where
     let batch = gateway.bottom_up_batch(state, height.into())?;
     Ok(
         // block height is 0 means the batch does not exists
-        if batch.block_height.as_u64() == 0 {
+        if batch.block_height.as_u64() == 0
+            && height.value() % gateway.bottom_up_msg_batch_period(state)? != 0
+        {
+            // this means the batch does not already exist and submission period not reached
             None
         } else {
             tracing::debug!(
@@ -285,7 +288,10 @@ where
 {
     // Make sure that these had time to be added to the ledger.
     if let Some(highest) = incomplete_batches.iter().map(|cp| cp.block_height).max() {
-        tracing::debug!(block = highest.as_u64(), "waiting for block to be committed(msg batch)");
+        tracing::debug!(
+            block = highest.as_u64(),
+            "waiting for block to be committed(msg batch)"
+        );
         wait_for_commit(
             client,
             highest.as_u64() + 1,
@@ -426,7 +432,10 @@ where
         .context("failed to broadcast signature")?;
 
     // The transaction should be in the mempool now.
-    tracing::info!(tx_hash = tx_hash.to_string(), "broadcasted msg batch signature");
+    tracing::info!(
+        tx_hash = tx_hash.to_string(),
+        "broadcasted msg batch signature"
+    );
 
     Ok(())
 }
@@ -455,7 +464,10 @@ where
         .context("failed to broadcast signature")?;
 
     // The transaction should be in the mempool now.
-    tracing::info!(tx_hash = tx_hash.to_string(), "broadcasted checkpoint signature");
+    tracing::info!(
+        tx_hash = tx_hash.to_string(),
+        "broadcasted checkpoint signature"
+    );
 
     Ok(())
 }

--- a/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -78,7 +78,7 @@ where
             None
         } else {
             tracing::debug!(
-                height = height.to_string(),
+                batch = ?height,
                 "creating bottom up msg batch at height"
             );
 

--- a/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -285,6 +285,7 @@ where
 {
     // Make sure that these had time to be added to the ledger.
     if let Some(highest) = incomplete_batches.iter().map(|cp| cp.block_height).max() {
+        tracing::info!(block = highest.as_u64(), "waiting for block to be committed(msg batch)");
         wait_for_commit(
             client,
             highest.as_u64() + 1,
@@ -322,7 +323,12 @@ where
             .await
             .context("failed to broadcast checkpoint signature")?;
 
-            tracing::debug!(?height, "submitted bottom up batch signature");
+            tracing::info!(?height, "submitted bottom up batch signature");
+        } else {
+            tracing::info!(
+                height = batch.block_height.as_u64(),
+                "validator not in active list, not signing for batch"
+            );
         }
     }
     Ok(())

--- a/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -322,7 +322,7 @@ where
             .await
             .context("failed to broadcast checkpoint signature")?;
 
-            tracing::debug!(?height, "submitted checkpoint signature");
+            tracing::debug!(?height, "submitted bottom up batch signature");
         }
     }
     Ok(())

--- a/fendermint/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -237,6 +237,8 @@ where
                     }
                 });
             }
+        } else {
+            tracing::debug!("validator not configured, not signing bottom up msg batch");
         }
         Ok(())
     }

--- a/fendermint/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -214,7 +214,10 @@ where
                     ctx.public_key,
                 )
                 .context("failed to fetch incomplete checkpoints")?;
-                tracing::debug!(batch_size = incomplete.len(), "obtained list of incomplete batches");
+                tracing::debug!(
+                    batch_size = incomplete.len(),
+                    "obtained list of incomplete batches"
+                );
 
                 let client = self.client.clone();
                 let gateway = self.gateway.clone();

--- a/fendermint/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -214,6 +214,7 @@ where
                     ctx.public_key,
                 )
                 .context("failed to fetch incomplete checkpoints")?;
+                tracing::debug!(batch_size = incomplete.len(), "obtained list of incomplete batches");
 
                 let client = self.client.clone();
                 let gateway = self.gateway.clone();

--- a/fendermint/fendermint/vm/interpreter/src/fvm/state/ipc.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/state/ipc.rs
@@ -117,6 +117,14 @@ impl<DB: Blockstore> GatewayCaller<DB> {
             .as_u64())
     }
 
+    /// Fetch the period with which the current subnet has to submit msg batches to its parent.
+    pub fn bottom_up_msg_batch_period(&self, state: &mut FvmExecState<DB>) -> anyhow::Result<u64> {
+        Ok(self
+            .getter
+            .call(state, |c| c.bottom_up_msg_batch_period())?
+            .as_u64())
+    }
+
     /// Fetch the bottom-up message batch enqueued for a given checkpoint height.
     pub fn bottom_up_batch(
         &self,


### PR DESCRIPTION
Adding msg batch related code in fendermint. This is almost the same process as compared to bottom up checkpoint, just function names and types are different.

Currently this PR has adding the over process flow, there are some duplicated code that can be removed, will do the clean up after integration testing.