### PR TITLE
Properly fix eth_getCode and eth_getStorageAt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2889,6 +2889,7 @@ dependencies = [
  "fendermint_testing",
  "fendermint_vm_actor_interface",
  "fendermint_vm_message",
+ "fil_actors_evm_shared",
  "futures",
  "fvm_ipld_encoding",
  "fvm_shared",

--- a/fendermint/app/src/tmconv.rs
+++ b/fendermint/app/src/tmconv.rs
@@ -254,6 +254,7 @@ pub fn to_query(ret: FvmQueryRet, block_height: BlockHeight) -> anyhow::Result<r
         // the query itself is successful, even if the value represents a failure.
         FvmQueryRet::Call(_) | FvmQueryRet::EstimateGas(_) => ExitCode::OK,
         FvmQueryRet::StateParams(_) => ExitCode::OK,
+        FvmQueryRet::BuiltinActors(_) => ExitCode::OK,
     };
 
     // The return value has a `key` field which is supposed to be set to the data matched.
@@ -288,6 +289,10 @@ pub fn to_query(ret: FvmQueryRet, block_height: BlockHeight) -> anyhow::Result<r
         }
         FvmQueryRet::StateParams(sp) => {
             let v = ipld_encode!(sp);
+            (Vec::new(), v)
+        }
+        FvmQueryRet::BuiltinActors(ba) => {
+            let v = ipld_encode!(ba);
             (Vec::new(), v)
         }
     };

--- a/fendermint/eth/api/Cargo.toml
+++ b/fendermint/eth/api/Cargo.toml
@@ -27,6 +27,7 @@ tendermint-rpc = { workspace = true }
 tokio = { workspace = true }
 
 cid = { workspace = true }
+fil_actors_evm_shared = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -752,7 +752,7 @@ where
     let height = data.query_height(block_id).await?;
 
     // If not an EVM actor, return empty.
-    if data.get_actor_type(&address, height).await? != ActorType::Known("evm".to_string()) {
+    if data.get_actor_type(&address, height).await? != ActorType::Evm {
         // The client library expects hex encoded string.
         return encode(None);
     }

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -754,7 +754,7 @@ where
     // If not an EVM actor, return empty.
     if data.get_actor_type(&address, height).await? != ActorType::Known("evm".to_string()) {
         // The client library expects hex encoded string.
-        return encode(None)
+        return encode(None);
     }
 
     let params = evm::GetStorageAtParams {
@@ -776,10 +776,10 @@ where
 
     if let Some(ret) = ret {
         // ret.storage.to_big_endian(&mut bz);
-        return encode(Some(ret.storage))
+        return encode(Some(ret.storage));
     }
 
-    return encode(None)
+    return encode(None);
 }
 
 /// Returns code at a given address.

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -794,8 +794,6 @@ where
 
     // Return empty if not an EVM actor.
     if data.get_actor_type(&address, height).await? != ActorType::Known("evm".to_string()) {
-        tracing::info!("jiejie: SHIT SHIT");
-        tracing::info!("jiejie: in get_code(), actor type for add {:} is {:?}", address, data.get_actor_type(&address, height).await?);
         return Ok(Default::default());
     }
 

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -779,7 +779,7 @@ where
         return encode(Some(ret.storage));
     }
 
-    return encode(None);
+    encode(None)
 }
 
 /// Returns code at a given address.

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -752,7 +752,7 @@ where
     let height = data.query_height(block_id).await?;
 
     // If not an EVM actor, return empty.
-    if data.get_actor_type(&address, height).await? != ActorType::Evm {
+    if data.get_actor_type(&address, height).await? != ActorType::EVM {
         // The client library expects hex encoded string.
         return encode(None);
     }
@@ -793,7 +793,7 @@ where
     let height = data.query_height(block_id).await?;
 
     // Return empty if not an EVM actor.
-    if data.get_actor_type(&address, height).await? != ActorType::Known("evm".to_string()) {
+    if data.get_actor_type(&address, height).await? != ActorType::EVM {
         return Ok(Default::default());
     }
 

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -3,6 +3,7 @@
 
 //! Tendermint RPC helper methods for the implementation of the APIs.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -119,14 +120,14 @@ pub enum ActorType {
     /// The queried actor does not exist in the state tree.
     Inexistent,
     /// The queried actor exists, and it's one of the built-in actor types.
-    Known(String),
+    Known(Cow<'static, str>),
     /// The queried actor exists, but it's not a built-in actor and therefore it cannot be identified.
     Unknown(Cid),
 }
 
 impl ActorType {
-    pub const Evm: ActorType = ActorType::Known("evm".into());
-    pub const EthAccount: ActorType = ActorType::Known("ethaccount".into());
+    pub const EVM: ActorType = ActorType::Known(Cow::Borrowed("evm"));
+    pub const ETH_ACCOUNT: ActorType = ActorType::Known(Cow::Borrowed("ethaccount"));
 }
 
 impl<C> JsonRpcState<C>
@@ -431,7 +432,7 @@ where
         };
         let registry = self.client.builtin_actors(height).await?.value.registry;
         let ret = match registry.into_iter().find(|(_, cid)| cid == &actor_type_cid) {
-            Some((typ, _)) => ActorType::Known(typ),
+            Some((typ, _)) => ActorType::Known(Cow::Owned(typ)),
             None => ActorType::Unknown(actor_type_cid),
         };
         Ok(ret)

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -36,7 +36,6 @@ use crate::filters::{
     FilterRecords,
 };
 use crate::handlers::ws::MethodNotification;
-use crate::state::ActorType::Unknown;
 use crate::GasOpt;
 use crate::{
     conv::from_tm::{map_rpc_block_txs, to_chain_message, to_eth_block, to_eth_transaction},
@@ -414,7 +413,7 @@ where
         address: &et::H160,
         height: FvmQueryHeight,
     ) -> JsonRpcResult<ActorType> {
-        let addr = to_fvm_address(address.clone());
+        let addr = to_fvm_address(*address);
         let Some((
             _,
             ActorState {
@@ -425,9 +424,11 @@ where
         else {
             return Ok(ActorType::Inexistent);
         };
+        println!("jiejie: before calling builtin_actors()");
         let registry = self.client.builtin_actors(height).await?.value.registry;
-        let ret = match registry.iter().find(|(typ, cid)| cid == &actor_type_cid) {
-            Some((typ, _)) => ActorType::Known(typ.clone()),
+        println!("jiejie: after calling builtin_actors()");
+        let ret = match registry.into_iter().find(|(_, cid)| cid == &actor_type_cid) {
+            Some((typ, _)) => ActorType::Known(typ),
             None => ActorType::Unknown(actor_type_cid),
         };
         Ok(ret)

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -424,9 +424,7 @@ where
         else {
             return Ok(ActorType::Inexistent);
         };
-        println!("jiejie: before calling builtin_actors()");
         let registry = self.client.builtin_actors(height).await?.value.registry;
-        println!("jiejie: after calling builtin_actors()");
         let ret = match registry.into_iter().find(|(_, cid)| cid == &actor_type_cid) {
             Some((typ, _)) => ActorType::Known(typ),
             None => ActorType::Unknown(actor_type_cid),

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -118,10 +118,15 @@ impl<C> JsonRpcState<C> {
 pub enum ActorType {
     /// The queried actor does not exist in the state tree.
     Inexistent,
-    /// The queried actor exists, and its type is identified by the supplied manifest key.
+    /// The queried actor exists, and it's one of the built-in actor types.
     Known(String),
     /// The queried actor exists, but it's not a built-in actor and therefore it cannot be identified.
     Unknown(Cid),
+}
+
+impl ActorType {
+    pub const Evm: ActorType = ActorType::Known("evm".into());
+    pub const EthAccount: ActorType = ActorType::Known("ethaccount".into());
 }
 
 impl<C> JsonRpcState<C>

--- a/fendermint/rpc/src/client.rs
+++ b/fendermint/rpc/src/client.rs
@@ -249,11 +249,13 @@ async fn perform_query<C>(
 where
     C: Client + Sync + Send,
 {
+    println!("jiejie: in perform_query...");
     tracing::debug!(?query, ?height, "perform ABCI query");
     let data = fvm_ipld_encoding::to_vec(&query).context("failed to encode query")?;
     let height: u64 = height.into();
     let height = Height::try_from(height).context("failed to conver to Height")?;
 
+    println!("jiejie: before client.abci_query");
     let res = client.abci_query(None, data, Some(height), false).await?;
 
     Ok(res)

--- a/fendermint/rpc/src/client.rs
+++ b/fendermint/rpc/src/client.rs
@@ -249,13 +249,11 @@ async fn perform_query<C>(
 where
     C: Client + Sync + Send,
 {
-    println!("jiejie: in perform_query...");
     tracing::debug!(?query, ?height, "perform ABCI query");
     let data = fvm_ipld_encoding::to_vec(&query).context("failed to encode query")?;
     let height: u64 = height.into();
     let height = Height::try_from(height).context("failed to conver to Height")?;
 
-    println!("jiejie: before client.abci_query");
     let res = client.abci_query(None, data, Some(height), false).await?;
 
     Ok(res)

--- a/fendermint/rpc/src/query.rs
+++ b/fendermint/rpc/src/query.rs
@@ -102,9 +102,7 @@ pub trait QueryClient: Sync {
         &self,
         height: FvmQueryHeight,
     ) -> anyhow::Result<QueryResponse<BuiltinActors>> {
-        println!("jiejie: before calling perform() against FmvQuery::BuiltinActors");
         let res = self.perform(FvmQuery::BuiltinActors, height).await?;
-        println!("jiejie: after calling perform() against FmvQuery::BuiltinActors");
         let height = res.height;
         let value = {
             let registry: Vec<(String, Cid)> = extract(res, |res| {

--- a/fendermint/rpc/src/query.rs
+++ b/fendermint/rpc/src/query.rs
@@ -102,7 +102,9 @@ pub trait QueryClient: Sync {
         &self,
         height: FvmQueryHeight,
     ) -> anyhow::Result<QueryResponse<BuiltinActors>> {
+        println!("jiejie: before calling perform() against FmvQuery::BuiltinActors");
         let res = self.perform(FvmQuery::BuiltinActors, height).await?;
+        println!("jiejie: after calling perform() against FmvQuery::BuiltinActors");
         let height = res.height;
         let value = {
             let registry: Vec<(String, Cid)> = extract(res, |res| {

--- a/fendermint/vm/interpreter/src/fvm/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/query.rs
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 use async_trait::async_trait;
+use cid::Cid;
 use fendermint_vm_message::query::{ActorState, FvmQuery, GasEstimate, StateParams};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
@@ -18,7 +19,7 @@ use super::{state::FvmQueryState, FvmApplyRet, FvmMessageInterpreter};
 /// sent in the response. The client has to know what to expect,
 /// depending on the kind of query it sent.
 pub enum FvmQueryRet {
-    /// Bytes from the IPLD store retult, if found.
+    /// Bytes from the IPLD store result, if found.
     Ipld(Option<Vec<u8>>),
     /// The full state of an actor, if found.
     ActorState(Option<Box<(ActorID, ActorState)>>),
@@ -28,6 +29,8 @@ pub enum FvmQueryRet {
     EstimateGas(GasEstimate),
     /// Current state parameters.
     StateParams(StateParams),
+    /// Builtin actors known by the system.
+    BuiltinActors(Vec<(String, Cid)>),
 }
 
 #[async_trait]
@@ -147,6 +150,10 @@ where
                     network_version: state_params.network_version,
                 };
                 Ok((state, FvmQueryRet::StateParams(state_params)))
+            }
+            FvmQuery::BuiltinActors => {
+                let (state, ret) = state.builtin_actors().await?;
+                Ok((state, FvmQueryRet::BuiltinActors(ret)))
             }
         }
     }

--- a/fendermint/vm/interpreter/src/fvm/state/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/query.rs
@@ -7,7 +7,7 @@ use std::{cell::RefCell, sync::Arc};
 use anyhow::{anyhow, Context};
 
 use cid::Cid;
-use fendermint_vm_actor_interface::system::{is_system_addr, State, SYSTEM_ACTOR_ADDR};
+use fendermint_vm_actor_interface::system::{is_system_addr, State as SystemState, SYSTEM_ACTOR_ADDR};
 use fendermint_vm_core::chainid::HasChainID;
 use fendermint_vm_message::query::ActorState;
 use fvm::engine::MultiEngine;
@@ -211,9 +211,9 @@ where
             let (s, state) = self.actor_state(&SYSTEM_ACTOR_ADDR).await?;
             (s, state.ok_or(anyhow!("no system actor"))?.1)
         };
-        let state: State = s
+        let state: SystemState = s
             .store
-            .get_cbor(&sys_state.code)
+            .get_cbor(&sys_state.state)
             .context("failed to get system state")?
             .ok_or(anyhow!("system actor state not found"))?;
         let ret = s

--- a/fendermint/vm/interpreter/src/fvm/state/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/query.rs
@@ -7,7 +7,9 @@ use std::{cell::RefCell, sync::Arc};
 use anyhow::{anyhow, Context};
 
 use cid::Cid;
-use fendermint_vm_actor_interface::system::{is_system_addr, State as SystemState, SYSTEM_ACTOR_ADDR};
+use fendermint_vm_actor_interface::system::{
+    is_system_addr, State as SystemState, SYSTEM_ACTOR_ADDR,
+};
 use fendermint_vm_core::chainid::HasChainID;
 use fendermint_vm_message::query::ActorState;
 use fvm::engine::MultiEngine;

--- a/fendermint/vm/message/src/query.rs
+++ b/fendermint/vm/message/src/query.rs
@@ -74,6 +74,8 @@ pub enum FvmQuery {
     EstimateGas(Box<FvmMessage>),
     /// Retrieve the slowly changing state parameters that aren't part of the state tree.
     StateParams,
+    /// Query the built-in actors known by the System actor.
+    BuiltinActors,
 }
 
 /// State of all actor implementations.
@@ -140,6 +142,12 @@ pub struct StateParams {
     pub chain_id: u64,
     /// Current network version.
     pub network_version: NetworkVersion,
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+pub struct BuiltinActors {
+    /// Registry of built-in actors known by the system.
+    pub registry: Vec<(String, Cid)>,
 }
 
 #[cfg(feature = "arb")]


### PR DESCRIPTION
Based on Raul's draft [PR](https://github.com/consensus-shipyard/ipc/pull/514/files) 

Manually verified with

getCode:
* Non existent address: return `0x0`
* EVM account: return `0x0`
* EVM contract: return expected binary code

getStorageAt
* Non existent address: return `0x0`
* EVM account: return `0000000000000000000000000000000000000000000000000000000000000000`
* EVM contract: return expected storage

Integration test covered by existing assertions in `fendermint/eth/api/examples/ethers.rs` running as `smoke-test`.