### PR TITLE
FIX: Add 0x prefix to eth_getStorageAt response

### DIFF
--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -745,8 +745,8 @@ where
         if let Some(data) = data {
             data.to_big_endian(&mut bz);
         }
-        // The client library expects hex encoded string.
-        Ok(hex::encode(bz))
+        // The client library expects hex encoded string. The JS client might want a prefix too.
+        Ok(format!("0x{}", hex::encode(bz)))
     };
 
     let height = data.query_height(block_id).await?;


### PR DESCRIPTION
https://filecoinproject.slack.com/archives/C04JR5R1UL8/p1707732077786189?thread_ts=1707502346.036449&cid=C04JR5R1UL8

```
“fuzz: failed to inspect: Database error: failed to get storage for 0xB5022A70376545e134aa89A5EA875F9368a8e667 at 24440054405305269366569402256811496959409073762505157381672968839269610695612: 
Deserialization error: invalid value: string “000000000000000000000000776efa0d1e94ad466838e27c4dfda7cdd1c2bd2d”, expected a 32 byte hex string at line 1 column 66"
```

The string looks like it should parse. Perhaps the client doesn't recognise it as a hex string unless it starts with 0x