### PR TITLE
[ipc-cli] Add ipc wallet list command

### DIFF
--- a/ipc/cli/src/commands/wallet/list.rs
+++ b/ipc/cli/src/commands/wallet/list.rs
@@ -1,0 +1,42 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: MIT
+//! Wallet list cli handler
+
+use async_trait::async_trait;
+use clap::Args;
+use ipc_wallet::{EthKeyAddress, EvmKeyStore};
+use std::fmt::Debug;
+
+use crate::{get_ipc_provider, CommandLineHandler, GlobalArguments};
+
+pub(crate) struct WalletList;
+
+#[async_trait]
+impl CommandLineHandler for WalletList {
+    type Arguments = WalletListArgs;
+
+    async fn handle(global: &GlobalArguments, _: &Self::Arguments) -> anyhow::Result<()> {
+        let provider = get_ipc_provider(global)?;
+        let wallet = provider.evm_wallet()?;
+        let addresses = wallet.read().unwrap().list()?;
+        for address in addresses.iter() {
+            if *address == EthKeyAddress::default() {
+                continue;
+            }
+
+            print!("Address: {}", address.to_string());
+
+            let key_info = wallet.read().unwrap().get(address)?.unwrap();
+            let sk = libsecp256k1::SecretKey::parse_slice(key_info.private_key())?;
+            let pub_key =
+                hex::encode(libsecp256k1::PublicKey::from_secret_key(&sk).serialize()).to_string();
+
+            println!("\tPubKey: {}", pub_key);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Args)]
+#[command(about = "List addresses and pubkeys in the wallet")]
+pub(crate) struct WalletListArgs {}

--- a/ipc/cli/src/commands/wallet/list.rs
+++ b/ipc/cli/src/commands/wallet/list.rs
@@ -4,8 +4,9 @@
 
 use async_trait::async_trait;
 use clap::Args;
-use ipc_wallet::{EthKeyAddress, EvmKeyStore};
+use ipc_wallet::{EthKeyAddress, EvmKeyStore, WalletType};
 use std::fmt::Debug;
+use std::str::FromStr;
 
 use crate::{get_ipc_provider, CommandLineHandler, GlobalArguments};
 
@@ -15,28 +16,51 @@ pub(crate) struct WalletList;
 impl CommandLineHandler for WalletList {
     type Arguments = WalletListArgs;
 
-    async fn handle(global: &GlobalArguments, _: &Self::Arguments) -> anyhow::Result<()> {
+    async fn handle(global: &GlobalArguments, arguments: &Self::Arguments) -> anyhow::Result<()> {
         let provider = get_ipc_provider(global)?;
-        let wallet = provider.evm_wallet()?;
-        let addresses = wallet.read().unwrap().list()?;
-        for address in addresses.iter() {
-            if *address == EthKeyAddress::default() {
-                continue;
+        let wallet_type = WalletType::from_str(&arguments.wallet_type)?;
+        match wallet_type {
+            WalletType::Evm => {
+                let wallet = provider.evm_wallet()?;
+                let addresses = wallet.read().unwrap().list()?;
+                for address in addresses.iter() {
+                    if *address == EthKeyAddress::default() {
+                        continue;
+                    }
+                    print!("Address: {}", address.to_string());
+
+                    let key_info = wallet.read().unwrap().get(address)?.unwrap();
+                    let sk = libsecp256k1::SecretKey::parse_slice(key_info.private_key())?;
+                    let pub_key =
+                        hex::encode(libsecp256k1::PublicKey::from_secret_key(&sk).serialize())
+                            .to_string();
+                    println!("\tPubKey: {}", pub_key);
+                }
+                Ok(())
             }
+            WalletType::Fvm => {
+                let wallet = provider.fvm_wallet()?;
+                let addresses = wallet.read().unwrap().list_addrs()?;
+                for address in addresses.iter() {
+                    print!("Address: {}", address);
 
-            print!("Address: {}", address.to_string());
-
-            let key_info = wallet.read().unwrap().get(address)?.unwrap();
-            let sk = libsecp256k1::SecretKey::parse_slice(key_info.private_key())?;
-            let pub_key =
-                hex::encode(libsecp256k1::PublicKey::from_secret_key(&sk).serialize()).to_string();
-
-            println!("\tPubKey: {}", pub_key);
+                    let key_info = wallet.write().unwrap().export(address)?;
+                    let sk = libsecp256k1::SecretKey::parse_slice(key_info.private_key())?;
+                    let pub_key =
+                        hex::encode(libsecp256k1::PublicKey::from_secret_key(&sk).serialize())
+                            .to_string();
+                    print!("\tPubKey: {}", pub_key);
+                    println!("\tKeyType: {:?}", key_info.key_type());
+                }
+                Ok(())
+            }
         }
-        Ok(())
     }
 }
 
 #[derive(Debug, Args)]
 #[command(about = "List addresses and pubkeys in the wallet")]
-pub(crate) struct WalletListArgs {}
+pub(crate) struct WalletListArgs {
+    #[arg(long, help = "The type of the wallet, i.e. fvm, evm")]
+    pub wallet_type: String,
+}

--- a/ipc/cli/src/commands/wallet/mod.rs
+++ b/ipc/cli/src/commands/wallet/mod.rs
@@ -11,12 +11,14 @@ use self::default::{
 };
 use self::export::{WalletExport, WalletExportArgs, WalletPublicKey, WalletPublicKeyArgs};
 use self::import::{WalletImport, WalletImportArgs};
+use self::list::{WalletList, WalletListArgs};
 use self::remove::{WalletRemove, WalletRemoveArgs};
 
 mod balances;
 mod default;
 mod export;
 mod import;
+mod list;
 mod new;
 mod remove;
 
@@ -39,6 +41,7 @@ impl WalletCommandsArgs {
             Commands::SetDefault(args) => WalletSetDefault::handle(global, args).await,
             Commands::GetDefault(args) => WalletGetDefault::handle(global, args).await,
             Commands::PubKey(args) => WalletPublicKey::handle(global, args).await,
+            Commands::List(args) => WalletList::handle(global, args).await,
         }
     }
 }
@@ -53,4 +56,5 @@ pub(crate) enum Commands {
     SetDefault(WalletSetDefaultArgs),
     GetDefault(WalletGetDefaultArgs),
     PubKey(WalletPublicKeyArgs),
+    List(WalletListArgs),
 }


### PR DESCRIPTION
https://linear.app/interplanetary-consensus/issue/ENG-611/ipc-wallet-list-command

Example usage:
```
$ ../target/release/ipc-cli wallet list --wallet-type evm
Address: 0xb4f69b8abc5b3a7f9b085661500b898a29fabe78     PubKey: 045dad983ebf44763387eb8ad65c1f32ea95fc6ac59425862365e13a68e699d4de2f4c4ffb866da7cd3ed56b5a8f7bbcc580107d316d5dc70eefbb33f7f78fdf06
Address: 0xefbd91dcdfd39a7aa2cb6566538ac57c8fe16093     PubKey: 04bdecde198fffcaf8dfc4e98a31ad07b5e653d961eedaba702505c46d749125fe5818a568af1e54de825b581d62734a9adf806e9c32bbbd8ac075af27bce27775
Address: 0xf161ba5e71ea64b34e95a860f3b093425c7ca9af     PubKey: 040e37bd1810d1519b2cf2d8993fe24872f81a81d068252d512cf9be1d0c9918526602423ef53a1523d3ef00658aeeeb1bcdb93942df0696b87b7becf437e1eee9

$ ../target/release/ipc-cli wallet list --wallet-type fvm
Address: t1giqacc3q4ielfoasz5ypllcfh7f2u6yidgujeba      PubKey: 04a2035d5a5e61dbb5ea313c2b5eda3cc473cda236e7fe3841c4f0d989a18e6384af36a49ec35af0b9178719ebbfb5599aa1984efb926d8f3789758003ef835f8d     KeyType: Secp256k1
```

Closes ENG-611