### PR TITLE
fix: fendermint docker image name

### DIFF
--- a/.github/workflows/fendermint-publish.yaml
+++ b/.github/workflows/fendermint-publish.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Docker Prep
         id: prep
         run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/fendermint
 
           # This changes all uppercase characters to lowercase.
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')


### PR DESCRIPTION
After moving to monorepo, we can not use the repository name anymore as the docker image