### PR TITLE
Infra Scripts Bugfix - minimum collateral for ipc gateway

### DIFF
--- a/infra/fendermint/scripts/genesis.toml
+++ b/infra/fendermint/scripts/genesis.toml
@@ -31,6 +31,7 @@ extend = "fendermint-tool"
 env = { "ENTRY" = "fendermint", "CMD" = """genesis --genesis-file /data/genesis.json ipc gateway --subnet-id /r0 \
     --bottom-up-check-period 10 \
     --msg-fee 10 \
+    --min-collateral 1000000000000000000 \
     --majority-percentage 67 \
     """ }
 


### PR DESCRIPTION
provide required argument to ipc gateway for min collateral using default from docs/fendermint/running.md

this issue came up from testing this file: https://github.com/consensus-shipyard/fevm-contract-tests/blob/main/.github/workflows/ci.yaml

steps to reproduce:
run 
```
cargo make --makefile ./infra/fendermint/Makefile.toml testnode
```
see error 

```
[cargo-make] INFO - Running Task: genesis-new-gateway
error: the following required arguments were not provided:
  --min-collateral <MIN_COLLATERAL>

Usage: fendermint genesis ipc gateway --subnet-id <SUBNET_ID> --bottom-up-check-period <BOTTOM_UP_CHECK_PERIOD> --min-collateral <MIN_COLLATERAL> --msg-fee <MSG_FEE> --majority-percentage <MAJORITY_PERCENTAGE>

```


this commit fixes this error and allows the cargo make command to succeed 

```
# Testnode ready! 🚀       #
```

