### PR TITLE
[ipc-cli] Use string for argument --supply-source-kind and --permission-mode

### DIFF
--- a/ipc/api/src/subnet.rs
+++ b/ipc/api/src/subnet.rs
@@ -78,6 +78,19 @@ impl TryFrom<u8> for PermissionMode {
     }
 }
 
+impl TryFrom<&str> for PermissionMode {
+    type Error = anyhow::Error;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Ok(match s {
+            "collateral" => PermissionMode::Collateral,
+            "federated" => PermissionMode::Federated,
+            "static" => PermissionMode::Static,
+            _ => return Err(anyhow!("invalid permission mode: {}", s)),
+        })
+    }
+}
+
 impl TryFrom<u8> for SupplyKind {
     type Error = anyhow::Error;
 

--- a/ipc/api/src/subnet.rs
+++ b/ipc/api/src/subnet.rs
@@ -89,3 +89,15 @@ impl TryFrom<u8> for SupplyKind {
         })
     }
 }
+
+impl TryFrom<&str> for SupplyKind {
+    type Error = anyhow::Error;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Ok(match s {
+            "native" => Self::Native,
+            "erc20" => Self::ERC20,
+            _ => return Err(anyhow!("invalid supply kind type: {}", s)),
+        })
+    }
+}

--- a/ipc/cli/src/commands/subnet/create.rs
+++ b/ipc/cli/src/commands/subnet/create.rs
@@ -39,7 +39,7 @@ impl CreateSubnet {
             None
         };
         let supply_source = SupplySource {
-            kind: SupplyKind::try_from(arguments.supply_source_kind)?,
+            kind: SupplyKind::try_from(arguments.supply_source_kind.as_str())?,
             token_address,
         };
         let addr = provider
@@ -115,9 +115,9 @@ pub struct CreateSubnetArgs {
     pub permission_mode: u8,
     #[arg(
         long,
-        help = "The kind of supply source of a subnet on its parent subnet, native(0), erc20(1)"
+        help = "The kind of supply source of a subnet on its parent subnet: native or erc20"
     )]
-    pub supply_source_kind: u8,
+    pub supply_source_kind: String,
     #[arg(
         long,
         help = "The address of supply source of a subnet on its parent subnet. None if kind is native"

--- a/ipc/cli/src/commands/subnet/create.rs
+++ b/ipc/cli/src/commands/subnet/create.rs
@@ -32,7 +32,7 @@ impl CreateSubnet {
             None => None,
         };
 
-        let permission_mode = PermissionMode::try_from(arguments.permission_mode)?;
+        let permission_mode = PermissionMode::try_from(arguments.permission_mode.as_str())?;
         let token_address = if let Some(addr) = &arguments.supply_source_address {
             Some(Address::from_str(addr)?)
         } else {
@@ -110,9 +110,9 @@ pub struct CreateSubnetArgs {
     pub min_cross_msg_fee: f64,
     #[arg(
         long,
-        help = "The permission mode for the subnet, collateral(0), federated(1) and static(2)"
+        help = "The permission mode for the subnet: collateral, federated and static"
     )]
-    pub permission_mode: u8,
+    pub permission_mode: String,
     #[arg(
         long,
         help = "The kind of supply source of a subnet on its parent subnet: native or erc20"


### PR DESCRIPTION
https://linear.app/interplanetary-consensus/issue/ENG-613/ipc-cli-avoid-using-int-enum-values-in-arguments

Closes ENG-613
