### PR TITLE
Keep binding/src/lib.rs codegen file formatted

### DIFF
--- a/contracts/binding/build.rs
+++ b/contracts/binding/build.rs
@@ -117,6 +117,18 @@ fn main() {
     }
 
     println!("cargo:rerun-if-changed=build.rs");
+
+    // Run rustfmt on binding/src/lib.rs to make sure we don't accidentally format it in our IDEs
+    //
+    // sync the binding/src/lib.rs file to disk
+    lib.sync_all().unwrap();
+    // then run rustfmt on the file (it should be available as its specifed in our toolchain
+    let mut proc = std::process::Command::new("rustfmt")
+        .arg(lib_path)
+        .spawn()
+        .expect("rustfmt failed to start");
+    let ecode = proc.wait().expect("rustfmt failed to run");
+    assert!(ecode.success());
 }
 
 /// Convert ContractName to contract_name so we can use it as a Rust module.

--- a/contracts/binding/src/lib.rs
+++ b/contracts/binding/src/lib.rs
@@ -2,25 +2,31 @@
 #[macro_use]
 mod convert;
 #[allow(clippy::all)]
-pub mod i_diamond;
-#[allow(clippy::all)]
-pub mod diamond_loupe_facet;
+pub mod checkpointing_facet;
 #[allow(clippy::all)]
 pub mod diamond_cut_facet;
 #[allow(clippy::all)]
-pub mod gateway_diamond;
+pub mod diamond_loupe_facet;
 #[allow(clippy::all)]
-pub mod gateway_manager_facet;
+pub mod gateway_diamond;
 #[allow(clippy::all)]
 pub mod gateway_getter_facet;
 #[allow(clippy::all)]
-pub mod checkpointing_facet;
-#[allow(clippy::all)]
-pub mod top_down_finality_facet;
-#[allow(clippy::all)]
-pub mod xnet_messaging_facet;
+pub mod gateway_manager_facet;
 #[allow(clippy::all)]
 pub mod gateway_messenger_facet;
+#[allow(clippy::all)]
+pub mod i_diamond;
+#[allow(clippy::all)]
+pub mod lib_gateway;
+#[allow(clippy::all)]
+pub mod lib_quorum;
+#[allow(clippy::all)]
+pub mod lib_staking;
+#[allow(clippy::all)]
+pub mod lib_staking_change_log;
+#[allow(clippy::all)]
+pub mod register_subnet_facet;
 #[allow(clippy::all)]
 pub mod subnet_actor_checkpointing_facet;
 #[allow(clippy::all)]
@@ -34,19 +40,13 @@ pub mod subnet_actor_pause_facet;
 #[allow(clippy::all)]
 pub mod subnet_actor_reward_facet;
 #[allow(clippy::all)]
-pub mod subnet_registry_diamond;
-#[allow(clippy::all)]
-pub mod register_subnet_facet;
-#[allow(clippy::all)]
 pub mod subnet_getter_facet;
 #[allow(clippy::all)]
-pub mod lib_staking;
+pub mod subnet_registry_diamond;
 #[allow(clippy::all)]
-pub mod lib_staking_change_log;
+pub mod top_down_finality_facet;
 #[allow(clippy::all)]
-pub mod lib_gateway;
-#[allow(clippy::all)]
-pub mod lib_quorum;
+pub mod xnet_messaging_facet;
 
 // The list of contracts need to convert FvmAddress to fvm_shared::Address
 fvm_address_conversion!(gateway_manager_facet);


### PR DESCRIPTION
Proposal: Lets updated the `build.rs` script to format the `binding/src/lib.rs` file to make sure we don't accidentally format it which causes PR noise/merge conflicts.