### PR TITLE
fix: short option names must be unique in fendermint cli

### DIFF
--- a/fendermint/app/options/src/lib.rs
+++ b/fendermint/app/options/src/lib.rs
@@ -76,7 +76,7 @@ pub struct Options {
     pub home_dir: PathBuf,
 
     /// Set a custom directory for ipc log files.
-    #[arg(short = 'l', long, env = "FM_LOG_DIR")]
+    #[arg(short = 'd', long, env = "FM_LOG_DIR")]
     pub log_dir: Option<PathBuf>,
 
     /// Optionally override the default configuration.
@@ -84,7 +84,7 @@ pub struct Options {
     pub mode: String,
 
     /// Set the logging level.
-    #[arg(short, long, default_value = "info", value_enum, env = "LOG_LEVEL")]
+    #[arg(short = 'l', long, default_value = "info", value_enum, env = "LOG_LEVEL")]
     pub log_level: LogLevel,
 
     /// Global options repeated here for discoverability, so they show up in `--help` among the others.


### PR DESCRIPTION
This PR fixes a s collision in our cli parser where the '-l' short option was duplicated between `log_dir` and `log_level`. I renamed the short option of the former to `-d`

Test

```
> fendermint -h
thread 'main' panicked at /home/fridrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.4.14/src/builder/debug_asserts.rs:112:17:
Command fendermint_app_options: Short option names must be unique for each argument, but '-l' is in use by both 'log_dir' and 'log_level'
```