### PR TITLE
FIX: Ability to skip updating the state on empty blocks

### DIFF
--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -41,6 +41,14 @@ port = 26658
 # Keep unlimited history by default.
 state_hist_size = 0
 
+# Whether to update the application state on empty blocks that would cause
+# no change other than the timestamp and the block height recorded in the
+# application history. Due to the changing timestamp, CometBFT creates a
+# block even if it is configured to skip doing so.
+#
+# This should only be set to false if CometBFT is configured to skip creating empty block.
+state_update_on_empty = true
+
 [snapshots]
 # Enable the export and import of snapshots.
 enabled = false

--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -87,6 +87,11 @@ pub struct DbSettings {
     ///
     /// This affects how long we can go back in state queries.
     pub state_hist_size: u64,
+
+    /// Whether to update the application state on empty blocks that otherwise cause no change
+    ///
+    /// This should be used in concert with the CometBFT setting to skip creating empty blocks.
+    pub state_update_on_empty: bool,
 }
 
 /// Settings affecting how we deal with failures in trying to send transactions to the local CometBFT node.

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -246,6 +246,7 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
             app_namespace: ns.app,
             state_hist_namespace: ns.state_hist,
             state_hist_size: settings.db.state_hist_size,
+            state_update_on_empty: settings.db.state_update_on_empty,
             builtin_actors_bundle: settings.builtin_actors_bundle(),
             custom_actors_bundle: settings.custom_actors_bundle(),
         },


### PR DESCRIPTION
Adds a setting to disable saving the application state on empty blocks.