### PR TITLE
include alias for ipc-cli shorthand in quickstart calibration docs

### DIFF
--- a/docs/ipc/quickstart-calibration.md
+++ b/docs/ipc/quickstart-calibration.md
@@ -22,6 +22,10 @@ sudo apt update && sudo apt install build-essential libssl-dev mesa-opencl-icd o
 ## Step 2: Initialise your config
 
 * Initialise the config
+```shell
+alias ipc-cli="cargo run -q -p ipc-cli --release --"
+```
+
 ```bash
 ipc-cli config init
 ```


### PR DESCRIPTION
add 
```
alias ipc-cli="cargo run -q -p ipc-cli --release --"
```

to the quickstart-calibration.md

closes ENG-686

preview is here https://github.com/consensus-shipyard/ipc/blob/3eefa2d27aae46c48e4e733b7bfbfd50b8233ccd/docs/ipc/quickstart-calibration.md#step-2-initialise-your-config