### PR TITLE
add pipefail and unused var error checking on bash script for deploying

### DIFF
--- a/contracts/ops/deploy.sh
+++ b/contracts/ops/deploy.sh
@@ -9,6 +9,11 @@ then
     exit 1
 fi
 
+if [ -f .env ]; then
+    source .env
+fi
+
+
 LIB_OUTPUT="libraries.out"
 GATEWAY_OUTPUT="gateway.out"
 NETWORK=$1

--- a/contracts/ops/deploy.sh
+++ b/contracts/ops/deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Deploys IPC on an EVM-compatible subnet using hardhat
-set -e
+set -eu
+set -o pipefail
 
 if [ $# -ne 1 ]
 then


### PR DESCRIPTION
https://linear.app/interplanetary-consensus/issue/ENG-626/ipc-deployment-scripts-fail-instead-of-trying-to-continue-empty

IPC deployment scripts: fail instead of trying to continue empty

This PR should make the deploy script fail when a sub part of it fails. I was able to recreate the early failure using

`export RPC_URL=https://filecoin-calibration.chainup.net/rpc/v1`

```
mikeseiler@Mikes-MacBook-Air contracts % make
./ops/deploy.sh auto
[*] Automatically getting chainID for network
[*] Target network Chain ID: 0x4cb2f
[*] Deploying libraries
[*] Output libraries available in /Users/mikeseiler/dev/consensus-shipyard/ipc/contracts/scripts/libraries.out
[*] Populating deploy-gateway script
[*] Gateway script in /Users/mikeseiler/dev/consensus-shipyard/ipc/contracts/scripts/deploy-gateway.ts
An unexpected error occurred:
ProviderError: Too Many Requests error received from filecoin-calibration.chainup.net
    at HttpProvider._fetchJsonRpcResponse (/Users/mikeseiler/dev/consensus-shipyard/ipc/contracts/node_modules/hardhat/src/internal/core/providers/http.ts:212:15)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async HttpProvider.request (/Users/mikeseiler/dev/consensus-shipyard/ipc/contracts/node_modules/hardhat/src/internal/core/providers/http.ts:85:29)
    at async EthersProviderWrapper.send (/Users/mikeseiler/dev/consensus-shipyard/ipc/contracts/node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)
make: *** [deploy-ipc] Error 1
```