### PR TITLE
ENG-544: Disallow killing subnet if not bootstrapped

### DIFF
--- a/contracts/src/errors/IPCErrors.sol
+++ b/contracts/src/errors/IPCErrors.sol
@@ -72,6 +72,7 @@ error SubnetNotFound();
 error WithdrawExceedingCollateral();
 error ZeroMembershipWeight();
 error SubnetAlreadyBootstrapped();
+error SubnetNotBootstrapped();
 error FacetCannotBeZero();
 error WrongGateway();
 error CannotFindSubnet();

--- a/contracts/src/subnet/SubnetActorManagerFacet.sol
+++ b/contracts/src/subnet/SubnetActorManagerFacet.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.19;
 
 import {VALIDATOR_SECP256K1_PUBLIC_KEY_LENGTH} from "../constants/Constants.sol";
 import {ERR_VALIDATOR_JOINED, ERR_VALIDATOR_NOT_JOINED} from "../errors/IPCErrors.sol";
-import {InvalidFederationPayload, SubnetAlreadyBootstrapped, NotEnoughFunds, CollateralIsZero, CannotReleaseZero, NotOwnerOfPublicKey, EmptyAddress, NotEnoughBalance, NotEnoughCollateral, NotValidator, NotAllValidatorsHaveLeft, InvalidPublicKeyLength, MethodNotAllowed} from "../errors/IPCErrors.sol";
+import {InvalidFederationPayload, SubnetAlreadyBootstrapped, NotEnoughFunds, CollateralIsZero, CannotReleaseZero, NotOwnerOfPublicKey, EmptyAddress, NotEnoughBalance, NotEnoughCollateral, NotValidator, NotAllValidatorsHaveLeft, InvalidPublicKeyLength, MethodNotAllowed, SubnetNotBootstrapped} from "../errors/IPCErrors.sol";
 import {IGateway} from "../interfaces/IGateway.sol";
 import {Validator, ValidatorSet} from "../structs/Subnet.sol";
 import {LibDiamond} from "../lib/LibDiamond.sol";
@@ -248,7 +248,9 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
         if (LibStaking.totalValidators() != 0) {
             revert NotAllValidatorsHaveLeft();
         }
-
+        if (!s.bootstrapped) {
+            revert SubnetNotBootstrapped();
+        }
         s.killed = true;
         IGateway(s.ipcGatewayAddr).kill();
     }

--- a/contracts/test/integration/SubnetActorDiamond.t.sol
+++ b/contracts/test/integration/SubnetActorDiamond.t.sol
@@ -407,7 +407,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         saManager.leave();
     }
 
-    function testSubnetActorDiamond_Leave() public {
+    function testSubnetActorDiamond_Leave_Subnet() public {
         (address validator1, uint256 privKey1, bytes memory publicKey1) = TestUtils.newValidator(100);
         (address validator2, uint256 privKey2, bytes memory publicKey2) = TestUtils.newValidator(101);
         (address validator3, uint256 privKey3, bytes memory publicKey3) = TestUtils.newValidator(102);
@@ -446,6 +446,15 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         require(!saGetter.isActiveValidator(validator1), "validator 1 is active");
         require(saGetter.isActiveValidator(validator2), "validator 2 is not active");
         require(saGetter.isActiveValidator(validator3), "validator 3 is not active");
+    }
+
+    function testSubnetActorDiamond_Kill_NotBootstrappedSubnet() public {
+        (address validator1, , ) = TestUtils.newValidator(100);
+
+        // not bootstrapped subnet can't be killed
+        vm.expectRevert(SubnetNotBootstrapped.selector);
+        vm.prank(validator1);
+        saManager.kill();
     }
 
     function testSubnetActorDiamond_Stake() public {


### PR DESCRIPTION
This PR fixes ENG-544 and implements the following rule to kill a subnet: a subnet can be killed if it was bootstrapped and does not contains validators.
