### PR TITLE
Fix relayer

### DIFF
--- a/contracts/src/GatewayDiamond.sol
+++ b/contracts/src/GatewayDiamond.sol
@@ -11,6 +11,7 @@ import {InvalidCollateral, InvalidSubmissionPeriod, InvalidMajorityPercentage} f
 import {LibDiamond} from "./lib/LibDiamond.sol";
 import {LibGateway} from "./lib/LibGateway.sol";
 import {SubnetID} from "./structs/Subnet.sol";
+import {QuorumObjKind} from "./structs/Quorum.sol";
 import {LibStaking} from "./lib/LibStaking.sol";
 import {BATCH_PERIOD, MAX_MSGS_PER_BATCH} from "./structs/CrossNet.sol";
 
@@ -66,6 +67,7 @@ contract GatewayDiamond {
         s.minCrossMsgFee = params.msgFee;
         s.majorityPercentage = params.majorityPercentage;
         s.checkpointQuorumMap.retentionHeight = 1;
+        s.checkpointQuorumMap.quorumObjKind = QuorumObjKind.BottomUpMsgBatch;
         s.bottomUpMsgBatchQuorumMap.retentionHeight = 1;
 
         // BottomUpMsgBatch config parameters.

--- a/contracts/src/GatewayDiamond.sol
+++ b/contracts/src/GatewayDiamond.sol
@@ -67,8 +67,8 @@ contract GatewayDiamond {
         s.minCrossMsgFee = params.msgFee;
         s.majorityPercentage = params.majorityPercentage;
         s.checkpointQuorumMap.retentionHeight = 1;
-        s.checkpointQuorumMap.quorumObjKind = QuorumObjKind.BottomUpMsgBatch;
         s.bottomUpMsgBatchQuorumMap.retentionHeight = 1;
+        s.bottomUpMsgBatchQuorumMap.quorumObjKind = QuorumObjKind.BottomUpMsgBatch;
 
         // BottomUpMsgBatch config parameters.
         // NOTE: Let's fix them for now, but we could make them configurable

--- a/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -285,7 +285,10 @@ where
 {
     // Make sure that these had time to be added to the ledger.
     if let Some(highest) = incomplete_batches.iter().map(|cp| cp.block_height).max() {
-        tracing::debug!(block = highest.as_u64(), "waiting for block to be committed(msg batch)");
+        tracing::debug!(
+            block = highest.as_u64(),
+            "waiting for block to be committed(msg batch)"
+        );
         wait_for_commit(
             client,
             highest.as_u64() + 1,
@@ -426,7 +429,10 @@ where
         .context("failed to broadcast signature")?;
 
     // The transaction should be in the mempool now.
-    tracing::info!(tx_hash = tx_hash.to_string(), "broadcasted msg batch signature");
+    tracing::info!(
+        tx_hash = tx_hash.to_string(),
+        "broadcasted msg batch signature"
+    );
 
     Ok(())
 }
@@ -455,7 +461,10 @@ where
         .context("failed to broadcast signature")?;
 
     // The transaction should be in the mempool now.
-    tracing::info!(tx_hash = tx_hash.to_string(), "broadcasted checkpoint signature");
+    tracing::info!(
+        tx_hash = tx_hash.to_string(),
+        "broadcasted checkpoint signature"
+    );
 
     Ok(())
 }

--- a/fendermint/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -214,7 +214,10 @@ where
                     ctx.public_key,
                 )
                 .context("failed to fetch incomplete checkpoints")?;
-                tracing::debug!(batch_size = incomplete.len(), "obtained list of incomplete batches");
+                tracing::debug!(
+                    batch_size = incomplete.len(),
+                    "obtained list of incomplete batches"
+                );
 
                 let client = self.client.clone();
                 let gateway = self.gateway.clone();

--- a/ipc/ipc/cli/src/commands/checkpoint/bottomup_bundles.rs
+++ b/ipc/ipc/cli/src/commands/checkpoint/bottomup_bundles.rs
@@ -29,8 +29,8 @@ impl CommandLineHandler for GetBottomUpBundles {
         for h in arguments.from_epoch..=arguments.to_epoch {
             let bundle = provider.get_bottom_up_bundle(&subnet, h).await?;
             println!(
-                "checkpoint: {:?}, signatures: {:?}, signatories: {:?}, cross_msgs: {:?}",
-                bundle.checkpoint, bundle.signatures, bundle.signatories, bundle.cross_msgs,
+                "checkpoint: {:?}, signatures: {:?}, signatories: {:?}",
+                bundle.checkpoint, bundle.signatures, bundle.signatories,
             );
             println!("{bundle:?}");
         }

--- a/ipc/ipc/cli/src/commands/checkpoint/bottomup_bundles.rs
+++ b/ipc/ipc/cli/src/commands/checkpoint/bottomup_bundles.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use clap::Args;
 use fvm_shared::clock::ChainEpoch;
+use ipc_sdk::checkpoint::QuorumObjKind;
 use ipc_sdk::subnet_id::SubnetID;
 
 use crate::commands::get_ipc_provider;
@@ -25,14 +26,25 @@ impl CommandLineHandler for GetBottomUpBundles {
 
         let provider = get_ipc_provider(global)?;
         let subnet = SubnetID::from_str(&arguments.subnet)?;
+        let kind = QuorumObjKind::try_from(arguments.kind)?;
 
         for h in arguments.from_epoch..=arguments.to_epoch {
-            let bundle = provider.get_bottom_up_bundle(&subnet, h).await?;
-            println!(
-                "checkpoint: {:?}, signatures: {:?}, signatories: {:?}",
-                bundle.checkpoint, bundle.signatures, bundle.signatories,
-            );
-            println!("{bundle:?}");
+            match kind {
+                QuorumObjKind::Checkpoint => {
+                    let bundle = provider.get_bottom_up_checkpoint_bundle(&subnet, h).await?;
+                    println!(
+                        "checkpoint: {:?}, signatures: {:?}, signatories: {:?}",
+                        bundle.checkpoint, bundle.signatures, bundle.signatories,
+                    );
+                }
+                QuorumObjKind::BottomUpMsgBatch => {
+                    let bundle = provider.get_bottom_up_msg_batch_bundle(&subnet, h).await?;
+                    println!(
+                        "batch: {:?}, signatures: {:?}, signatories: {:?}",
+                        bundle.checkpoint, bundle.signatures, bundle.signatories,
+                    );
+                }
+            }
         }
 
         Ok(())
@@ -44,8 +56,14 @@ impl CommandLineHandler for GetBottomUpBundles {
 pub(crate) struct GetBottomUpBundlesArgs {
     #[arg(long, short, help = "The target subnet to perform query")]
     pub subnet: String,
-    #[arg(long, short, help = "Include checkpoints from this epoch")]
+    #[arg(
+        long,
+        short,
+        help = "List the bottom up checkpoint(0) or the msg batch(1)"
+    )]
+    pub kind: u8,
+    #[arg(long, short, help = "Include data from this epoch")]
     pub from_epoch: ChainEpoch,
-    #[arg(long, short, help = "Include checkpoints up to this epoch")]
+    #[arg(long, short, help = "Include data up to this epoch")]
     pub to_epoch: ChainEpoch,
 }

--- a/ipc/ipc/cli/src/commands/checkpoint/bottomup_height.rs
+++ b/ipc/ipc/cli/src/commands/checkpoint/bottomup_height.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 
 use async_trait::async_trait;
 use clap::Args;
+use ipc_sdk::checkpoint::QuorumObjKind;
 use ipc_sdk::subnet_id::SubnetID;
 
 use crate::commands::get_ipc_provider;
@@ -26,8 +27,11 @@ impl CommandLineHandler for LastBottomUpCheckpointHeight {
 
         let provider = get_ipc_provider(global)?;
         let subnet = SubnetID::from_str(&arguments.subnet)?;
+        let kind = QuorumObjKind::try_from(arguments.kind)?;
 
-        let height = provider.last_bottom_up_checkpoint_height(&subnet).await?;
+        let height = provider
+            .last_bottom_up_checkpoint_height(&subnet, kind)
+            .await?;
         println!("height: {height}");
 
         Ok(())
@@ -39,4 +43,10 @@ impl CommandLineHandler for LastBottomUpCheckpointHeight {
 pub(crate) struct LastBottomUpCheckpointHeightArgs {
     #[arg(long, short, help = "The target subnet to perform query")]
     pub subnet: String,
+    #[arg(
+        long,
+        short,
+        help = "List the bottom up checkpoint(0) or the msg batch(1)"
+    )]
+    pub kind: u8,
 }

--- a/ipc/ipc/cli/src/commands/checkpoint/bottomup_submitted.rs
+++ b/ipc/ipc/cli/src/commands/checkpoint/bottomup_submitted.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use clap::Args;
 use fvm_shared::address::Address;
+use ipc_sdk::checkpoint::QuorumObjKind;
 use ipc_sdk::subnet_id::SubnetID;
 
 use crate::commands::get_ipc_provider;
@@ -28,9 +29,10 @@ impl CommandLineHandler for SubmittedInBottomUpHeight {
         let provider = get_ipc_provider(global)?;
         let subnet = SubnetID::from_str(&arguments.subnet)?;
         let address = Address::from_str(&arguments.submitter)?;
+        let kind = QuorumObjKind::try_from(arguments.kind)?;
 
         let submitted = provider
-            .has_submitted_in_last_checkpoint_height(&subnet, &address)
+            .has_submitted_in_last_checkpoint_height(&subnet, &address, kind)
             .await?;
         println!("has submitted: {submitted}");
 
@@ -47,4 +49,10 @@ pub(crate) struct SubmittedInBottomUpHeightArgs {
     pub subnet: String,
     #[arg(long, short, help = "The hex encoded address of the submitter")]
     pub submitter: String,
+    #[arg(
+        long,
+        short,
+        help = "List the bottom up checkpoint(0) or the msg batch(1)"
+    )]
+    pub kind: u8,
 }

--- a/ipc/ipc/cli/src/commands/checkpoint/quorum_reached.rs
+++ b/ipc/ipc/cli/src/commands/checkpoint/quorum_reached.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use clap::Args;
 use fvm_shared::clock::ChainEpoch;
+use ipc_sdk::checkpoint::QuorumObjKind;
 use ipc_sdk::subnet_id::SubnetID;
 
 use crate::commands::get_ipc_provider;
@@ -25,9 +26,10 @@ impl CommandLineHandler for GetQuorumReacehdEvents {
 
         let provider = get_ipc_provider(global)?;
         let subnet = SubnetID::from_str(&arguments.subnet)?;
+        let kind = QuorumObjKind::try_from(arguments.kind)?;
 
         for h in arguments.from_epoch..=arguments.to_epoch {
-            let events = provider.quorum_reached_events(&subnet, h).await?;
+            let events = provider.quorum_reached_events(&subnet, h, kind).await?;
             for e in events {
                 println!("{e}");
             }
@@ -42,6 +44,12 @@ impl CommandLineHandler for GetQuorumReacehdEvents {
 pub(crate) struct GetQuorumReachedEventsArgs {
     #[arg(long, short, help = "The target subnet to perform query")]
     pub subnet: String,
+    #[arg(
+        long,
+        short,
+        help = "List the bottom up checkpoint(0) or the msg batch(1)"
+    )]
+    pub kind: u8,
     #[arg(long, short, help = "Include events from this epoch")]
     pub from_epoch: ChainEpoch,
     #[arg(long, short, help = "Include events up to this epoch")]

--- a/ipc/ipc/provider/src/checkpoint.rs
+++ b/ipc/ipc/provider/src/checkpoint.rs
@@ -238,7 +238,7 @@ where
         }
 
         let prev_h = next_submission_height - self.checkpoint_period();
-        log::debug!("start querying quorum reached events from : {prev_h} to {finalized_height}");
+        log::debug!("start querying quorum reached events from : {} to {finalized_height}", prev_h + 1);
 
         for h in (prev_h + 1)..=finalized_height {
             let events = self.child_handler.quorum_reached_events(h).await?;
@@ -247,7 +247,7 @@ where
                 continue;
             }
 
-            log::debug!("found reached events at height : {h}");
+            log::debug!("found reached events {events:?} at height : {h}");
 
             for event in events {
                 let bundle = self.child_handler.bundle_at(event.height).await?;

--- a/ipc/ipc/provider/src/checkpoint.rs
+++ b/ipc/ipc/provider/src/checkpoint.rs
@@ -3,15 +3,17 @@
 //! Bottom up checkpoint manager
 
 use crate::config::Subnet;
-use crate::manager::{BottomUpCheckpointRelayer, EthSubnetManager};
+use crate::manager::{BottomUpRelayer, EthSubnetManager};
 use anyhow::{anyhow, Result};
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use ipc_identity::{EthKeyAddress, PersistentKeyStore};
 use std::cmp::max;
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
+use std::marker::PhantomData;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
+use ipc_sdk::checkpoint::{BottomUpBundle, BottomUpCheckpoint, BottomUpMsgBatch};
 
 /// Tracks the config required for bottom up checkpoint submissions
 /// parent/child subnet and checkpoint period.
@@ -24,44 +26,49 @@ pub struct CheckpointConfig {
 /// Manages the submission of bottom up checkpoint. It checks if the submitter has already
 /// submitted in the `last_checkpoint_height`, if not, it will submit the checkpoint at that height.
 /// Then it will submit at the next submission height for the new checkpoint.
-pub struct BottomUpCheckpointManager<T> {
-    metadata: CheckpointConfig,
-    parent_handler: T,
-    child_handler: T,
-    /// The number of blocks away from the chain head that is considered final
-    finalization_blocks: ChainEpoch,
+pub struct BottomUpCheckpointManager<Checkpoint: BottomUpRelayer<BottomUpCheckpoint>, MsgBatch: BottomUpRelayer<BottomUpMsgBatch>> {
+    bottom_up_checkpoint_relayer: BottomUpRelayerManager<BottomUpCheckpoint, Checkpoint>,
+    bottom_up_msg_batch_relayer: BottomUpRelayerManager<BottomUpMsgBatch, MsgBatch>,
 }
 
-impl<T: BottomUpCheckpointRelayer> BottomUpCheckpointManager<T> {
+impl<T> BottomUpCheckpointManager<T, T>
+where T: BottomUpRelayer<BottomUpCheckpoint> + BottomUpRelayer<BottomUpMsgBatch> + 'static{
     pub async fn new(
         parent: Subnet,
         child: Subnet,
         parent_handler: T,
         child_handler: T,
     ) -> Result<Self> {
-        let period = parent_handler
-            .checkpoint_period(&child.id)
+        let parent_handler = Arc::new(parent_handler);
+        let child_handler = Arc::new(child_handler);
+
+        let bottom_up_msg_batch_period = BottomUpRelayer::<BottomUpMsgBatch>::checkpoint_period(parent_handler.as_ref(), &child.id)
             .await
             .map_err(|e| anyhow!("cannot get bottom up checkpoint period: {e}"))?;
         Ok(Self {
-            metadata: CheckpointConfig {
+            bottom_up_checkpoint_relayer: BottomUpRelayerManager::new(
+                parent.clone(),
+                child.clone(),
+                parent_handler.clone(),
+                child_handler.clone(),
+            ).await?,
+            bottom_up_msg_batch_relayer: BottomUpRelayerManager::new(
                 parent,
                 child,
-                period,
-            },
-            parent_handler,
-            child_handler,
-            finalization_blocks: 0,
+                parent_handler,
+                child_handler,
+            ).await?,
         })
     }
 
     pub fn with_finalization_blocks(mut self, finalization_blocks: ChainEpoch) -> Self {
-        self.finalization_blocks = finalization_blocks;
+        self.bottom_up_checkpoint_relayer.finalization_blocks = finalization_blocks;
+        self.bottom_up_msg_batch_relayer.finalization_blocks = finalization_blocks;
         self
     }
 }
 
-impl BottomUpCheckpointManager<EthSubnetManager> {
+impl BottomUpCheckpointManager<EthSubnetManager, EthSubnetManager> {
     pub async fn new_evm_manager(
         parent: Subnet,
         child: Subnet,
@@ -75,25 +82,68 @@ impl BottomUpCheckpointManager<EthSubnetManager> {
     }
 }
 
-impl<T: BottomUpCheckpointRelayer> Display for BottomUpCheckpointManager<T> {
+impl<T> Display for BottomUpCheckpointManager<T, T>
+where T: BottomUpRelayer<BottomUpCheckpoint> + BottomUpRelayer<BottomUpMsgBatch> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "bottom-up relayer, parent: {:}, child: {:}",
-            self.metadata.parent.id, self.metadata.child.id
+            self.bottom_up_checkpoint_relayer.metadata.parent.id,
+            self.bottom_up_checkpoint_relayer.metadata.child.id
         )
     }
 }
 
-impl<T: BottomUpCheckpointRelayer + Send + Sync + 'static> BottomUpCheckpointManager<T> {
-    /// Getter for the parent subnet this checkpoint manager is handling
-    pub fn parent_subnet(&self) -> &Subnet {
-        &self.metadata.parent
-    }
+impl<T> BottomUpCheckpointManager<T, T>
+where T : BottomUpRelayer<BottomUpCheckpoint> + BottomUpRelayer<BottomUpMsgBatch> + Send + Sync + 'static{
+    /// Run the bottom up checkpoint submission daemon in the foreground
+    pub async fn run(self, submitter: Address, submission_interval: Duration) {
+        log::info!("launching {self} for {submitter}");
 
-    /// Getter for the target subnet this checkpoint manager is handling
-    pub fn child_subnet(&self) -> &Subnet {
-        &self.metadata.child
+        loop {
+            if let Err(e) = self.bottom_up_checkpoint_relayer.submit(&submitter).await {
+                log::error!("cannot submit checkpoint for submitter: {submitter} due to {e}");
+            }
+
+            if let Err(e) = self.bottom_up_msg_batch_relayer.submit(&submitter).await {
+                log::error!("cannot submit msg batch for submitter: {submitter} due to {e}");
+            }
+
+            tokio::time::sleep(submission_interval).await;
+        }
+    }
+}
+
+struct BottomUpRelayerManager<G, T: BottomUpRelayer<G>> {
+    metadata: CheckpointConfig,
+    parent_handler: Arc<T>,
+    child_handler: Arc<T>,
+    /// The number of blocks away from the chain head that is considered final
+    finalization_blocks: ChainEpoch,
+    ph: PhantomData<G>,
+}
+
+impl<G, T> BottomUpRelayerManager<G, T>
+    where T : BottomUpRelayer<G> + Send + Sync + 'static{
+    pub async fn new(
+        parent: Subnet,
+        child: Subnet,
+        parent_handler: Arc<T>,
+        child_handler: Arc<T>,
+    ) -> Result<Self> {
+        let period = parent_handler.checkpoint_period(&child.id)
+            .await
+            .map_err(|e| anyhow!("cannot get bottom up checkpoint period: {e}"))?;
+
+        Ok(Self {
+            metadata: CheckpointConfig {
+                parent, child, period
+            },
+            parent_handler,
+            child_handler,
+            finalization_blocks: 0,
+            ph: Default::default(),
+        })
     }
 
     /// The checkpoint period that the current manager is submitting upon
@@ -101,30 +151,15 @@ impl<T: BottomUpCheckpointRelayer + Send + Sync + 'static> BottomUpCheckpointMan
         self.metadata.period
     }
 
-    /// Run the bottom up checkpoint submission daemon in the foreground
-    pub async fn run(self, submitter: Address, submission_interval: Duration) {
-        log::info!("launching {self} for {submitter}");
-
-        loop {
-            if let Err(e) = self.submit_checkpoint(&submitter).await {
-                log::error!("cannot submit checkpoint for submitter: {submitter} due to {e}");
-            }
-
-            tokio::time::sleep(submission_interval).await;
-        }
-    }
-
     /// Submit the checkpoint from the target submitter address
-    pub async fn submit_checkpoint(&self, submitter: &Address) -> Result<()> {
+    pub async fn submit(&self, submitter: &Address) -> Result<()> {
         self.submit_last_epoch(submitter).await?;
         self.submit_next_epoch(submitter).await
     }
 
     /// Derive the next submission checkpoint height
     async fn next_submission_height(&self) -> Result<ChainEpoch> {
-        let last_checkpoint_epoch = self
-            .parent_handler
-            .last_bottom_up_checkpoint_height(&self.metadata.child.id)
+        let last_checkpoint_epoch = T::last_bottom_up_checkpoint_height(self.parent_handler.as_ref(), &self.metadata.child.id)
             .await
             .map_err(|e| {
                 anyhow!("cannot obtain the last bottom up checkpoint height due to: {e:}")
@@ -135,45 +170,37 @@ impl<T: BottomUpCheckpointRelayer + Send + Sync + 'static> BottomUpCheckpointMan
     /// Checks if the relayer has already submitted at the `last_checkpoint_height`, if not it submits it.
     async fn submit_last_epoch(&self, submitter: &Address) -> Result<()> {
         let subnet = &self.metadata.child.id;
-        if self
-            .parent_handler
-            .has_submitted_in_last_checkpoint_height(subnet, submitter)
+        if self.parent_handler.has_submitted_in_last_confirmed_height(subnet, submitter)
             .await?
         {
             return Ok(());
         }
 
-        let height = self
-            .parent_handler
-            .last_bottom_up_checkpoint_height(subnet)
-            .await?;
+        let height = self.parent_handler.last_bottom_up_checkpoint_height(subnet).await?;
 
         if height == 0 {
             log::debug!("no previous checkpoint yet");
             return Ok(());
         }
 
-        let bundle = self.child_handler.checkpoint_bundle_at(height).await?;
-        log::debug!("bottom up bundle: {bundle:?}");
+        let bundle: BottomUpBundle<G> = self.child_handler.bundle_at(height).await?;
 
-        todo!("implement submit checkpoint")
+        let epoch = self
+            .parent_handler
+            .submit_checkpoint(submitter, bundle.checkpoint, bundle.signatures, bundle.signatories)
+            .await
+            .map_err(|e| anyhow!("cannot submit bottom up checkpoint due to: {e:}"))?;
+        log::info!(
+            "submitted bottom up checkpoint({}) in parent at height {}",
+            height,
+            epoch
+        );
 
-        // let epoch = self
-        //     .parent_handler
-        //     .submit_checkpoint(submitter, bundle)
-        //     .await
-        //     .map_err(|e| anyhow!("cannot submit bottom up checkpoint due to: {e:}"))?;
-        // log::info!(
-        //     "submitted bottom up checkpoint({}) in parent at height {}",
-        //     height,
-        //     epoch
-        // );
-        //
-        // Ok(())
+        Ok(())
     }
 
     /// Checks if the relayer has already submitted at the next submission epoch, if not it submits it.
-    async fn submit_next_epoch(&self, _submitter: &Address) -> Result<()> {
+    async fn submit_next_epoch(&self, submitter: &Address) -> Result<()> {
         let next_submission_height = self.next_submission_height().await?;
         let current_height = self.child_handler.current_epoch().await?;
         let finalized_height = max(1, current_height - self.finalization_blocks);
@@ -197,24 +224,20 @@ impl<T: BottomUpCheckpointRelayer + Send + Sync + 'static> BottomUpCheckpointMan
             log::debug!("found reached events at height : {h}");
 
             for event in events {
-                let bundle = self
-                    .child_handler
-                    .checkpoint_bundle_at(event.height)
-                    .await?;
-                log::debug!("bottom up bundle: {bundle:?}");
+                let bundle = self.child_handler.bundle_at(event.height).await?;
+                // log::debug!("bottom up bundle: {bundle:?}");
 
-                todo!("implement submiet checkpoint")
-                // let epoch = self
-                //     .parent_handler
-                //     .submit_checkpoint(submitter, bundle)
-                //     .await
-                //     .map_err(|e| anyhow!("cannot submit bottom up checkpoint due to: {e:}"))?;
-                //
-                // log::info!(
-                //     "submitted bottom up checkpoint({}) in parent at height {}",
-                //     event.height,
-                //     epoch
-                // );
+                let epoch = self
+                    .parent_handler
+                    .submit_checkpoint(submitter, bundle.checkpoint, bundle.signatures, bundle.signatories)
+                    .await
+                    .map_err(|e| anyhow!("cannot submit bottom up checkpoint due to: {e:}"))?;
+
+                log::info!(
+                    "submitted bottom up checkpoint({}) in parent at height {}",
+                    event.height,
+                    epoch
+                );
             }
         }
 

--- a/ipc/ipc/provider/src/lib.rs
+++ b/ipc/ipc/provider/src/lib.rs
@@ -12,7 +12,7 @@ use fvm_shared::{
 use ipc_identity::{
     EthKeyAddress, EvmKeyStore, KeyStore, KeyStoreConfig, PersistentKeyStore, Wallet,
 };
-use ipc_sdk::checkpoint::{BottomUpCheckpointBundle, QuorumReachedEvent};
+use ipc_sdk::checkpoint::{BottomUpBundle, BottomUpCheckpoint, QuorumReachedEvent};
 use ipc_sdk::staking::{StakingChangeRequest, ValidatorInfo};
 use ipc_sdk::subnet::{PermissionMode, SupplySource};
 use ipc_sdk::{
@@ -699,13 +699,13 @@ impl IpcProvider {
         &self,
         subnet: &SubnetID,
         height: ChainEpoch,
-    ) -> anyhow::Result<BottomUpCheckpointBundle> {
+    ) -> anyhow::Result<BottomUpBundle<BottomUpCheckpoint>> {
         let conn = match self.connection(subnet) {
             None => return Err(anyhow!("target subnet not found")),
             Some(conn) => conn,
         };
 
-        conn.manager().checkpoint_bundle_at(height).await
+        conn.manager().bundle_at(height).await
     }
 
     pub async fn has_submitted_in_last_checkpoint_height(
@@ -720,7 +720,7 @@ impl IpcProvider {
         };
 
         conn.manager()
-            .has_submitted_in_last_checkpoint_height(subnet, addr)
+            .has_submitted_in_last_confirmed_height(subnet, addr)
             .await
     }
 

--- a/ipc/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/ipc/provider/src/manager/evm/manager.rs
@@ -1234,6 +1234,7 @@ impl EthSubnetManager {
         height: ChainEpoch,
         quorum_kind: QuorumObjKind,
     ) -> Result<Vec<QuorumReachedEvent>> {
+        log::debug!("query quorum reached events for height {} and kind {:?}", height, quorum_kind);
         let contract = bottom_up_router_facet::BottomUpRouterFacet::new(
             self.ipc_contract_info.gateway_addr,
             Arc::new(self.ipc_contract_info.provider.clone()),
@@ -1246,6 +1247,7 @@ impl EthSubnetManager {
 
         let mut events = vec![];
         for (event, _meta) in query_with_meta(ev, contract.client()).await? {
+            log::debug!("received raw event: {:?}", event);
             let kind = QuorumObjKind::try_from(event.obj_kind)?;
             if kind != quorum_kind {
                 continue;

--- a/ipc/ipc/provider/src/manager/mod.rs
+++ b/ipc/ipc/provider/src/manager/mod.rs
@@ -3,8 +3,8 @@
 pub use crate::lotus::message::ipc::SubnetInfo;
 pub use evm::{EthManager, EthSubnetManager};
 pub use subnet::{
-    BottomUpCheckpointRelayer, GetBlockHashResult, SubnetGenesisInfo, SubnetManager,
-    TopDownFinalityQuery, TopDownQueryPayload,
+    BottomUpRelayer, GetBlockHashResult, SubnetGenesisInfo, SubnetManager, TopDownFinalityQuery,
+    TopDownQueryPayload,
 };
 
 pub mod evm;

--- a/ipc/ipc/provider/src/manager/subnet.rs
+++ b/ipc/ipc/provider/src/manager/subnet.rs
@@ -8,9 +8,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::{address::Address, econ::TokenAmount};
-use ipc_sdk::checkpoint::{
-    BottomUpBundle, BottomUpCheckpoint, BottomUpMsgBatch, QuorumReachedEvent, Signature,
-};
+use ipc_sdk::checkpoint::{BottomUpBundle, BottomUpCheckpoint, QuorumReachedEvent, Signature};
 use ipc_sdk::cross::CrossMsg;
 use ipc_sdk::staking::{StakingChangeRequest, ValidatorInfo};
 use ipc_sdk::subnet::{ConstructParams, PermissionMode, SupplySource};

--- a/ipc/ipc/provider/src/manager/subnet.rs
+++ b/ipc/ipc/provider/src/manager/subnet.rs
@@ -8,7 +8,9 @@ use anyhow::Result;
 use async_trait::async_trait;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::{address::Address, econ::TokenAmount};
-use ipc_sdk::checkpoint::{BottomUpBundle, BottomUpCheckpoint, QuorumReachedEvent, Signature};
+use ipc_sdk::checkpoint::{
+    BottomUpBundle, BottomUpCheckpoint, BottomUpMsgBatch, QuorumReachedEvent, Signature,
+};
 use ipc_sdk::cross::CrossMsg;
 use ipc_sdk::staking::{StakingChangeRequest, ValidatorInfo};
 use ipc_sdk::subnet::{ConstructParams, PermissionMode, SupplySource};
@@ -20,7 +22,11 @@ use crate::lotus::message::ipc::SubnetInfo;
 /// Trait to interact with a subnet and handle its lifecycle.
 #[async_trait]
 pub trait SubnetManager:
-    Send + Sync + TopDownFinalityQuery + BottomUpRelayer<BottomUpCheckpoint>
+    Send
+    + Sync
+    + TopDownFinalityQuery
+    + BottomUpRelayer<BottomUpCheckpoint>
+    + BottomUpRelayer<BottomUpMsgBatch>
 {
     /// Deploys a new subnet actor on the `parent` subnet and with the
     /// configuration passed in `ConstructParams`.

--- a/ipc/ipc/sdk/src/checkpoint.rs
+++ b/ipc/ipc/sdk/src/checkpoint.rs
@@ -50,6 +50,16 @@ impl Display for QuorumReachedEvent {
 
 /// The collection of items for the bottom up checkpoint submission
 #[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+pub struct BottomUpBundle<T> {
+    pub checkpoint: T,
+    /// The list of signatures that have signed the checkpoint hash
+    pub signatures: Vec<Signature>,
+    /// The list of addresses that have signed the checkpoint hash
+    pub signatories: Vec<Address>,
+}
+
+/// The collection of items for the bottom up checkpoint submission
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
 pub struct BottomUpCheckpointBundle {
     pub checkpoint: BottomUpCheckpoint,
     /// The list of signatures that have signed the checkpoint hash

--- a/ipc/ipc/sdk/src/checkpoint.rs
+++ b/ipc/ipc/sdk/src/checkpoint.rs
@@ -27,7 +27,7 @@ lazy_static! {
 
 pub type Signature = Vec<u8>;
 
-#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum QuorumObjKind {
     Checkpoint,

--- a/ipc/ipc/sdk/src/evm.rs
+++ b/ipc/ipc/sdk/src/evm.rs
@@ -174,6 +174,22 @@ macro_rules! bottom_up_type_conversion {
             }
         }
 
+        impl TryFrom<$module::BottomUpMsgBatch> for BottomUpMsgBatch {
+            type Error = anyhow::Error;
+
+            fn try_from(value: $module::BottomUpMsgBatch) -> Result<Self, Self::Error> {
+                Ok(BottomUpMsgBatch {
+                    subnet_id: SubnetID::try_from(value.subnet_id)?,
+                    block_height: value.block_height.as_u128() as ChainEpoch,
+                    msgs: value
+                        .msgs
+                        .into_iter()
+                        .map(CrossMsg::try_from)
+                        .collect::<Result<Vec<_>, _>>()?,
+                })
+            }
+        }
+
         impl TryFrom<BottomUpCheckpoint> for $module::BottomUpCheckpoint {
             type Error = anyhow::Error;
 


### PR DESCRIPTION
This fixes the relayer by adding the bottom up msg batch handling.

The key changes are abstracting the `BottomUpRelayer` trait to handle both `BottomUpCheckpoint` and `BottomUpMsgBatch` and `EthManager` implements both traits.