### PR TITLE
IPC-578: Update vote tally power table

### DIFF
--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -14,7 +14,6 @@ use fendermint_storage::{
     Codec, Encode, KVCollection, KVRead, KVReadable, KVStore, KVWritable, KVWrite,
 };
 use fendermint_vm_core::Timestamp;
-use fendermint_vm_genesis::{Power, Validator};
 use fendermint_vm_interpreter::bytes::{
     BytesMessageApplyRes, BytesMessageCheckRes, BytesMessageQuery, BytesMessageQueryRes,
 };
@@ -24,7 +23,7 @@ use fendermint_vm_interpreter::fvm::state::{
     FvmUpdatableParams,
 };
 use fendermint_vm_interpreter::fvm::store::ReadOnlyBlockstore;
-use fendermint_vm_interpreter::fvm::{FvmApplyRet, FvmGenesisOutput};
+use fendermint_vm_interpreter::fvm::{FvmApplyRet, FvmGenesisOutput, PowerUpdates};
 use fendermint_vm_interpreter::signed::InvalidSignature;
 use fendermint_vm_interpreter::{
     CheckInterpreter, ExecInterpreter, GenesisInterpreter, ProposalInterpreter, QueryInterpreter,
@@ -402,7 +401,7 @@ where
         Message = Vec<u8>,
         BeginOutput = FvmApplyRet,
         DeliverOutput = BytesMessageApplyRes,
-        EndOutput = Vec<Validator<Power>>,
+        EndOutput = PowerUpdates,
     >,
     I: CheckInterpreter<
         State = FvmExecState<ReadOnlyBlockstore<SS>>,

--- a/fendermint/app/src/tmconv.rs
+++ b/fendermint/app/src/tmconv.rs
@@ -6,7 +6,7 @@ use fendermint_vm_core::Timestamp;
 use fendermint_vm_genesis::{Power, Validator};
 use fendermint_vm_interpreter::fvm::{
     state::{BlockHash, FvmStateParams},
-    FvmApplyRet, FvmCheckRet, FvmQueryRet,
+    FvmApplyRet, FvmCheckRet, FvmQueryRet, PowerUpdates,
 };
 use fendermint_vm_message::signed::DomainHash;
 use fendermint_vm_snapshot::{SnapshotItem, SnapshotManifest};
@@ -142,9 +142,9 @@ pub fn to_check_tx(ret: FvmCheckRet) -> response::CheckTx {
 }
 
 /// Map the return values from epoch boundary operations to validator updates.
-pub fn to_end_block(power_table: Vec<Validator<Power>>) -> anyhow::Result<response::EndBlock> {
+pub fn to_end_block(power_table: PowerUpdates) -> anyhow::Result<response::EndBlock> {
     let validator_updates =
-        to_validator_updates(power_table).context("failed to convert validator updates")?;
+        to_validator_updates(power_table.0).context("failed to convert validator updates")?;
 
     Ok(response::EndBlock {
         validator_updates,

--- a/fendermint/vm/interpreter/src/chain.rs
+++ b/fendermint/vm/interpreter/src/chain.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use crate::fvm::state::ipc::GatewayCaller;
-use crate::fvm::{topdown, FvmApplyRet};
+use crate::fvm::{topdown, FvmApplyRet, PowerUpdates};
 use crate::{
     fvm::state::FvmExecState,
     fvm::FvmMessage,
@@ -186,6 +186,7 @@ where
         Message = VerifiableMessage,
         DeliverOutput = SignedMessageApplyRes,
         State = FvmExecState<DB>,
+        EndOutput = PowerUpdates,
     >,
 {
     // The state consists of the resolver pool, which this interpreter needs, and the rest of the
@@ -349,6 +350,7 @@ where
         (env, state): Self::State,
     ) -> anyhow::Result<(Self::State, Self::EndOutput)> {
         let (state, out) = self.inner.end(state).await?;
+
         Ok(((env, state), out))
     }
 }

--- a/fendermint/vm/interpreter/src/chain.rs
+++ b/fendermint/vm/interpreter/src/chain.rs
@@ -19,7 +19,7 @@ use fendermint_vm_message::{
 };
 use fendermint_vm_resolver::pool::{ResolveKey, ResolvePool};
 use fendermint_vm_topdown::proxy::IPCProviderProxy;
-use fendermint_vm_topdown::voting::VoteTally;
+use fendermint_vm_topdown::voting::{ValidatorKey, VoteTally};
 use fendermint_vm_topdown::{
     CachedFinalityProvider, IPCParentFinality, ParentFinalityProvider, ParentViewProvider, Toggle,
 };
@@ -350,6 +350,25 @@ where
         (env, state): Self::State,
     ) -> anyhow::Result<(Self::State, Self::EndOutput)> {
         let (state, out) = self.inner.end(state).await?;
+
+        // Update any component that needs to know about changes in the power table.
+        if !out.0.is_empty() {
+            let power_updates = out
+                .0
+                .iter()
+                .map(|v| {
+                    let vk = ValidatorKey::from(v.public_key.0);
+                    let w = v.power.0;
+                    (vk, w)
+                })
+                .collect::<Vec<_>>();
+
+            atomically(|| {
+                env.parent_finality_votes
+                    .update_power_table(power_updates.clone())
+            })
+            .await;
+        }
 
         Ok(((env, state), out))
     }

--- a/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -3,7 +3,6 @@
 
 use anyhow::Context;
 use async_trait::async_trait;
-use fendermint_vm_genesis::{Power, Validator};
 use std::collections::HashMap;
 
 use fendermint_vm_actor_interface::{cron, system};
@@ -47,7 +46,7 @@ where
     /// Return validator power updates.
     /// Currently ignoring events as there aren't any emitted by the smart contract,
     /// but keep in mind that if there were, those would have to be propagated.
-    type EndOutput = Vec<Validator<Power>>;
+    type EndOutput = PowerUpdates;
 
     async fn begin(
         &self,
@@ -183,6 +182,6 @@ where
             PowerUpdates::default()
         };
 
-        Ok((state, updates.0))
+        Ok((state, updates))
     }
 }

--- a/fendermint/vm/topdown/src/voting.rs
+++ b/fendermint/vm/topdown/src/voting.rs
@@ -8,7 +8,7 @@ use std::hash::Hash;
 use crate::{BlockHash, BlockHeight};
 
 // Usign this type because it's `Hash`, unlike the normal `libsecp256k1::PublicKey`.
-use ipc_ipld_resolver::ValidatorKey;
+pub use ipc_ipld_resolver::ValidatorKey;
 
 pub type Weight = u64;
 
@@ -278,6 +278,9 @@ where
     ///
     /// This method expects only the updated values, leaving everyone who isn't in it untouched
     pub fn update_power_table(&self, power_updates: Vec<(K, Weight)>) -> Stm<()> {
+        if power_updates.is_empty() {
+            return Ok(());
+        }
         // We don't actually have to remove the votes of anyone who is no longer a validator,
         // we just have to make sure to handle the case when they are not in the power table.
         self.power_table.update_mut(|pt| {

--- a/fendermint/vm/topdown/src/voting.rs
+++ b/fendermint/vm/topdown/src/voting.rs
@@ -264,12 +264,30 @@ where
         Ok(())
     }
 
-    /// Update the power table after it has changed to a new snapshot, removing the votes of anyone
-    /// who is no longer a validator.
+    /// Overwrite the power table after it has changed to a new snapshot.
+    ///
+    /// This method expects absolute values, it completely replaces the existing powers.
     pub fn set_power_table(&self, power_table: Vec<(K, Weight)>) -> Stm<()> {
         let power_table = im::HashMap::from_iter(power_table);
         // We don't actually have to remove the votes of anyone who is no longer a validator,
         // we just have to make sure to handle the case when they are not in the power table.
         self.power_table.write(power_table)
+    }
+
+    /// Update the power table after it has changed with changes.
+    ///
+    /// This method expects only the updated values, leaving everyone who isn't in it untouched
+    pub fn update_power_table(&self, power_updates: Vec<(K, Weight)>) -> Stm<()> {
+        // We don't actually have to remove the votes of anyone who is no longer a validator,
+        // we just have to make sure to handle the case when they are not in the power table.
+        self.power_table.update_mut(|pt| {
+            for (vk, w) in power_updates {
+                if w == 0 {
+                    pt.remove(&vk);
+                } else {
+                    *pt.entry(vk).or_default() = w;
+                }
+            }
+        })
     }
 }


### PR DESCRIPTION
Closes #578 

Adds a hook to `ChainInterpeter::end` to call a new `VoteTally::update_power_table` if there are changes being passed back to CometBFT in the voting power. 