### PR TITLE
update github container location to use new mono repo in infra scripts

### DIFF
--- a/infra/fendermint/Makefile.toml
+++ b/infra/fendermint/Makefile.toml
@@ -75,8 +75,8 @@ ETHAPI_CONTAINER_NAME = "${NODE_NAME}-ethapi"
 
 CMT_DOCKER_IMAGE = "cometbft/cometbft:v0.37.x"
 FM_DOCKER_TAG = "latest"
-FM_DOCKER_IMAGE = "fendermint:${FM_DOCKER_TAG}"
-FM_REMOTE_DOCKER_IMAGE = "ghcr.io/consensus-shipyard/fendermint:${FM_DOCKER_TAG}"
+FM_DOCKER_IMAGE = "ipc:${FM_DOCKER_TAG}"
+FM_REMOTE_DOCKER_IMAGE = "ghcr.io/consensus-shipyard/ipc:${FM_DOCKER_TAG}"
 # If this wasn't present, any wait task is skipped.
 CARGO_MAKE_WAIT_MILLISECONDS = 5000
 # This wait time seems to work locally.

--- a/infra/fendermint/docker-compose.yml
+++ b/infra/fendermint/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   fendermint-node:
     container_name: fendermint-node${NODE_ID}
     user: ${UID}:${GID}
-    image: "fendermint:latest"
+    image: "ipc:latest"
     environment:
       - FM_DATA_DIR=/data/fendermint/data
       - FM_CHAIN_NAME=$NETWORK_NAME
@@ -41,7 +41,7 @@ services:
   ethapi-node:
     container_name: ethapi-node${NODE_ID}
     user: ${UID}:${GID}
-    image: "fendermint:latest"
+    image: "ipc:latest"
     command: "eth run"
     environment:
       - TENDERMINT_RPC_URL=http://cometbft-node${NODE_ID}:26657

--- a/infra/fendermint/scripts/fendermint.toml
+++ b/infra/fendermint/scripts/fendermint.toml
@@ -7,8 +7,8 @@ condition = { env_not_set = [
   "FM_PULL_SKIP",
 ], fail_message = "Skipped pulling fendermint Docker image." }
 script = """
-  docker pull ghcr.io/consensus-shipyard/fendermint:${FM_DOCKER_TAG}
-  docker tag ghcr.io/consensus-shipyard/fendermint:${FM_DOCKER_TAG} fendermint:${FM_DOCKER_TAG}
+  docker pull ghcr.io/consensus-shipyard/ipc:${FM_DOCKER_TAG}
+  docker tag ghcr.io/consensus-shipyard/ipc:${FM_DOCKER_TAG} ipc:${FM_DOCKER_TAG}
 """
 
 [tasks.fendermint-run]
@@ -140,11 +140,11 @@ dependencies = ["fendermint-deps"]
 script = """
 # Check if the image exists
 # TODO: Check the version or use a flag to always re-build?
-if docker images | awk '{print $1":"$2}' | grep fendermint; then
-    echo fendermint image already exists
-    docker images | grep fendermint
+if docker images | awk '{print $1":"$2}' | grep ipc; then
+    echo ipc image already exists
+    docker images | grep ipc
 else
-    cd ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/fendermint
+    cd ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/ipc
     make docker-build
 fi
 """


### PR DESCRIPTION
On main running the command `cargo make --makefile ./infra/fendermint/Makefile.toml testnode` leads to failure because we are pointing to the previous gh repo, not this current mono repo. 

This PR addresses this concern that was raised [in issue #546](https://github.com/consensus-shipyard/ipc/issues/546)

when running the makefile from this PR we have the following success output:

```
:~/dev/consensus-shipyard/ipc$ cargo make --makefile ./infra/fendermint/Makefile.toml testnode 
[cargo-make] INFO - cargo make 0.37.5
[cargo-make] INFO - Calling cargo metadata to extract project info
[cargo-make] INFO - Cargo metadata done
[cargo-make] INFO - Build File: ./infra/fendermint/Makefile.toml
[cargo-make] INFO - Task: testnode
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: legacy-migration
[cargo-make] INFO - Execute Command: "docker" "stop" "ipc-node-cometbft"
ipc-node-cometbft
[cargo-make] INFO - Execute Command: "docker" "rm" "--force" "ipc-node-cometbft"
ipc-node-cometbft
[cargo-make] INFO - Execute Command: "docker" "stop" "ipc-node-fendermint"
ipc-node-fendermint
[cargo-make] INFO - Execute Command: "docker" "rm" "--force" "ipc-node-fendermint"
ipc-node-fendermint
[cargo-make] INFO - Execute Command: "docker" "stop" "ipc-node-ethapi"
ipc-node-ethapi
[cargo-make] INFO - Execute Command: "docker" "rm" "--force" "ipc-node-ethapi"
ipc-node-ethapi
[cargo-make] INFO - Execute Command: "docker" "network" "rm" "r0"
r0
[cargo-make] INFO - Running Task: fendermint-pull
latest: Pulling from consensus-shipyard/ipc
Digest: sha256:16db626542b6f780086dff8f197088a5a6d097f163cfd5ce914c686ccafcc5ba
Status: Image is up to date for ghcr.io/consensus-shipyard/ipc:latest
ghcr.io/consensus-shipyard/ipc:latest
[cargo-make] INFO - Running Task: node-clear
clearing all IPC data
[cargo-make] INFO - Running Task: node-mkdir
creating directories: /home/mikers/.ipc/r0/ipc-node /home/mikers/.ipc/r0/ipc-node/ipc-node/fendermint /home/mikers/.ipc/r0/ipc-node/ipc-node/cometbft
[cargo-make] INFO - Execute Command: "docker" "network" "create" "r0"
b48eeaca8bc2517b83925892a36ff376347befa187faeea9cfc3e016a80dadc9
[cargo-make] INFO - Execute Command: "docker" "pull" "cometbft/cometbft:v0.37.x"
v0.37.x: Pulling from cometbft/cometbft
Digest: sha256:e6220583125171b617e79e112c8fbff5c9c56d569bf53c5faea3b124cf1b432a
Status: Image is up to date for cometbft/cometbft:v0.37.x
docker.io/cometbft/cometbft:v0.37.x
[cargo-make] INFO - Running Task: cometbft-init
Running cometbft init to create (default) configuration for docker run.
I[2024-01-12|02:12:18.596] Generated private validator                  module=main keyFile=/cometbft/config/priv_validator_key.json stateFile=/cometbft/data/priv_validator_state.json
I[2024-01-12|02:12:18.596] Generated node key                           module=main path=/cometbft/config/node_key.json
I[2024-01-12|02:12:18.596] Generated genesis file                       module=main path=/cometbft/config/genesis.json
I[2024-01-12|02:12:18.607] Found private validator                      module=main keyFile=/cometbft/config/priv_validator_key.json stateFile=/cometbft/data/priv_validator_state.json
I[2024-01-12|02:12:18.607] Found node key                               module=main path=/cometbft/config/node_key.json
I[2024-01-12|02:12:18.607] Found genesis file                           module=main path=/cometbft/config/genesis.json
[cargo-make] INFO - Running Task: fendermint-deps
ipc:latest
ghcr.io/consensus-shipyard/ipc:latest
ipc image already exists
ghcr.io/consensus-shipyard/ipc          latest     14a87820af5a   13 hours ago   204MB
ipc                                     latest     14a87820af5a   13 hours ago   204MB
[cargo-make] INFO - Running Task: genesis-new
[cargo-make] INFO - Running Task: genesis-new-key
[cargo-make] INFO - Running Task: genesis-new-account-f1
[cargo-make] INFO - Running Task: genesis-new-account-eth
[cargo-make] INFO - Running Task: genesis-add-validator
[cargo-make] INFO - Running Task: genesis-new-gateway
[cargo-make] INFO - Running Task: genesis-write
[cargo-make] INFO - Running Task: testnode-export-keys
[cargo-make] INFO - Running Task: fendermint-start
ecf22b76f48c0502d746688a8be27802f8772eef030877d7b5c8c04e60aff094
[cargo-make] INFO - Running Task: cometbft-start
554d17bcd435109d4badcd573c34c1e95ddbb0566af5dd1e4fc32ad92f6434a9
[cargo-make] INFO - Running Task: cometbft-wait
[cargo-make] INFO - Running Task: ethapi-start
3594c5d5252c1be1349b0430763a4088839c6e93ba0cd446c80f92932fbe677e
[cargo-make] INFO - Running Task: testnode-report
############################
#                          #
# Testnode ready! 🚀       #
#                          #
############################

Eth API:
	http://0.0.0.0:8545

Accounts:
	x: 10000000000000000000000000000 coin units
	x: 10000000000000000000000000000 coin units

Private key (hex ready to import in MetaMask):
	x

Note: both accounts use the same private key @ /home/mikers/.ipc/r0/ipc-node/keys/validator_key.sk

Chain ID:
	x

Fendermint API:
	http://localhost:26658

CometBFT API:
	http://0.0.0.0:26657
[cargo-make] INFO - Build Done in 34.13 seconds.

```