### PR TITLE
[HOLD] Add an example custom kernel defining a custom syscall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,6 +2803,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fendermint_actor_customsyscall"
+version = "0.1.0"
+dependencies = [
+ "cid",
+ "fil_actors_runtime",
+ "frc42_dispatch",
+ "fvm_ipld_encoding",
+ "fvm_sdk",
+ "fvm_shared",
+ "num-derive 0.3.3",
+ "num-traits",
+ "serde",
+ "serde_tuple",
+]
+
+[[package]]
 name = "fendermint_actor_eam"
 version = "0.1.0"
 dependencies = [
@@ -2829,6 +2845,7 @@ dependencies = [
  "anyhow",
  "cid",
  "fendermint_actor_chainmetadata",
+ "fendermint_actor_customsyscall",
  "fendermint_actor_eam",
  "fil_actor_bundler",
  "fil_actors_runtime",
@@ -3281,6 +3298,7 @@ dependencies = [
  "cid",
  "ethers",
  "fendermint_actor_chainmetadata",
+ "fendermint_actor_customsyscall",
  "fendermint_actor_eam",
  "fendermint_actors",
  "fendermint_crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,6 +3273,7 @@ dependencies = [
 name = "fendermint_vm_interpreter"
 version = "0.1.0"
 dependencies = [
+ "ambassador",
  "anyhow",
  "arbitrary",
  "async-stm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-appender = "0.2.3"
 url = { version = "2.4.1", features = ["serde"] }
 zeroize = "1.6"
+ambassador = "0.3.5"
 
 # Workspace deps
 ipc-api = { path = "ipc/api" }

--- a/fendermint/actors/Cargo.toml
+++ b/fendermint/actors/Cargo.toml
@@ -10,6 +10,9 @@ fendermint_actor_chainmetadata = { path = "chainmetadata", features = [
     "fil-actor",
 ] }
 fendermint_actor_eam = { path = "eam", features = ["fil-actor"] }
+fendermint_actor_customsyscall = { path = "customsyscall", features = [
+    "fil-actor",
+] }
 
 [dependencies]
 cid = { workspace = true }
@@ -18,6 +21,7 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fendermint_actor_chainmetadata = { path = "chainmetadata" }
 fendermint_actor_eam = { path = "eam" }
+fendermint_actor_customsyscall = { path = "customsyscall" }
 
 [build-dependencies]
 fil_actors_runtime = { workspace = true, features = ["test_utils"] }

--- a/fendermint/actors/build.rs
+++ b/fendermint/actors/build.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::thread;
 
-const ACTORS: &[&str] = &["chainmetadata", "eam"];
+const ACTORS: &[&str] = &["chainmetadata", "eam", "customsyscall"];
 
 const FILES_TO_WATCH: &[&str] = &["Cargo.toml", "src"];
 

--- a/fendermint/actors/customsyscall/Cargo.toml
+++ b/fendermint/actors/customsyscall/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "fendermint_actor_customsyscall"
+description = "Test actor for demonstrating calling custom syscalls"
+license.workspace = true
+edition.workspace = true
+authors.workspace = true
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+cid = { workspace = true, default-features = false }
+fil_actors_runtime = { workspace = true, optional = true, features = [
+    "fil-actor",
+] }
+fvm_sdk = { workspace = true }
+fvm_shared = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+num-derive = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_tuple = { workspace = true }
+num-traits = { workspace = true }
+frc42_dispatch = { workspace = true }
+
+[features]
+default = []
+fil-actor = ["fil_actors_runtime"]

--- a/fendermint/actors/customsyscall/src/actor.rs
+++ b/fendermint/actors/customsyscall/src/actor.rs
@@ -1,0 +1,41 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fil_actors_runtime::actor_dispatch;
+use fil_actors_runtime::actor_error;
+use fil_actors_runtime::builtin::singletons::SYSTEM_ACTOR_ADDR;
+use fil_actors_runtime::runtime::{ActorCode, Runtime};
+use fil_actors_runtime::ActorError;
+
+use crate::{Method, CUSTOMSYSCALL_ACTOR_NAME};
+
+fil_actors_runtime::wasm_trampoline!(Actor);
+
+fvm_sdk::sys::fvm_syscalls! {
+    module = "my_custom_kernel";
+    pub fn my_custom_syscall() -> Result<u64>;
+}
+
+pub struct Actor;
+impl Actor {
+    fn invoke(rt: &impl Runtime) -> Result<u64, ActorError> {
+        rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
+
+        unsafe {
+            let value = my_custom_syscall().unwrap();
+            Ok(value)
+        }
+    }
+}
+
+impl ActorCode for Actor {
+    type Methods = Method;
+
+    fn name() -> &'static str {
+        CUSTOMSYSCALL_ACTOR_NAME
+    }
+
+    actor_dispatch! {
+        Invoke => invoke,
+    }
+}

--- a/fendermint/actors/customsyscall/src/lib.rs
+++ b/fendermint/actors/customsyscall/src/lib.rs
@@ -1,0 +1,7 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+#[cfg(feature = "fil-actor")]
+mod actor;
+mod shared;
+
+pub use shared::*;

--- a/fendermint/actors/customsyscall/src/shared.rs
+++ b/fendermint/actors/customsyscall/src/shared.rs
@@ -1,0 +1,12 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use num_derive::FromPrimitive;
+
+pub const CUSTOMSYSCALL_ACTOR_NAME: &str = "customsyscall";
+
+#[derive(FromPrimitive)]
+#[repr(u64)]
+pub enum Method {
+    Invoke = frc42_dispatch::method_hash!("Invoke"),
+}

--- a/fendermint/actors/src/manifest.rs
+++ b/fendermint/actors/src/manifest.rs
@@ -3,13 +3,19 @@
 use anyhow::{anyhow, Context};
 use cid::Cid;
 use fendermint_actor_chainmetadata::CHAINMETADATA_ACTOR_NAME;
+use fendermint_actor_customsyscall::CUSTOMSYSCALL_ACTOR_NAME;
 use fendermint_actor_eam::IPC_EAM_ACTOR_NAME;
+
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
 use std::collections::HashMap;
 
 // array of required actors
-pub const REQUIRED_ACTORS: &[&str] = &[CHAINMETADATA_ACTOR_NAME, IPC_EAM_ACTOR_NAME];
+pub const REQUIRED_ACTORS: &[&str] = &[
+    CHAINMETADATA_ACTOR_NAME,
+    IPC_EAM_ACTOR_NAME,
+    CUSTOMSYSCALL_ACTOR_NAME,
+];
 
 /// A mapping of internal actor CIDs to their respective types.
 pub struct Manifest {

--- a/fendermint/vm/actor_interface/src/customsyscall.rs
+++ b/fendermint/vm/actor_interface/src/customsyscall.rs
@@ -1,0 +1,4 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+define_id!(CUSTOMSYSCALL { id: 49 });

--- a/fendermint/vm/actor_interface/src/lib.rs
+++ b/fendermint/vm/actor_interface/src/lib.rs
@@ -46,6 +46,7 @@ pub mod account;
 pub mod burntfunds;
 pub mod chainmetadata;
 pub mod cron;
+pub mod customsyscall;
 pub mod diamond;
 pub mod eam;
 pub mod ethaccount;

--- a/fendermint/vm/interpreter/Cargo.toml
+++ b/fendermint/vm/interpreter/Cargo.toml
@@ -24,6 +24,7 @@ fendermint_actors = { path = "../../actors" }
 fendermint_actor_chainmetadata = { path = "../../actors/chainmetadata" }
 fendermint_actor_eam = { workspace = true }
 fendermint_testing = { path = "../../testing", optional = true }
+fendermint_actor_customsyscall = { path = "../../actors/customsyscall" }
 ipc_actors_abis = { workspace = true }
 
 ipc-api = { workspace = true }

--- a/fendermint/vm/interpreter/Cargo.toml
+++ b/fendermint/vm/interpreter/Cargo.toml
@@ -56,6 +56,7 @@ tokio = { workspace = true }
 pin-project = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
+ambassador = { workspace = true }
 
 arbitrary = { workspace = true, optional = true }
 quickcheck = { workspace = true, optional = true }

--- a/fendermint/vm/interpreter/src/fvm/examples/mod.rs
+++ b/fendermint/vm/interpreter/src/fvm/examples/mod.rs
@@ -1,0 +1,1 @@
+pub mod mycustomkernel;

--- a/fendermint/vm/interpreter/src/fvm/examples/mod.rs
+++ b/fendermint/vm/interpreter/src/fvm/examples/mod.rs
@@ -1,1 +1,3 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 pub mod mycustomkernel;

--- a/fendermint/vm/interpreter/src/fvm/examples/mycustomkernel.rs
+++ b/fendermint/vm/interpreter/src/fvm/examples/mycustomkernel.rs
@@ -1,0 +1,201 @@
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+use fvm::call_manager::CallManager;
+use fvm::gas::Gas;
+use fvm::kernel::filecoin::{DefaultFilecoinKernel, FilecoinKernel};
+use fvm::kernel::prelude::*;
+use fvm::kernel::Result;
+use fvm::kernel::{
+    ActorOps, CryptoOps, DebugOps, EventOps, IpldBlockOps, MessageOps, NetworkOps, RandomnessOps,
+    SelfOps, SendOps, SyscallHandler, UpgradeOps,
+};
+use fvm::syscalls::Linker;
+use fvm_shared::clock::ChainEpoch;
+use fvm_shared::consensus::ConsensusFault;
+use fvm_shared::piece::PieceInfo;
+use fvm_shared::randomness::RANDOMNESS_LENGTH;
+use fvm_shared::sector::{
+    AggregateSealVerifyProofAndInfos, RegisteredSealProof, ReplicaUpdateInfo, SealVerifyInfo,
+};
+use fvm_shared::sys::out::network::NetworkContext;
+use fvm_shared::sys::out::vm::MessageContext;
+use fvm_shared::{address::Address, econ::TokenAmount, ActorID, MethodNum};
+
+use ambassador::Delegate;
+use cid::Cid;
+
+// we define a single custom syscall which simply doubles the input
+pub trait CustomKernel: Kernel {
+    fn my_custom_syscall(&self, doubleme: i32) -> Result<i32>;
+}
+
+// our custom kernel extends the filecoin kernel
+#[derive(Delegate)]
+#[delegate(IpldBlockOps, where = "C: CallManager")]
+#[delegate(ActorOps, where = "C: CallManager")]
+#[delegate(CryptoOps, where = "C: CallManager")]
+#[delegate(DebugOps, where = "C: CallManager")]
+#[delegate(EventOps, where = "C: CallManager")]
+#[delegate(MessageOps, where = "C: CallManager")]
+#[delegate(NetworkOps, where = "C: CallManager")]
+#[delegate(RandomnessOps, where = "C: CallManager")]
+#[delegate(SelfOps, where = "C: CallManager")]
+#[delegate(SendOps<K>, generics = "K", where = "K: CustomKernel")]
+#[delegate(UpgradeOps<K>, generics = "K", where = "K: CustomKernel")]
+pub struct DefaultCustomKernel<C>(pub DefaultFilecoinKernel<C>);
+
+impl<C> CustomKernel for DefaultCustomKernel<C>
+where
+    C: CallManager,
+    DefaultCustomKernel<C>: Kernel,
+{
+    fn my_custom_syscall(&self, doubleme: i32) -> Result<i32> {
+        Ok(doubleme * 2)
+    }
+}
+
+impl<C> DefaultCustomKernel<C>
+where
+    C: CallManager,
+{
+    fn price_list(&self) -> &PriceList {
+        (self.0).0.call_manager.price_list()
+    }
+}
+
+impl<C> Kernel for DefaultCustomKernel<C>
+where
+    C: CallManager,
+{
+    type CallManager = C;
+    type Limiter = <DefaultFilecoinKernel<C> as Kernel>::Limiter;
+
+    fn into_inner(self) -> (Self::CallManager, BlockRegistry)
+    where
+        Self: Sized,
+    {
+        self.0.into_inner()
+    }
+
+    fn new(
+        mgr: C,
+        blocks: BlockRegistry,
+        caller: ActorID,
+        actor_id: ActorID,
+        method: MethodNum,
+        value_received: TokenAmount,
+        read_only: bool,
+    ) -> Self {
+        DefaultCustomKernel(DefaultFilecoinKernel::new(
+            mgr,
+            blocks,
+            caller,
+            actor_id,
+            method,
+            value_received,
+            read_only,
+        ))
+    }
+
+    fn machine(&self) -> &<Self::CallManager as CallManager>::Machine {
+        self.0.machine()
+    }
+
+    fn limiter_mut(&mut self) -> &mut Self::Limiter {
+        self.0.limiter_mut()
+    }
+
+    fn gas_available(&self) -> Gas {
+        self.0.gas_available()
+    }
+
+    fn charge_gas(&self, name: &str, compute: Gas) -> Result<GasTimer> {
+        self.0.charge_gas(name, compute)
+    }
+}
+
+impl<C> FilecoinKernel for DefaultCustomKernel<C>
+where
+    C: CallManager,
+{
+    fn compute_unsealed_sector_cid(
+        &self,
+        proof_type: RegisteredSealProof,
+        pieces: &[PieceInfo],
+    ) -> Result<Cid> {
+        self.0.compute_unsealed_sector_cid(proof_type, pieces)
+    }
+
+    fn verify_post(&self, verify_info: &fvm_shared::sector::WindowPoStVerifyInfo) -> Result<bool> {
+        self.0.verify_post(verify_info)
+    }
+
+    // NOT forwarded
+    fn batch_verify_seals(&self, vis: &[SealVerifyInfo]) -> Result<Vec<bool>> {
+        Ok(vec![true; vis.len()])
+    }
+
+    // NOT forwarded
+    fn verify_consensus_fault(
+        &self,
+        h1: &[u8],
+        h2: &[u8],
+        extra: &[u8],
+    ) -> Result<Option<ConsensusFault>> {
+        let charge = self
+            .price_list()
+            .on_verify_consensus_fault(h1.len(), h2.len(), extra.len());
+        let _ = self.charge_gas(&charge.name, charge.total())?;
+        Ok(None)
+    }
+
+    // NOT forwarded
+    fn verify_aggregate_seals(&self, agg: &AggregateSealVerifyProofAndInfos) -> Result<bool> {
+        let charge = self.price_list().on_verify_aggregate_seals(agg);
+        let _ = self.charge_gas(&charge.name, charge.total())?;
+        Ok(true)
+    }
+
+    // NOT forwarded
+    fn verify_replica_update(&self, rep: &ReplicaUpdateInfo) -> Result<bool> {
+        let charge = self.price_list().on_verify_replica_update(rep);
+        let _ = self.charge_gas(&charge.name, charge.total())?;
+        Ok(true)
+    }
+
+    fn total_fil_circ_supply(&self) -> Result<TokenAmount> {
+        self.0.total_fil_circ_supply()
+    }
+}
+
+impl<K> SyscallHandler<K> for DefaultCustomKernel<K::CallManager>
+where
+    K: CustomKernel
+        + FilecoinKernel
+        + ActorOps
+        + SendOps
+        + UpgradeOps
+        + IpldBlockOps
+        + CryptoOps
+        + DebugOps
+        + EventOps
+        + MessageOps
+        + NetworkOps
+        + RandomnessOps
+        + SelfOps,
+{
+    fn link_syscalls(linker: &mut Linker<K>) -> anyhow::Result<()> {
+        DefaultFilecoinKernel::<K::CallManager>::link_syscalls(linker)?;
+
+        linker.link_syscall("my_custom_kernel", "my_custom_syscall", my_custom_syscall)?;
+
+        Ok(())
+    }
+}
+
+pub fn my_custom_syscall(
+    context: fvm::syscalls::Context<'_, impl CustomKernel>,
+    doubleme: i32,
+) -> Result<i32> {
+    context.kernel.my_custom_syscall(doubleme)
+}

--- a/fendermint/vm/interpreter/src/fvm/examples/mycustomkernel.rs
+++ b/fendermint/vm/interpreter/src/fvm/examples/mycustomkernel.rs
@@ -21,7 +21,7 @@ use cid::Cid;
 
 // we define a single custom syscall which simply doubles the input
 pub trait CustomKernel: Kernel {
-    fn my_custom_syscall(&self, doubleme: i32) -> Result<i32>;
+    fn my_custom_syscall(&self) -> Result<u64>;
 }
 
 // our custom kernel extends the filecoin kernel
@@ -44,8 +44,17 @@ where
     C: CallManager,
     CustomKernelImpl<C>: Kernel,
 {
-    fn my_custom_syscall(&self, doubleme: i32) -> Result<i32> {
-        Ok(doubleme * 2)
+    fn my_custom_syscall(&self) -> Result<u64> {
+        // Here we have access to the Kernel structure and can call
+        // any of its methods, send messages, etc.
+
+        // We can also run an external program, link to any rust library
+        // access the network, etc.
+
+        // In this example, lets access the file system and return
+        // the number of paths in /
+        let paths = std::fs::read_dir("/").unwrap();
+        Ok(paths.count() as u64)
     }
 }
 
@@ -124,9 +133,6 @@ where
     }
 }
 
-pub fn my_custom_syscall(
-    context: fvm::syscalls::Context<'_, impl CustomKernel>,
-    doubleme: i32,
-) -> Result<i32> {
-    context.kernel.my_custom_syscall(doubleme)
+pub fn my_custom_syscall(context: fvm::syscalls::Context<'_, impl CustomKernel>) -> Result<u64> {
+    context.kernel.my_custom_syscall()
 }

--- a/fendermint/vm/interpreter/src/fvm/genesis.rs
+++ b/fendermint/vm/interpreter/src/fvm/genesis.rs
@@ -15,7 +15,8 @@ use fendermint_vm_actor_interface::diamond::{EthContract, EthContractMap};
 use fendermint_vm_actor_interface::eam::EthAddress;
 use fendermint_vm_actor_interface::ipc::IPC_CONTRACTS;
 use fendermint_vm_actor_interface::{
-    account, burntfunds, chainmetadata, cron, eam, init, ipc, reward, system, EMPTY_ARR,
+    account, burntfunds, chainmetadata, cron, customsyscall, eam, init, ipc, reward, system,
+    EMPTY_ARR,
 };
 use fendermint_vm_core::{chainid, Timestamp};
 use fendermint_vm_genesis::{ActorMeta, Genesis, Power, PowerScale, Validator};
@@ -246,6 +247,17 @@ where
                 None,
             )
             .context("failed to create chainmetadata actor")?;
+
+        // Initialize the customsyscall actor which gives an example of calling a custom syscall
+        state
+            .create_custom_actor(
+                fendermint_actor_customsyscall::CUSTOMSYSCALL_ACTOR_NAME,
+                customsyscall::CUSTOMSYSCALL_ACTOR_ID,
+                &EMPTY_ARR,
+                TokenAmount::zero(),
+                None,
+            )
+            .context("failed to create customsyscall actor")?;
 
         let eam_state = fendermint_actor_eam::State::new(
             state.store(),

--- a/fendermint/vm/interpreter/src/fvm/mod.rs
+++ b/fendermint/vm/interpreter/src/fvm/mod.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 mod broadcast;
 mod check;
 mod checkpoint;
+pub mod examples;
 mod exec;
 mod externs;
 mod genesis;

--- a/fendermint/vm/interpreter/src/fvm/state/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/exec.rs
@@ -12,7 +12,6 @@ use fvm::{
     executor::{ApplyFailure, ApplyKind, ApplyRet, DefaultExecutor, Executor},
     machine::{DefaultMachine, Machine, Manifest, NetworkConfig},
     state_tree::StateTree,
-    DefaultKernel,
 };
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
@@ -23,7 +22,7 @@ use fvm_shared::{
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use crate::fvm::externs::FendermintExterns;
+use crate::fvm::{examples::mycustomkernel::CustomKernelImpl, externs::FendermintExterns};
 use fendermint_vm_core::{chainid::HasChainID, Timestamp};
 use fendermint_vm_encoding::IsHumanReadable;
 
@@ -90,7 +89,7 @@ where
 {
     #[allow(clippy::type_complexity)]
     executor: DefaultExecutor<
-        DefaultKernel<DefaultCallManager<DefaultMachine<DB, FendermintExterns<DB>>>>,
+        CustomKernelImpl<DefaultCallManager<DefaultMachine<DB, FendermintExterns<DB>>>>,
     >,
 
     /// Hash of the block currently being executed. For queries and checks this is empty.


### PR DESCRIPTION
DO NOT MERGE

This is PR is part of a pluggable syscall tutorial which we will share later and contains the final source code after following the tutorial.

**Context**
This PR replaces the current Fendermint FVM kernel with a new custom kernel which implements a new syscall and shows how you can use this syscall from a new custom actor which we load at genesis.

More specifically, this PR:
- Implement a new `CustomKernelImpl FVM kernel which extends the default kernel.
- Implement a new syscall called `my_custom_syscall` on the new kernel
- Switches out the DefaultKernel used in Fendermint with this new custom kernel
- Creates a new `customsyscall` actor which demonstrates calling the new syscall
- Updates fendermint to load this new actor at genesis and run it at each epoch


**Test plan**
You can test this new kernel/syscall/actor by running one of our integration tests.

First you need to have docker installed, then compile a local docker image with this PR checked out:

```
cd fendermint
make docker-build
```
After the fendermint docker image has been built, you can run one of the integration tests

```
cd fendermint/testing/smoke-test
# creates the docker containers
cargo make setup
# runs the integration test
cargo make test
```

View fendermint logs and see the output generated by calling the `customsyscall` actor in each epoch:

```
docker ps
CONTAINER ID   IMAGE                       COMMAND
8da423d8bb1e   fendermint:latest           "fendermint --networ…"
...
```

View the docker logs:

```
docker logs 8da423d8bb1e
...
customsyscall actor returned: 21
```

You can now run `cargo make teardown` to stop the container. 