### PR TITLE
BUILD: Run tests if Cargo.toml changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
       pull-requests: read
     # Set job outputs to values from filter step
     outputs:
+      workspace:     ${{ steps.filter.outputs.workspace }}
       contracts:     ${{ steps.filter.outputs.contracts }}
       ipc:           ${{ steps.filter.outputs.ipc }}
       ipld-resolver: ${{ steps.filter.outputs.ipld-resolver }}
@@ -37,6 +38,8 @@ jobs:
         id: filter
         with:
           filters: |
+            workspace:
+              - 'Cargo.toml'
             contracts:
               - 'contracts/**'
             ipc:
@@ -84,6 +87,7 @@ jobs:
     uses: ./.github/workflows/ipc.yaml
     needs: [changes, license]
     if: >-
+      needs.changes.outputs.workspace == 'true' ||
       needs.changes.outputs.contracts == 'true' ||
       needs.changes.outputs.ipc == 'true' ||
       github.ref == 'refs/heads/main'
@@ -92,6 +96,7 @@ jobs:
     uses: ./.github/workflows/ipld-resolver.yaml
     needs: [changes, license]
     if: >-
+      needs.changes.outputs.workspace == 'true' ||
       needs.changes.outputs.ipld-resolver == 'true' ||
       github.ref == 'refs/heads/main'
 
@@ -99,6 +104,7 @@ jobs:
     uses: ./.github/workflows/fendermint-test.yaml
     needs: [changes, license]
     if: >-
+      needs.changes.outputs.workspace == 'true' ||
       needs.changes.outputs.contracts == 'true' ||
       needs.changes.outputs.ipc == 'true' ||
       needs.changes.outputs.ipld-resolver == 'true' ||


### PR DESCRIPTION
Changes `ci.yaml` to run all Rust workflows if `Cargo.toml` changes, so that if we change some dependency version we don't have to wait until the PR is merged into `master` to see any build failures, which might be only due to `clippy`, as it happened in https://github.com/consensus-shipyard/ipc/pull/569

This is a tradeoff between doing more work with potentially no reason vs fixing stuff on `main`.