### PR TITLE
Remove short names from all ipc-cli commands

### DIFF
--- a/docs/ipc/quickstart-calibration.md
+++ b/docs/ipc/quickstart-calibration.md
@@ -58,14 +58,14 @@ You'll need to create a set of wallets to spawn and interact of the subnet. Plea
 
 * Create the three different wallets
 ```bash
-ipc-cli wallet new -w evm
-ipc-cli wallet new -w evm
-ipc-cli wallet new -w evm
+ipc-cli wallet new -wallet-type evm
+ipc-cli wallet new -wallet-type evm
+ipc-cli wallet new -wallet-type evm
 ```
 
 * You can optionally set one of the wallets as your default so you don't have to use the `--from` flag explicitly in some of the commands:
 ```bash
-ipc-cli wallet set-default --address <DEFAULT_ETH_ADDR> -w evm
+ipc-cli wallet set-default --address <DEFAULT_ETH_ADDR> -wallet-type evm
 ```
 
 <!-- * Convert the 0x addresses to f4 addresses for later usage (OWNER_1_F4, OWNER_2_F4, and OWNER_3_F4)  -->
@@ -99,9 +99,9 @@ Before we deploy the infrastructure for the subnet, we will have to bootstrap th
 
 * Get the public key for all of your wallets and note it down. This is the public key that each of your validators will use to sign blocks in the subnet.
 ```bash
-ipc-cli wallet pub-key -w evm --address <WALLET_ADDR1>
-ipc-cli wallet pub-key -w evm --address <WALLET_ADDR2>
-ipc-cli wallet pub-key -w evm --address <WALLET_ADDR3>
+ipc-cli wallet pub-key -wallet-type evm --address <WALLET_ADDR1>
+ipc-cli wallet pub-key -wallet-type evm --address <WALLET_ADDR2>
+ipc-cli wallet pub-key -wallet-type evm --address <WALLET_ADDR3>
 ```
 
 * Join the subnet with each validator
@@ -190,9 +190,9 @@ With the bootstrap node deployed and advertised to the network, we are now ready
 * First we need to export the private keys of our validators from the addresses that we created with our `ipc-cli wallet` to a known path so they can be picked by Fendermint to sign blocks. We can use the default repo of IPC for this, `~/.ipc`. We'll later refer to the private key paths as `<PATH_PRIV_KEY_VALIDATOR_n>`.
 
 ```bash
-ipc-cli wallet export -w evm -a <WALLET_ADDR1> --hex -o ~/.ipc/validator_1.sk
-ipc-cli wallet export -w evm -a <WALLET_ADDR2> --hex -o ~/.ipc/validator_2.sk
-ipc-cli wallet export -w evm -a <WALLET_ADDR3> --hex -o ~/.ipc/validator_3.sk
+ipc-cli wallet export --wallet-type evm --address <WALLET_ADDR1> --hex > ~/.ipc/validator_1.sk
+ipc-cli wallet export --wallet-type evm --address <WALLET_ADDR2> --hex > ~/.ipc/validator_2.sk
+ipc-cli wallet export --wallet-type evm --address <WALLET_ADDR3> --hex > ~/.ipc/validator_3.sk
 ```
 
 * Now we have all that we need to deploy the three validators using the following command (configured for each of the validators, i.e. replace the arguments with `<..-n>` to fit that of the specific validator).
@@ -219,13 +219,13 @@ With this, we have everything in place, and our subnet should start automaticall
 ## Step 7: Configure your subnet in the IPC CLI
 
 * Edit the `ipc-cli` configuration `config.toml`
-  
+
 ```bash
 nano ~/.ipc/config.toml
 ```
 
 * Append the new subnet to the configuration
-  
+
 ```toml
 [[subnets]]
 id = <SUBNET_ID>    ## i.e. "/r314159/..."
@@ -239,7 +239,7 @@ registry_addr = "0x74539671a1d2f1c8f200826baba665179f53a1b7"
 
 With this you should be able to start interacting with your local subnet directly through your `ipc-cli`. You can try to fetch the balances of your wallets through the following command. The result should show the initial balance that you have included for your validators address in genesis:
 ```bash
-ipc-cli wallet balances -w evm --subnet=<SUBNET_ID>
+ipc-cli wallet balances --wallet-type evm --subnet=<SUBNET_ID>
 ```
 
 > The ETH addresses for `gateway_addr` and `registry_addr` used when they are deployed in genesis in a child subnet by Fendermint are `0x77aa40b105843728088c0132e43fc44348881da8` and `0x74539671a1d2f1c8f200826baba665179f53a1b7`, respectively.

--- a/docs/ipc/quickstart-calibration.md
+++ b/docs/ipc/quickstart-calibration.md
@@ -58,14 +58,14 @@ You'll need to create a set of wallets to spawn and interact of the subnet. Plea
 
 * Create the three different wallets
 ```bash
-ipc-cli wallet new -wallet-type evm
-ipc-cli wallet new -wallet-type evm
-ipc-cli wallet new -wallet-type evm
+ipc-cli wallet new --wallet-type evm
+ipc-cli wallet new --wallet-type evm
+ipc-cli wallet new --wallet-type evm
 ```
 
 * You can optionally set one of the wallets as your default so you don't have to use the `--from` flag explicitly in some of the commands:
 ```bash
-ipc-cli wallet set-default --address <DEFAULT_ETH_ADDR> -wallet-type evm
+ipc-cli wallet set-default --address <DEFAULT_ETH_ADDR> --wallet-type evm
 ```
 
 <!-- * Convert the 0x addresses to f4 addresses for later usage (OWNER_1_F4, OWNER_2_F4, and OWNER_3_F4)  -->
@@ -77,7 +77,7 @@ ipc-cli wallet set-default --address <DEFAULT_ETH_ADDR> -wallet-type evm
 
 * Go to the [Calibration faucet](https://faucet.calibration.fildev.network/) and get some funds sent to each of your addresses
 
->💡 In case you'd like to import an EVM account into Metamask, you can use export the private key using `ipc-cli wallet export -w evm -a <ADDRESS>`. More information is available in the [EVM IPC agent support docs](./usage.md#key-management).
+>💡 In case you'd like to import an EVM account into Metamask, you can use export the private key using `ipc-cli wallet export --wallet-type evm --address <ADDRESS>`. More information is available in the [EVM IPC agent support docs](./usage.md#key-management).
 
 >💡 Note that you may hit faucet rate limits. In that case, wait a few minutes or continue with the guide and come back to this before step 9. Alternatively, you can send funds from your primary wallet to your owner wallets.
 
@@ -99,9 +99,9 @@ Before we deploy the infrastructure for the subnet, we will have to bootstrap th
 
 * Get the public key for all of your wallets and note it down. This is the public key that each of your validators will use to sign blocks in the subnet.
 ```bash
-ipc-cli wallet pub-key -wallet-type evm --address <WALLET_ADDR1>
-ipc-cli wallet pub-key -wallet-type evm --address <WALLET_ADDR2>
-ipc-cli wallet pub-key -wallet-type evm --address <WALLET_ADDR3>
+ipc-cli wallet pub-key --wallet-type evm --address <WALLET_ADDR1>
+ipc-cli wallet pub-key --wallet-type evm --address <WALLET_ADDR2>
+ipc-cli wallet pub-key --wallet-type evm --address <WALLET_ADDR3>
 ```
 
 * Join the subnet with each validator

--- a/docs/ipc/usage.md
+++ b/docs/ipc/usage.md
@@ -6,41 +6,41 @@
 The `ipc-cli` has internally an EVM wallet that it uses to sign transactions and interact with IPC on behalf of specific addresses. Some of the features available for EVM addresses through the EVM are:
 * Creating new Ethereum addresses
 ```bash
-./bin/ipc-cli wallet new -w evm
+./bin/ipc-cli wallet new --wallet-type evm
 ```
 ```console
 # Sample execution
-./bin/ipc-cli wallet new -w evm
+./bin/ipc-cli wallet new --wallet-type evm
 "0x406a7a1d002b71ece175cc7e067620ae5b58e9ec"
 ```
 
 * Exporting a key stored in the IPC cli keystore.
 ```bash
-./bin/ipc-cli wallet export -w evm -a <EVM-ADDRESS> -o <OUTPUT_FILE>
+./bin/ipc-cli wallet export --wallet-type evm --address <EVM-ADDRESS> > <OUTPUT_FILE>
 ```
 ```console
 # Sample execution
-./bin/ipc-cli wallet export -w evm -a 0x406a7a1d002b71ece175cc7e067620ae5b58e9ec -o /tmp/priv.key
+./bin/ipc-cli wallet export --wallet-type evm --address 0x406a7a1d002b71ece175cc7e067620ae5b58e9ec -o /tmp/priv.key
 exported new wallet with address 0x406a7a1d002b71ece175cc7e067620ae5b58e9ec in file "/tmp/priv.key"
 ```
 
 * You can also export your private key encoded in base64 in a format that can be consumed by Fendermint by adding the `--fendermint` flag.
 ```bash
-./bin/ipc-cli wallet export -w evm -a <EVM-ADDRESS> -o <OUTPUT_FILE> --fendermint
+./bin/ipc-cli wallet export --wallet-type evm --address <EVM-ADDRESS>  --fendermint > <OUTPUT_FILE>
 ```
 
 * Or hex encoded as expected by Ethereum tooling (like Metamask or hardhat).
 ```bash
-./bin/ipc-cli wallet export -w evm -a <EVM-ADDRESS> -o <OUTPUT_FILE> --hex
+./bin/ipc-cli wallet export --wallet-type evm --address <EVM-ADDRESS> -o <OUTPUT_FILE> --hex
 ```
 
 * Importing a key from a file
 ```bash
-./bin/ipc-cli wallet import -w evm --path=<INPUT_FILE_WITH_KEY>
+./bin/ipc-cli wallet import --wallet-type evm --path=<INPUT_FILE_WITH_KEY>
 ```
 ```console
 # Sample execution
-$ ./bin/ipc-cli wallet import -w evm --path=~/tmp/wallet.key
+$ ./bin/ipc-cli wallet import --wallet-type evm --path=~/tmp/wallet.key
 imported wallet with address "0x406a7a1d002b71ece175cc7e067620ae5b58e9ec"
 ```
 
@@ -52,27 +52,27 @@ imported wallet with address "0x406a7a1d002b71ece175cc7e067620ae5b58e9ec"
 
 * Importing an identity directly from its private key
 ```bash
-./bin/ipc-cli wallet import -w evm --private-key <PRIVATE_KEY>
+./bin/ipc-cli wallet import --wallet-type evm --private-key <PRIVATE_KEY>
 ```
 ```console
 # Sample execution
-$ ./bin/ipc-cli wallet import -w evm --private-key=0x405f50458008edd6e2eb2efc3bf34846db1d6689b89fe1a9f9ccfe7f6e301d8d
+$ ./bin/ipc-cli wallet import --wallet-type evm --private-key=0x405f50458008edd6e2eb2efc3bf34846db1d6689b89fe1a9f9ccfe7f6e301d8d
 imported wallet with address "0x406a7a1d002b71ece175cc7e067620ae5b58e9ec"
 ```
 
 * You can set a default key for your wallet so it is always the one used when the `--from` flag is not explicitly set
 ```bash
-./bin/ipc-cli wallet set-default --address <EVM-ADDRESS> -w evm
+./bin/ipc-cli wallet set-default --address <EVM-ADDRESS> --wallet-type evm
 ```
 
 * And check what is your current default key:
 ```bash
-./bin/ipc-cli wallet get-default -w evm
+./bin/ipc-cli wallet get-default --wallet-type evm
 ```
 
 * Check the hex encoded public key of your address with:
 ```bash
-./bin/ipc-cli wallet pub-key -w evm --address=<EVM-address>
+./bin/ipc-cli wallet pub-key --wallet-type evm --address=<EVM-address>
 ```
 
 ## Listing active subnets
@@ -121,7 +121,7 @@ $ ./bin/ipc-cli subnet stake --subnet=/r314159/t410fh4ywg4wvxcjzz4vsja3uh4f53joh
 ## Listing your balance in a subnet
 In order to send messages in a subnet, you'll need to have funds in your subnt account. You can use the following command to list the balance of your wallets in a subnet:
 ```bash
-./bin/ipc-cli wallet balances -w evm --subnet <subnet-id>
+./bin/ipc-cli wallet balances --wallet-type evm --subnet <subnet-id>
 ```
 ```console
 # Example execution
@@ -247,7 +247,7 @@ IPC relies on the role of a specific type of peer on the network called the rela
 ```bash
 ./bin/ipc-cli checkpoint relayer --subnet <SUBNET_ID>
 ```
-* In order to run the relayer from a different address you can use the `--submitted` flag: 
+* In order to run the relayer from a different address you can use the `--submitted` flag:
 ```bash
 ./bin/ipc-cli checkpoint relayer --subnet <SUBNET_ID> --submitter <RELAYER_ADDR>
 ```
@@ -259,7 +259,7 @@ Relayers are rewarded through cross-net messages fees for the timely submission 
 
 ## Listing checkpoints from a subnet
 
-Subnets are periodically committing checkpoints to their parent every `bottomup-check-period` (parameter defined when creating the subnet). If you want to inspect the information of a range of bottom-up checkpoints committed in the parent for a subnet, you can use the `checkpoint list-bottomup` command provided by the agent as follows: 
+Subnets are periodically committing checkpoints to their parent every `bottomup-check-period` (parameter defined when creating the subnet). If you want to inspect the information of a range of bottom-up checkpoints committed in the parent for a subnet, you can use the `checkpoint list-bottomup` command provided by the agent as follows:
 ```bash
 ./bin/ipc-cli checkpoint list-bottomup --from-epoch <range-start> --to-epoch <range-end> --subnet <subnet-id>
 ```
@@ -316,7 +316,7 @@ Leaving a subnet will release the collateral for the validator and remove all th
 $ ./bin/ipc-cli subnet stake --subnet=/r314159/t410fh4ywg4wvxcjzz4vsja3uh4f53johc2lf5bpjo6i --collateral=1
 ```
 
-> 💡 Remember, as described in the joining and leaving collateral section, that changes to the validator set and their collateral are not reflected immediately. Validator changes between two epochs can be inspected through: 
+> 💡 Remember, as described in the joining and leaving collateral section, that changes to the validator set and their collateral are not reflected immediately. Validator changes between two epochs can be inspected through:
 > ```bash
 > ./bin/ipc-cli checkpoint list-validator-changes --from-epoch=<START_EPOCH> --to-epoch=<END_EPOCH>
 > ```

--- a/ipc/cli/src/commands/checkpoint/bottomup_bundles.rs
+++ b/ipc/cli/src/commands/checkpoint/bottomup_bundles.rs
@@ -42,10 +42,10 @@ impl CommandLineHandler for GetBottomUpBundles {
 #[derive(Debug, Args)]
 #[command(about = "List bottom up checkpoint signature bundle for a child subnet")]
 pub(crate) struct GetBottomUpBundlesArgs {
-    #[arg(long, short, help = "The target subnet to perform query")]
+    #[arg(long, help = "The target subnet to perform query")]
     pub subnet: String,
-    #[arg(long, short, help = "Include checkpoints from this epoch")]
+    #[arg(long, help = "Include checkpoints from this epoch")]
     pub from_epoch: ChainEpoch,
-    #[arg(long, short, help = "Include checkpoints up to this epoch")]
+    #[arg(long, help = "Include checkpoints up to this epoch")]
     pub to_epoch: ChainEpoch,
 }

--- a/ipc/cli/src/commands/checkpoint/bottomup_height.rs
+++ b/ipc/cli/src/commands/checkpoint/bottomup_height.rs
@@ -37,6 +37,6 @@ impl CommandLineHandler for LastBottomUpCheckpointHeight {
 #[derive(Debug, Args)]
 #[command(about = "Last bottom up checkpoint height committed for a child subnet in the parent")]
 pub(crate) struct LastBottomUpCheckpointHeightArgs {
-    #[arg(long, short, help = "The target subnet to perform query")]
+    #[arg(long, help = "The target subnet to perform query")]
     pub subnet: String,
 }

--- a/ipc/cli/src/commands/checkpoint/list_checkpoints.rs
+++ b/ipc/cli/src/commands/checkpoint/list_checkpoints.rs
@@ -26,10 +26,10 @@ impl CommandLineHandler for ListBottomUpCheckpoints {
 #[derive(Debug, Args)]
 #[command(about = "List bottom-up checkpoints")]
 pub(crate) struct ListBottomUpCheckpointsArgs {
-    #[arg(long, short, help = "The subnet id of the checkpointing subnet")]
+    #[arg(long, help = "The subnet id of the checkpointing subnet")]
     pub subnet: String,
-    #[arg(long, short, help = "Include checkpoints from this epoch")]
+    #[arg(long, help = "Include checkpoints from this epoch")]
     pub from_epoch: ChainEpoch,
-    #[arg(long, short, help = "Include checkpoints up to this epoch")]
+    #[arg(long, help = "Include checkpoints up to this epoch")]
     pub to_epoch: ChainEpoch,
 }

--- a/ipc/cli/src/commands/checkpoint/list_validator_changes.rs
+++ b/ipc/cli/src/commands/checkpoint/list_validator_changes.rs
@@ -38,10 +38,10 @@ impl CommandLineHandler for ListValidatorChanges {
 #[derive(Debug, Args)]
 #[command(about = "List of validator changes commmitted for a child subnet")]
 pub(crate) struct ListValidatorChangesArgs {
-    #[arg(long, short, help = "Lists the validator changes between two epochs")]
+    #[arg(long, help = "Lists the validator changes between two epochs")]
     pub subnet: String,
-    #[arg(long, short, help = "Include checkpoints from this epoch")]
+    #[arg(long, help = "Include checkpoints from this epoch")]
     pub from_epoch: ChainEpoch,
-    #[arg(long, short, help = "Include checkpoints up to this epoch")]
+    #[arg(long, help = "Include checkpoints up to this epoch")]
     pub to_epoch: ChainEpoch,
 }

--- a/ipc/cli/src/commands/checkpoint/quorum_reached.rs
+++ b/ipc/cli/src/commands/checkpoint/quorum_reached.rs
@@ -40,10 +40,10 @@ impl CommandLineHandler for GetQuorumReacehdEvents {
 #[derive(Debug, Args)]
 #[command(about = "List quorum reached events for a child subnet")]
 pub(crate) struct GetQuorumReachedEventsArgs {
-    #[arg(long, short, help = "The target subnet to perform query")]
+    #[arg(long, help = "The target subnet to perform query")]
     pub subnet: String,
-    #[arg(long, short, help = "Include events from this epoch")]
+    #[arg(long, help = "Include events from this epoch")]
     pub from_epoch: ChainEpoch,
-    #[arg(long, short, help = "Include events up to this epoch")]
+    #[arg(long, help = "Include events up to this epoch")]
     pub to_epoch: ChainEpoch,
 }

--- a/ipc/cli/src/commands/checkpoint/relayer.rs
+++ b/ipc/cli/src/commands/checkpoint/relayer.rs
@@ -76,17 +76,16 @@ impl CommandLineHandler for BottomUpRelayer {
 #[derive(Debug, Args)]
 #[command(about = "Start the bottom up relayer daemon")]
 pub(crate) struct BottomUpRelayerArgs {
-    #[arg(long, short, help = "The subnet id of the checkpointing subnet")]
+    #[arg(long, help = "The subnet id of the checkpointing subnet")]
     pub subnet: String,
-    #[arg(long, short, help = "The number of seconds to submit checkpoint")]
+    #[arg(long, help = "The number of seconds to submit checkpoint")]
     pub checkpoint_interval_sec: Option<u64>,
     #[arg(
         long,
-        short,
         default_value = "0",
         help = "The number of blocks away from chain head that is considered final"
     )]
     pub finalization_blocks: Option<u64>,
-    #[arg(long, short, help = "The hex encoded address of the submitter")]
+    #[arg(long, help = "The hex encoded address of the submitter")]
     pub submitter: Option<String>,
 }

--- a/ipc/cli/src/commands/crossmsg/fund.rs
+++ b/ipc/cli/src/commands/crossmsg/fund.rs
@@ -57,17 +57,16 @@ impl CommandLineHandler for Fund {
 #[derive(Debug, Args)]
 #[command(about = "Send funds from a parent to a child subnet")]
 pub(crate) struct FundArgs {
-    #[arg(long, short, help = "The gateway address of the subnet")]
+    #[arg(long, help = "The gateway address of the subnet")]
     pub gateway_address: Option<String>,
-    #[arg(long, short, help = "The address to send funds from")]
+    #[arg(long, help = "The address to send funds from")]
     pub from: Option<String>,
     #[arg(
         long,
-        short,
         help = "The address to send funds to (if not set, amount sent to from address)"
     )]
     pub to: Option<String>,
-    #[arg(long, short, help = "The subnet to fund")]
+    #[arg(long, help = "The subnet to fund")]
     pub subnet: String,
     #[arg(help = "The amount to fund in FIL, in whole FIL")]
     pub amount: f64,
@@ -107,9 +106,9 @@ impl CommandLineHandler for PreFund {
     about = "Add some funds in genesis to an address in a child-subnet"
 )]
 pub struct PreFundArgs {
-    #[arg(long, short, help = "The address funded in the subnet")]
+    #[arg(long, help = "The address funded in the subnet")]
     pub from: Option<String>,
-    #[arg(long, short, help = "The subnet to add balance to")]
+    #[arg(long, help = "The subnet to add balance to")]
     pub subnet: String,
     #[arg(help = "Add an initial balance for the address in genesis in the subnet")]
     pub initial_balance: f64,
@@ -150,15 +149,14 @@ impl CommandLineHandler for FundWithToken {
 #[derive(Debug, Args)]
 #[command(about = "Send erc20 tokens from a parent to a child subnet")]
 pub(crate) struct FundWithTokenArgs {
-    #[arg(long, short, help = "The address to send funds from")]
+    #[arg(long, help = "The address to send funds from")]
     pub from: Option<String>,
     #[arg(
         long,
-        short,
         help = "The address to send funds to (if not set, amount sent to from address)"
     )]
     pub to: Option<String>,
-    #[arg(long, short, help = "The subnet to fund")]
+    #[arg(long, help = "The subnet to fund")]
     pub subnet: String,
     #[arg(help = "The amount to fund in erc20, in ether, supports up to 9 decimal places")]
     pub amount: f64,

--- a/ipc/cli/src/commands/crossmsg/propagate.rs
+++ b/ipc/cli/src/commands/crossmsg/propagate.rs
@@ -23,11 +23,11 @@ impl CommandLineHandler for Propagate {
 #[derive(Debug, Args)]
 #[command(about = "Propagate operation in the gateway actor")]
 pub(crate) struct PropagateArgs {
-    #[arg(long, short, help = "The JSON RPC server url for ipc agent")]
+    #[arg(long, help = "The JSON RPC server url for ipc agent")]
     pub ipc_agent_url: Option<String>,
-    #[arg(long, short, help = "The address that pays for the propagation gas")]
+    #[arg(long, help = "The address that pays for the propagation gas")]
     pub from: Option<String>,
-    #[arg(long, short, help = "The subnet of the message to propagate")]
+    #[arg(long, help = "The subnet of the message to propagate")]
     pub subnet: String,
     #[arg(help = "The message cid to propagate")]
     pub postbox_msg_key: String,

--- a/ipc/cli/src/commands/crossmsg/release.rs
+++ b/ipc/cli/src/commands/crossmsg/release.rs
@@ -57,17 +57,16 @@ impl CommandLineHandler for Release {
 #[derive(Debug, Args)]
 #[command(about = "Release operation in the gateway actor")]
 pub(crate) struct ReleaseArgs {
-    #[arg(long, short, help = "The gateway address of the subnet")]
+    #[arg(long, help = "The gateway address of the subnet")]
     pub gateway_address: Option<String>,
-    #[arg(long, short, help = "The address that releases funds")]
+    #[arg(long, help = "The address that releases funds")]
     pub from: Option<String>,
     #[arg(
         long,
-        short,
         help = "The address to release funds to (if not set, amount sent to from address)"
     )]
     pub to: Option<String>,
-    #[arg(long, short, help = "The subnet to release funds from")]
+    #[arg(long, help = "The subnet to release funds from")]
     pub subnet: String,
     #[arg(help = "The amount to release in FIL, in whole FIL")]
     pub amount: f64,
@@ -103,9 +102,9 @@ impl CommandLineHandler for PreRelease {
     about = "Release some funds from the genesis balance of the child subnet"
 )]
 pub struct PreReleaseArgs {
-    #[arg(long, short, help = "The address funded in the subnet")]
+    #[arg(long, help = "The address funded in the subnet")]
     pub from: Option<String>,
-    #[arg(long, short, help = "The subnet to release balance from")]
+    #[arg(long, help = "The subnet to release balance from")]
     pub subnet: String,
     #[arg(help = "Amount to release from the genesis balance of a child subnet")]
     pub amount: f64,

--- a/ipc/cli/src/commands/crossmsg/topdown_cross.rs
+++ b/ipc/cli/src/commands/crossmsg/topdown_cross.rs
@@ -52,15 +52,11 @@ impl CommandLineHandler for ListTopdownMsgs {
 #[derive(Debug, Args)]
 #[command(about = "List topdown cross messages for a specific epoch")]
 pub(crate) struct ListTopdownMsgsArgs {
-    #[arg(long, short, help = "The subnet id of the topdown subnet")]
+    #[arg(long, help = "The subnet id of the topdown subnet")]
     pub subnet: String,
-    #[arg(
-        long,
-        short,
-        help = "Include topdown messages starting from this epoch"
-    )]
+    #[arg(long, help = "Include topdown messages starting from this epoch")]
     pub from: ChainEpoch,
-    #[arg(long, short, help = "Include topdown messages to this epoch")]
+    #[arg(long, help = "Include topdown messages to this epoch")]
     pub to: ChainEpoch,
 }
 
@@ -84,6 +80,6 @@ impl CommandLineHandler for LatestParentFinality {
 #[derive(Debug, Args)]
 #[command(about = "Latest height of parent finality committed in child subnet")]
 pub(crate) struct LatestParentFinalityArgs {
-    #[arg(long, short, help = "The subnet id to check parent finality")]
+    #[arg(long, help = "The subnet id to check parent finality")]
     pub subnet: String,
 }

--- a/ipc/cli/src/commands/subnet/bootstrap.rs
+++ b/ipc/cli/src/commands/subnet/bootstrap.rs
@@ -35,15 +35,11 @@ impl CommandLineHandler for AddBootstrap {
 #[derive(Debug, Args)]
 #[command(name = "add-bootstrap", about = "Advertise bootstrap in the subnet")]
 pub struct AddBootstrapArgs {
-    #[arg(
-        long,
-        short,
-        help = "The address of the validator adding the bootstrap"
-    )]
+    #[arg(long, help = "The address of the validator adding the bootstrap")]
     pub from: Option<String>,
-    #[arg(long, short, help = "The subnet to add the bootstrap to")]
+    #[arg(long, help = "The subnet to add the bootstrap to")]
     pub subnet: String,
-    #[arg(long, short, help = "The bootstrap node's network endpoint")]
+    #[arg(long, help = "The bootstrap node's network endpoint")]
     pub endpoint: String,
 }
 
@@ -78,6 +74,6 @@ impl CommandLineHandler for ListBootstraps {
 #[derive(Debug, Args)]
 #[command(name = "list-bootstraps", about = "List bootstraps in the subnet")]
 pub struct ListBootstrapsArgs {
-    #[arg(long, short, help = "The subnet to list bootstraps from")]
+    #[arg(long, help = "The subnet to list bootstraps from")]
     pub subnet: String,
 }

--- a/ipc/cli/src/commands/subnet/create.rs
+++ b/ipc/cli/src/commands/subnet/create.rs
@@ -84,13 +84,12 @@ impl CommandLineHandler for CreateSubnet {
 #[derive(Debug, Args)]
 #[command(name = "create", about = "Create a new subnet actor")]
 pub struct CreateSubnetArgs {
-    #[arg(long, short, help = "The address that creates the subnet")]
+    #[arg(long, help = "The address that creates the subnet")]
     pub from: Option<String>,
-    #[arg(long, short, help = "The parent subnet to create the new actor in")]
+    #[arg(long, help = "The parent subnet to create the new actor in")]
     pub parent: String,
     #[arg(
         long,
-        short,
         help = "The minimum number of collateral required for validators"
     )]
     pub min_validator_stake: f64,
@@ -105,7 +104,6 @@ pub struct CreateSubnetArgs {
     pub active_validators_limit: Option<u16>,
     #[arg(
         long,
-        short,
         default_value = "0.000001",
         help = "Minimum fee for cross-net messages in subnet (in whole FIL)"
     )]

--- a/ipc/cli/src/commands/subnet/genesis_epoch.rs
+++ b/ipc/cli/src/commands/subnet/genesis_epoch.rs
@@ -33,6 +33,6 @@ impl CommandLineHandler for GenesisEpoch {
 #[derive(Debug, Args)]
 #[command(name = "genesis-epoch", about = "Get the genesis epoch of subnet")]
 pub(crate) struct GenesisEpochArgs {
-    #[arg(long, short, help = "The subnet id to query genesis epoch")]
+    #[arg(long, help = "The subnet id to query genesis epoch")]
     pub subnet: String,
 }

--- a/ipc/cli/src/commands/subnet/join.rs
+++ b/ipc/cli/src/commands/subnet/join.rs
@@ -52,17 +52,16 @@ impl CommandLineHandler for JoinSubnet {
 #[derive(Debug, Args)]
 #[command(name = "join", about = "Join a subnet")]
 pub struct JoinSubnetArgs {
-    #[arg(long, short, help = "The address that joins the subnet")]
+    #[arg(long, help = "The address that joins the subnet")]
     pub from: Option<String>,
-    #[arg(long, short, help = "The subnet to join")]
+    #[arg(long, help = "The subnet to join")]
     pub subnet: String,
     #[arg(
         long,
-        short,
         help = "The collateral to stake in the subnet (in whole FIL units)"
     )]
     pub collateral: f64,
-    #[arg(long, short, help = "The validator's metadata, hex encoded")]
+    #[arg(long, help = "The validator's metadata, hex encoded")]
     pub public_key: String,
     #[arg(
         long,
@@ -96,13 +95,12 @@ impl CommandLineHandler for StakeSubnet {
 #[derive(Debug, Args)]
 #[command(name = "stake", about = "Add collateral to an already joined subnet")]
 pub struct StakeSubnetArgs {
-    #[arg(long, short, help = "The address that stakes in the subnet")]
+    #[arg(long, help = "The address that stakes in the subnet")]
     pub from: Option<String>,
-    #[arg(long, short, help = "The subnet to add collateral to")]
+    #[arg(long, help = "The subnet to add collateral to")]
     pub subnet: String,
     #[arg(
         long,
-        short,
         help = "The collateral to stake in the subnet (in whole FIL units)"
     )]
     pub collateral: f64,
@@ -136,13 +134,12 @@ impl CommandLineHandler for UnstakeSubnet {
     about = "Remove collateral to an already joined subnet"
 )]
 pub struct UnstakeSubnetArgs {
-    #[arg(long, short, help = "The address that unstakes in the subnet")]
+    #[arg(long, help = "The address that unstakes in the subnet")]
     pub from: Option<String>,
-    #[arg(long, short, help = "The subnet to release collateral from")]
+    #[arg(long, help = "The subnet to release collateral from")]
     pub subnet: String,
     #[arg(
         long,
-        short,
         help = "The collateral to unstake from the subnet (in whole FIL units)"
     )]
     pub collateral: f64,

--- a/ipc/cli/src/commands/subnet/kill.rs
+++ b/ipc/cli/src/commands/subnet/kill.rs
@@ -33,8 +33,8 @@ impl CommandLineHandler for KillSubnet {
 #[derive(Debug, Args)]
 #[command(name = "kill", about = "Kill an existing subnet")]
 pub struct KillSubnetArgs {
-    #[arg(long, short, help = "The address that kills the subnet")]
+    #[arg(long, help = "The address that kills the subnet")]
     pub from: Option<String>,
-    #[arg(long, short, help = "The subnet to kill")]
+    #[arg(long, help = "The subnet to kill")]
     pub subnet: String,
 }

--- a/ipc/cli/src/commands/subnet/leave.rs
+++ b/ipc/cli/src/commands/subnet/leave.rs
@@ -32,9 +32,9 @@ impl CommandLineHandler for LeaveSubnet {
 #[derive(Debug, Args)]
 #[command(name = "leave", about = "Leaving a subnet")]
 pub struct LeaveSubnetArgs {
-    #[arg(long, short, help = "The address that leaves the subnet")]
+    #[arg(long, help = "The address that leaves the subnet")]
     pub from: Option<String>,
-    #[arg(long, short, help = "The subnet to leave")]
+    #[arg(long, help = "The subnet to leave")]
     pub subnet: String,
 }
 
@@ -64,13 +64,12 @@ impl CommandLineHandler for Claim {
     about = "Claim collateral or rewards available for validators and relayers, respectively"
 )]
 pub struct ClaimArgs {
-    #[arg(long, short, help = "The address that claims the collateral")]
+    #[arg(long, help = "The address that claims the collateral")]
     pub from: Option<String>,
-    #[arg(long, short, help = "The subnet to claim from")]
+    #[arg(long, help = "The subnet to claim from")]
     pub subnet: String,
     #[arg(
         long,
-        short,
         help = "Determine if we want to claim rewards instead of collateral"
     )]
     pub rewards: bool,

--- a/ipc/cli/src/commands/subnet/list_subnets.rs
+++ b/ipc/cli/src/commands/subnet/list_subnets.rs
@@ -47,8 +47,8 @@ impl CommandLineHandler for ListSubnets {
     about = "List all child subnets registered in the gateway (i.e. that have provided enough collateral)"
 )]
 pub(crate) struct ListSubnetsArgs {
-    #[arg(long, short, help = "The gateway address to query subnets")]
+    #[arg(long, help = "The gateway address to query subnets")]
     pub gateway_address: Option<String>,
-    #[arg(long, short, help = "The subnet id to query child subnets")]
+    #[arg(long, help = "The subnet id to query child subnets")]
     pub subnet: String,
 }

--- a/ipc/cli/src/commands/subnet/rpc.rs
+++ b/ipc/cli/src/commands/subnet/rpc.rs
@@ -36,7 +36,7 @@ impl CommandLineHandler for RPCSubnet {
 #[derive(Debug, Args)]
 #[command(name = "rpc", about = "RPC endpoint for a subnet")]
 pub struct RPCSubnetArgs {
-    #[arg(long, short, help = "The subnet to get the ChainId from")]
+    #[arg(long, help = "The subnet to get the ChainId from")]
     pub subnet: String,
 }
 
@@ -65,6 +65,6 @@ impl CommandLineHandler for ChainIdSubnet {
 #[derive(Debug, Args)]
 #[command(name = "chain-id", about = "Chain ID endpoint for a subnet")]
 pub struct ChainIdSubnetArgs {
-    #[arg(long, short, help = "The subnet to get the Chain ID from")]
+    #[arg(long, help = "The subnet to get the Chain ID from")]
     pub subnet: String,
 }

--- a/ipc/cli/src/commands/subnet/send_value.rs
+++ b/ipc/cli/src/commands/subnet/send_value.rs
@@ -42,11 +42,11 @@ impl CommandLineHandler for SendValue {
 #[derive(Debug, Args)]
 #[command(about = "Send value to an address within a subnet")]
 pub(crate) struct SendValueArgs {
-    #[arg(long, short, help = "The address to send value from")]
+    #[arg(long, help = "The address to send value from")]
     pub from: Option<String>,
-    #[arg(long, short, help = "The address to send value to")]
+    #[arg(long, help = "The address to send value to")]
     pub to: String,
-    #[arg(long, short, help = "The subnet of the addresses")]
+    #[arg(long, help = "The subnet of the addresses")]
     pub subnet: String,
     #[arg(help = "The amount to send (in whole FIL units)")]
     pub amount: f64,

--- a/ipc/cli/src/commands/subnet/validator.rs
+++ b/ipc/cli/src/commands/subnet/validator.rs
@@ -35,8 +35,8 @@ impl CommandLineHandler for ValidatorInfo {
 #[derive(Debug, Args)]
 #[command(name = "validator-info", about = "Get the validator info")]
 pub(crate) struct ValidatorInfoArgs {
-    #[arg(long, short, help = "The subnet id to query validator info")]
+    #[arg(long, help = "The subnet id to query validator info")]
     pub subnet: String,
-    #[arg(long, short, help = "The validator address")]
+    #[arg(long, help = "The validator address")]
     pub validator: String,
 }

--- a/ipc/cli/src/commands/util/f4.rs
+++ b/ipc/cli/src/commands/util/f4.rs
@@ -27,10 +27,6 @@ impl CommandLineHandler for EthToF4Addr {
 #[derive(Debug, Args)]
 #[command(about = "Get F4 for an Ethereum address")]
 pub(crate) struct EthToF4AddrArgs {
-    #[arg(
-        long,
-        short,
-        help = "Ethereum address to get the underlying f4 addr from"
-    )]
+    #[arg(long, help = "Ethereum address to get the underlying f4 addr from")]
     pub addr: String,
 }

--- a/ipc/cli/src/commands/wallet/balances.rs
+++ b/ipc/cli/src/commands/wallet/balances.rs
@@ -108,8 +108,8 @@ impl CommandLineHandler for WalletBalances {
 #[derive(Debug, Args)]
 #[command(about = "List balance of wallets in a subnet")]
 pub(crate) struct WalletBalancesArgs {
-    #[arg(long, short, help = "The subnet to list wallets from")]
+    #[arg(long, help = "The subnet to list wallets from")]
     pub subnet: String,
-    #[arg(long, short, help = "The type of the wallet, i.e. fvm, evm")]
+    #[arg(long, help = "The type of the wallet, i.e. fvm, evm")]
     pub wallet_type: String,
 }

--- a/ipc/cli/src/commands/wallet/default.rs
+++ b/ipc/cli/src/commands/wallet/default.rs
@@ -41,9 +41,9 @@ impl CommandLineHandler for WalletSetDefault {
 #[derive(Debug, Args)]
 #[command(about = "Set default wallet")]
 pub(crate) struct WalletSetDefaultArgs {
-    #[arg(long, short, help = "Address of the key to default")]
+    #[arg(long, help = "Address of the key to default")]
     pub address: String,
-    #[arg(long, short, help = "The type of the wallet, i.e. fvm, evm")]
+    #[arg(long, help = "The type of the wallet, i.e. fvm, evm")]
     pub wallet_type: String,
 }
 
@@ -80,6 +80,6 @@ impl CommandLineHandler for WalletGetDefault {
 #[derive(Debug, Args)]
 #[command(about = "Set default wallet")]
 pub(crate) struct WalletGetDefaultArgs {
-    #[arg(long, short, help = "The type of the wallet, i.e. fvm, evm")]
+    #[arg(long, help = "The type of the wallet, i.e. fvm, evm")]
     pub wallet_type: String,
 }

--- a/ipc/cli/src/commands/wallet/export.rs
+++ b/ipc/cli/src/commands/wallet/export.rs
@@ -102,23 +102,21 @@ impl CommandLineHandler for WalletExport {
 #[derive(Debug, Args)]
 #[command(about = "Export the key from a wallet address in JSON format")]
 pub(crate) struct WalletExportArgs {
-    #[arg(long, short, help = "Address of the key to export")]
+    #[arg(long, help = "Address of the key to export")]
     pub address: String,
     #[arg(
         long,
-        short,
         help = "Optional parameter that outputs the address key into the file specified"
     )]
     pub output: Option<String>,
-    #[arg(long, short, help = "The type of the wallet, i.e. fvm, evm")]
+    #[arg(long, help = "The type of the wallet, i.e. fvm, evm")]
     pub wallet_type: String,
     #[arg(
         long,
-        short,
         help = "Exports the secret key encoded in base64 as Fendermint expects"
     )]
     pub fendermint: bool,
-    #[arg(long, short, help = "Export the hex encoded secret key")]
+    #[arg(long, help = "Export the hex encoded secret key")]
     pub hex: bool,
 }
 
@@ -178,8 +176,8 @@ impl CommandLineHandler for WalletPublicKey {
 #[derive(Debug, Args)]
 #[command(about = "Return public key from a wallet address")]
 pub(crate) struct WalletPublicKeyArgs {
-    #[arg(long, short, help = "Address of the key to export")]
+    #[arg(long, help = "Address of the key to export")]
     pub address: String,
-    #[arg(long, short, help = "The type of the wallet, i.e. fvm, evm")]
+    #[arg(long, help = "The type of the wallet, i.e. fvm, evm")]
     pub wallet_type: String,
 }

--- a/ipc/cli/src/commands/wallet/import.rs
+++ b/ipc/cli/src/commands/wallet/import.rs
@@ -63,18 +63,16 @@ impl CommandLineHandler for WalletImport {
 .args(&["path", "private_key"]),
 ))]
 pub(crate) struct WalletImportArgs {
-    #[arg(long, short, help = "The type of the wallet, i.e. fvm, evm")]
+    #[arg(long, help = "The type of the wallet, i.e. fvm, evm")]
     pub wallet_type: String,
     #[arg(
         long,
-        short,
         group = "key_source",
         help = "Path of key info file for the key to import"
     )]
     pub path: Option<String>,
     #[arg(
         long,
-        short,
         group = "key_source",
         help = "The evm private key to import if path is not specified"
     )]

--- a/ipc/cli/src/commands/wallet/new.rs
+++ b/ipc/cli/src/commands/wallet/new.rs
@@ -47,10 +47,9 @@ impl CommandLineHandler for WalletNew {
 pub(crate) struct WalletNewArgs {
     #[arg(
         long,
-        short,
         help = "The fvm key type of the wallet (secp256k1, bls, secp256k1-ledger), only for fvm wallet type"
     )]
     pub key_type: Option<String>,
-    #[arg(long, short, help = "The type of the wallet, i.e. fvm, evm")]
+    #[arg(long, help = "The type of the wallet, i.e. fvm, evm")]
     pub wallet_type: String,
 }

--- a/ipc/cli/src/commands/wallet/remove.rs
+++ b/ipc/cli/src/commands/wallet/remove.rs
@@ -41,8 +41,8 @@ impl CommandLineHandler for WalletRemove {
 #[derive(Debug, Args)]
 #[command(about = "Remove wallet from keystore")]
 pub(crate) struct WalletRemoveArgs {
-    #[arg(long, short, help = "Address of the key to remove")]
+    #[arg(long, help = "Address of the key to remove")]
     pub address: String,
-    #[arg(long, short, help = "The type of the wallet, i.e. fvm, evm")]
+    #[arg(long, help = "The type of the wallet, i.e. fvm, evm")]
     pub wallet_type: String,
 }

--- a/ipc/cli/src/lib.rs
+++ b/ipc/cli/src/lib.rs
@@ -33,14 +33,13 @@ pub trait CommandLineHandler {
 #[derive(Debug, Args, Clone, Default)]
 pub struct GlobalArguments {
     #[arg(
-        short,
         long,
         help = "The toml config file path for IPC Agent, default to ${HOME}/.ipc-agent/config.toml"
     )]
     config_path: Option<String>,
 
     /// Set the FVM Address Network. It's value affects whether `f` (main) or `t` (test) prefixed addresses are accepted.
-    #[arg(short, long, default_value = "testnet", env = "NETWORK", value_parser = parse_network)]
+    #[arg(long, default_value = "testnet", env = "NETWORK", value_parser = parse_network)]
     pub network: Network,
 }
 


### PR DESCRIPTION
Issue: https://github.com/consensus-shipyard/ipc/issues/660

Noticed this error when following the quickstart calibration guide. Lets just remove the short names as we should always prefer the long names anyway for clarity

```bash
fridrik@workpc:~/workspace4/ipc-monorepo$ cargo run --bin ipc-cli subnet create --parent /r314159 --min-validators 3 --min-validator-stake 1 --bottomup-check-period 30
    Finished dev [unoptimized + debuginfo] target(s) in 0.19s
     Running `target/debug/ipc-cli subnet create --parent /r314159 --min-validators 3 --min-validator-stake 1 --bottomup-check-period 30`
thread 'main' panicked at /home/fridrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.4.14/src/builder/debug_asserts.rs:112:17:
Command create: Short option names must be unique for each argument, but '-m' is in use by both 'min_validator_stake' and 'min_cross_msg_fee'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```
