### PR TITLE
fix: always compiling fendermint  due to missed directives in build.rs

### DIFF
--- a/fendermint/actors/build.rs
+++ b/fendermint/actors/build.rs
@@ -10,7 +10,7 @@ use std::thread;
 
 const ACTORS: &[&str] = &["chainmetadata"];
 
-const FILES_TO_WATCH: &[&str] = &["Cargo.toml", "src", "actors"];
+const FILES_TO_WATCH: &[&str] = &["Cargo.toml", "src"];
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Cargo executable location.
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         Path::new(&std::env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR unset"))
             .join("Cargo.toml");
 
-    for file in FILES_TO_WATCH {
+    for file in [FILES_TO_WATCH, ACTORS].concat() {
         println!("cargo:rerun-if-changed={}", file);
     }
 


### PR DESCRIPTION
See https://github.com/consensus-shipyard/ipc/issues/643

Issue raised on [slack](https://filecoinproject.slack.com/archives/C04JR5R1UL8/p1706616819780489?thread_ts=1704813449.258009&cid=C04JR5R1UL8)


Before this PR, running the following command took 15-20 seconds as fendermint binary was created every time it ran even though no code changed:

```
cargo run --bin fendermint -- -help
```

Now it should take <1second