### PR TITLE
fix: clippy ptr_arg error on CI

### DIFF
--- a/fendermint/eth/api/src/gas/mod.rs
+++ b/fendermint/eth/api/src/gas/mod.rs
@@ -44,10 +44,7 @@ pub fn effective_gas_premium(msg: &Message, base_fee: &TokenAmount) -> TokenAmou
 // finds 55th percntile instead of median to put negative pressure on gas price
 // Rust implementation of:
 // https://github.com/consensus-shipyard/lotus/blob/156f5556b3ecc042764d76308dca357da3adfb4d/node/impl/full/gas.go#L144
-pub fn median_gas_premium(
-    prices: &mut Vec<(TokenAmount, i64)>,
-    block_gas_target: i64,
-) -> TokenAmount {
+pub fn median_gas_premium(prices: &mut [(TokenAmount, i64)], block_gas_target: i64) -> TokenAmount {
     // Sort in descending order based on premium
     prices.sort_by(|a, b| b.0.cmp(&a.0));
     let blocks = prices.len() as i64;


### PR DESCRIPTION
This PR should address the failing CI clippy task which suddenly started to complain about this. Not sure why as this code hasn't as far as I know changed recently and I don't get this error locally when running `make check-clippy`.

Here is the failing test: https://github.com/consensus-shipyard/ipc/actions/runs/7834028859/job/21376393430?pr=630