### PR TITLE
Upgrade to newest frc42_dispatch version after FVM upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3523,7 +3523,8 @@ dependencies = [
 [[package]]
 name = "frc42_dispatch"
 version = "6.0.0"
-source = "git+https://github.com/fridrik01/filecoin.git?branch=update-fvm-4.1#5589e45464e78264710f65a9900b4b9ad1f45781"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a1704e27193af21e58435974ff20f2be25cc59338afb89920abdb540ad3182b"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
@@ -3536,7 +3537,8 @@ dependencies = [
 [[package]]
 name = "frc42_hasher"
 version = "4.0.0"
-source = "git+https://github.com/fridrik01/filecoin.git?branch=update-fvm-4.1#5589e45464e78264710f65a9900b4b9ad1f45781"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63f58bb50d36d90f5d0fee8391d6e1ed1a2b15ab8da6417dc42d7c78b587479d"
 dependencies = [
  "fvm_sdk",
  "fvm_shared",
@@ -3546,7 +3548,8 @@ dependencies = [
 [[package]]
 name = "frc42_macros"
 version = "4.0.0"
-source = "git+https://github.com/fridrik01/filecoin.git?branch=update-fvm-4.1#5589e45464e78264710f65a9900b4b9ad1f45781"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9ce38a981bab5e0d3c0835baa86f83066afe9afaf0aec23cee421f6d8c628e"
 dependencies = [
  "blake2b_simd",
  "frc42_hasher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,16 +184,12 @@ fvm_ipld_amt = "0.6.2"
 fil_actors_evm_shared = { git = "https://github.com/filecoin-project/builtin-actors", tag = "v12.0.0" }
 fil_actors_runtime = { git = "https://github.com/filecoin-project/builtin-actors", tag = "v12.0.0" }
 
-# Using 0.8 because of ref-fvm.
-# 0.9 would be better because of its updated quickcheck dependency.
-# 0.10 breaks some API.
 cid = { version = "0.10.1", default-features = false, features = [
   "serde-codec",
   "std",
 ] }
 
-# We need a version of frc42_dispatch that has been updated to use FVM 4.1
-frc42_dispatch = { git = "https://github.com/fridrik01/filecoin.git", branch = "update-fvm-4.1" }
+frc42_dispatch = "6.0.0"
 
 # Using the same tendermint-rs dependency as tower-abci. From both we are interested in v037 modules.
 tower-abci = { version = "0.7" }


### PR DESCRIPTION
We had to temporarily use a fork to unblock migrating to  FVM 4.1 but a new version has now been released