### PR TITLE
ENG-624: Vote throttling

### DIFF
--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -193,4 +193,10 @@ rate_limit_period = 0
 
 # IPC related configuration parameters
 [ipc]
+# Default subnet ID, which basically means IPC is disabled.
 subnet_id = "/r0"
+# Voting interval about things such as the top-down finality, in seconds.
+# It's limited to avoid GossipSub throttling or banning the node for over production.
+# The minimum is 1 seconds which is about the minimum target block time as well;
+# ideally one round of gossip per block should be as frequent as we would go.
+vote_interval = 1

--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -141,6 +141,9 @@ pub struct TopDownSettings {
 pub struct IpcSettings {
     #[serde_as(as = "IsHumanReadable")]
     pub subnet_id: SubnetID,
+    /// Interval with which votes can be gossiped.
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub vote_interval: Duration,
     /// The config for top down checkpoint. It's None if subnet id is root or not activating
     /// any top down checkpoint related operations
     pub topdown: Option<TopDownSettings>,

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -159,6 +159,7 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
                 tokio::spawn(async move {
                     publish_vote_loop(
                         parent_finality_votes,
+                        settings.ipc.vote_interval,
                         key,
                         own_subnet_id,
                         client,


### PR DESCRIPTION
Closes ENG-624

Adds a `vote_interval` to the `ipc` settings with a default value of 1 second, which is used to limit the number of top-down finality votes published to gossipsub to maximum 1 per second, to avoid potential bursts. If there are more blocks, it will vote on the latest next time, not the next-in-line height. 

I thought about adding the setting as milliseconds, but stayed with seconds because:
1. all the existing time related values are in seconds
2. I find it unlikely that we can complete more than 1 round of gossip when the block interval is 1 second
3. we only want 1 proposal in a block, so agreeing on one value should suffice

But I could be wrong, maybe the default should be 1000 millis, with an option to set lower values.