### PR TITLE
Commit parent finality only if finality height is greater

### DIFF
--- a/contracts/src/lib/LibGateway.sol
+++ b/contracts/src/lib/LibGateway.sol
@@ -130,7 +130,7 @@ library LibGateway {
         GatewayActorStorage storage s = LibGatewayActorStorage.appStorage();
 
         uint256 lastHeight = s.latestParentHeight;
-        if (lastHeight > finality.height) {
+        if (lastHeight >= finality.height) {
             revert ParentFinalityAlreadyCommitted();
         }
         lastFinality = s.finalitiesMap[lastHeight];

--- a/contracts/test/integration/GatewayDiamond.t.sol
+++ b/contracts/test/integration/GatewayDiamond.t.sol
@@ -1149,6 +1149,9 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         weights[1] = 150;
 
         vm.startPrank(FilAddress.SYSTEM_ACTOR);
+        // increase the block number so that current block number is 
+        // not the same as init committed parent finality height
+        vm.roll(10);
 
         ParentFinality memory finality = ParentFinality({height: block.number, blockHash: bytes32(0)});
 

--- a/contracts/test/integration/GatewayDiamond.t.sol
+++ b/contracts/test/integration/GatewayDiamond.t.sol
@@ -1149,7 +1149,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         weights[1] = 150;
 
         vm.startPrank(FilAddress.SYSTEM_ACTOR);
-        // increase the block number so that current block number is 
+        // increase the block number so that current block number is
         // not the same as init committed parent finality height
         vm.roll(10);
 

--- a/contracts/test/integration/GatewayDiamondToken.t.sol
+++ b/contracts/test/integration/GatewayDiamondToken.t.sol
@@ -240,9 +240,9 @@ contract GatewayDiamondTokenTest is Test, IntegrationTestBase {
         saLouper = DiamondLoupeFacet(address(saDiamond));
         saCutter = DiamondCutFacet(address(saDiamond));
 
-        // increment the block number by 5 (could be other number as well) so that commit 
-        // parent finality called down stream will work we need this because in setUp, 
-        // parent finality is committed at the block height, without 
+        // increment the block number by 5 (could be other number as well) so that commit
+        // parent finality called down stream will work we need this because in setUp,
+        // parent finality is committed at the block height, without
         // incrementing the block number, test won't pass
         vm.roll(5);
 

--- a/contracts/test/integration/GatewayDiamondToken.t.sol
+++ b/contracts/test/integration/GatewayDiamondToken.t.sol
@@ -240,6 +240,12 @@ contract GatewayDiamondTokenTest is Test, IntegrationTestBase {
         saLouper = DiamondLoupeFacet(address(saDiamond));
         saCutter = DiamondCutFacet(address(saDiamond));
 
+        // increment the block number by 5 (could be other number as well) so that commit 
+        // parent finality called down stream will work we need this because in setUp, 
+        // parent finality is committed at the block height, without 
+        // incrementing the block number, test won't pass
+        vm.roll(5);
+
         addValidator(TOPDOWN_VALIDATOR_1, 100);
 
         (address validatorAddress, bytes memory publicKey) = TestUtils.deriveValidatorAddress(100);


### PR DESCRIPTION
Fixing issue #567. 

Adding a "=" to the check, this also forces the tests to advance by some value.