### PR TITLE
Fix minor findings

### DIFF
--- a/contracts/sdk/IpcContract.sol
+++ b/contracts/sdk/IpcContract.sol
@@ -22,7 +22,7 @@ interface IpcHandler {
     function handleIpcMessage(IpcEnvelope calldata envelope) external payable returns (bytes memory ret);
 }
 
-abstract contract IpcExchange is IpcHandler, Ownable {
+abstract contract IpcExchange is IpcHandler, Ownable, ReentrancyGuard  {
     using CrossMsgHelper for IpcEnvelope;
 
     // The address of the gateway in the network.
@@ -76,7 +76,7 @@ abstract contract IpcExchange is IpcHandler, Ownable {
     function _handleIpcResult(IpcEnvelope storage original, IpcEnvelope memory result, ResultMsg memory resultMsg) internal virtual;
 
     /// @notice Method the implementation of this contract can invoke to perform an IPC call.
-    function performIpcCall(IPCAddress calldata to, CallMsg calldata callMsg, uint256 value) internal {
+    function performIpcCall(IPCAddress calldata to, CallMsg calldata callMsg, uint256 value) internal nonReentrant {
         // Queue the cross-net message for dispatch.
         IpcEnvelope memory envelope = IGateway(gatewayAddr).sendContractXnetMessage{value: value}(IpcEnvelope({
             kind: IpcMsgKind.Call,

--- a/contracts/src/errors/IPCErrors.sol
+++ b/contracts/src/errors/IPCErrors.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.19;
 
 error AddressShouldBeValidator();
 error AlreadyRegisteredSubnet();
+error AlreadyInSet();
 error CannotConfirmFutureChanges();
 error CannotReleaseZero();
 error CannotSendCrossMsgToItself();
@@ -53,6 +54,7 @@ error NotEnoughFundsToRelease();
 error NotEnoughSubnetCircSupply();
 error NotEnoughValidatorsInSubnet();
 error NotGateway();
+error NotInSet();
 error NotOwnerOfPublicKey();
 error NotRegisteredSubnet();
 error NotStakedBefore();

--- a/contracts/src/gateway/GatewayGetterFacet.sol
+++ b/contracts/src/gateway/GatewayGetterFacet.sol
@@ -196,7 +196,7 @@ contract GatewayGetterFacet {
 
         BottomUpCheckpoint[] memory checkpoints = new BottomUpCheckpoint[](size);
         for (uint64 i; i < size; ) {
-            checkpoints[i] = s.bottomUpCheckpoints[uint64(heights[i])];
+            checkpoints[i] = s.bottomUpCheckpoints[heights[i]];
             unchecked {
                 ++i;
             }

--- a/contracts/src/gateway/GatewayManagerFacet.sol
+++ b/contracts/src/gateway/GatewayManagerFacet.sol
@@ -8,7 +8,7 @@ import {IpcEnvelope} from "../structs/CrossNet.sol";
 import {FvmAddress} from "../structs/FvmAddress.sol";
 import {SubnetID, Subnet, SupplySource} from "../structs/Subnet.sol";
 import {Membership, SupplyKind} from "../structs/Subnet.sol";
-import {AlreadyRegisteredSubnet, AlreadyInSet, NotInSet, CannotReleaseZero, MethodNotAllowed, NotEnoughFunds, NotEnoughFundsToRelease, NotEnoughCollateral, NotEmptySubnetCircSupply, NotRegisteredSubnet, InvalidXnetMessage, InvalidXnetMessageReason} from "../errors/IPCErrors.sol";
+import {AlreadyRegisteredSubnet, CannotReleaseZero, MethodNotAllowed, NotEnoughFunds, NotEnoughFundsToRelease, NotEnoughCollateral, NotEmptySubnetCircSupply, NotRegisteredSubnet, InvalidXnetMessage, InvalidXnetMessageReason} from "../errors/IPCErrors.sol";
 import {LibGateway} from "../lib/LibGateway.sol";
 import {SubnetIDHelper} from "../lib/SubnetIDHelper.sol";
 import {CrossMsgHelper} from "../lib/CrossMsgHelper.sol";
@@ -53,13 +53,7 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
         subnet.genesisEpoch = block.number;
         subnet.circSupply = genesisCircSupply;
 
-        // This is situation when the subnet has not been registered from the Gateway perspective,
-        // but exists in the set.
-        bool added = s.subnetKeys.add(subnetId.toHash());
-        if (!added) {
-            revert AlreadyInSet();
-        }
-
+        s.subnetKeys.add(subnetId.toHash());
         s.totalSubnets += 1;
     }
 
@@ -119,10 +113,7 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
         s.totalSubnets -= 1;
         delete s.subnets[id];
 
-        bool removed = s.subnetKeys.remove(id);
-        if (!removed) {
-            revert NotInSet();
-        }
+        s.subnetKeys.remove(id);
 
         payable(msg.sender).sendValue(stake);
     }

--- a/contracts/src/lib/LibGateway.sol
+++ b/contracts/src/lib/LibGateway.sol
@@ -505,8 +505,10 @@ library LibGateway {
             // Check the next subnet (which can may be the destination subnet).
             reject = to.down(s.networkName).getActor().hasSupplyOfKind(SupplyKind.ERC20);
         }
-        if (reject && crossMessage.kind == IpcMsgKind.Transfer) {
-            revert MethodNotAllowed("propagation of `Transfer` messages not suppported for subnets with ERC20 supply");
+        if (reject) {
+            if (crossMessage.kind == IpcMsgKind.Transfer) {
+                revert MethodNotAllowed("propagation of `Transfer` messages not suppported for subnets with ERC20 supply");
+            }
         }
 
         // If the directionality is top-down, or if we're inverting the direction

--- a/contracts/src/lib/LibStaking.sol
+++ b/contracts/src/lib/LibStaking.sol
@@ -251,8 +251,10 @@ library LibValidatorSet {
         uint256 newCollateral = self.validators[validator].confirmedCollateral - amount;
         uint256 totalCollateral = self.validators[validator].totalCollateral;
 
-        if (newCollateral == 0 && totalCollateral == 0) {
-            delete self.validators[validator];
+        if (newCollateral == 0) {
+            if (totalCollateral == 0) {
+                delete self.validators[validator];
+            }
         } else {
             self.validators[validator].confirmedCollateral = newCollateral;
         }

--- a/contracts/src/lib/LibStaking.sol
+++ b/contracts/src/lib/LibStaking.sol
@@ -251,10 +251,8 @@ library LibValidatorSet {
         uint256 newCollateral = self.validators[validator].confirmedCollateral - amount;
         uint256 totalCollateral = self.validators[validator].totalCollateral;
 
-        if (newCollateral == 0) {
-            if (totalCollateral == 0) {
-                delete self.validators[validator];
-            }
+        if (newCollateral == 0 && totalCollateral == 0) {
+            delete self.validators[validator];
         } else {
             self.validators[validator].confirmedCollateral = newCollateral;
         }

--- a/contracts/src/subnet/SubnetActorCheckpointingFacet.sol
+++ b/contracts/src/subnet/SubnetActorCheckpointingFacet.sol
@@ -97,11 +97,10 @@ contract SubnetActorCheckpointingFacet is SubnetActorModifiers, ReentrancyGuard,
 
         // the max batch size not reached, we only support checkpoint period submission.
         uint256 lastBottomUpCheckpointHeight = s.lastBottomUpCheckpointHeight;
-        if (
-            checkpoint.blockHeight != lastBottomUpCheckpointHeight + s.bottomUpCheckPeriod &&
-            checkpoint.blockHeight != lastBottomUpCheckpointHeight
-        ) {
-            revert InvalidCheckpointEpoch();
+        if (checkpoint.blockHeight != lastBottomUpCheckpointHeight + s.bottomUpCheckPeriod) {
+            if (checkpoint.blockHeight != lastBottomUpCheckpointHeight) {
+                revert InvalidCheckpointEpoch();
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes minor findings:

1. Renaming variables and using `revert` for consistency.
2. Adding `nonReentrant` for IPC calls.
3. Checking return value from Set calls.