### PR TITLE
IPC-579: Update finality in the voting tally

### DIFF
--- a/fendermint/vm/interpreter/src/chain.rs
+++ b/fendermint/vm/interpreter/src/chain.rs
@@ -321,7 +321,12 @@ where
 
                     atomically(|| {
                         env.parent_finality_provider
-                            .set_new_finality(finality.clone(), prev_finality.clone())
+                            .set_new_finality(finality.clone(), prev_finality.clone())?;
+
+                        env.parent_finality_votes
+                            .set_finalized(finality.height, finality.block_hash.clone())?;
+
+                        Ok(())
                     })
                     .await;
 


### PR DESCRIPTION
Closes #579 

Updates the parent finality in the vote tally whenever a top-down proposal is executed.