### PR TITLE
IPC-583: Use the vote tally in prepare proposal

### DIFF
--- a/fendermint/vm/interpreter/src/chain.rs
+++ b/fendermint/vm/interpreter/src/chain.rs
@@ -121,6 +121,9 @@ where
         });
 
         // Prepare top down proposals.
+        // Before we try to find a quorum, pause incoming votes. This is optional but if there are lots of votes coming in it might hold up proposals.
+        atomically(|| state.parent_finality_votes.pause_votes_until_find_quorum()).await;
+
         // The pre-requisite for proposal is that there is a quorum of gossiped votes at that height.
         // The final proposal can be at most as high as the quorum, but can be less if we have already,
         // hit some limits such as how many blocks we can propose in a single step.


### PR DESCRIPTION
Closes #583 

Changes `ChainInterpreter::prepare` so that it looks at both the vote tally and the current parent finality provider: 
1. asks the vote tally if there is a quorum over any height in the parent chain
2. if there is, asks the provider for its next proposal
3. proposes the minimum of the two

This way we go as little as possible forward in the chain: only as much as there is quorum for, but potentially less if some of the existing limits are hit.

This way we don't have to change the logic of the existing provider, we are strictly just gatekeeping it from proposing too early.