### PR TITLE
ENG-555: Fix check in submitBottomUpMsgBatch

### DIFF
--- a/contracts/src/gateway/router/BottomUpRouterFacet.sol
+++ b/contracts/src/gateway/router/BottomUpRouterFacet.sol
@@ -96,7 +96,7 @@ contract BottomUpRouterFacet is GatewayActorModifiers {
         // of messages for the batch hasn't been reached.
         // We also check that we are not trying to create a batch from
         // the future
-        if (batch.blockHeight % s.bottomUpMsgBatchPeriod != 0 || block.number <= batch.blockHeight) {
+        if (batch.blockHeight % s.bottomUpMsgBatchPeriod != 0 || block.number < batch.blockHeight) {
             revert InvalidBatchEpoch();
         }
 


### PR DESCRIPTION
This PR implements the following suggestion from the audit: 
Change the statement to 
```
if (batch.blockHeight % s.bottomUpMsgBatchPeriod != 0 || block.number < batch.blockHeight) {
        revert InvalidBatchEpoch();
}
```