### PR TITLE
ENG-719: Pull the latest image before building docker

### DIFF
--- a/.github/workflows/fendermint-publish.yaml
+++ b/.github/workflows/fendermint-publish.yaml
@@ -81,6 +81,10 @@ jobs:
 
           echo "IMAGE_TAG=$IMAGE_ID:$VERSION" >> $GITHUB_OUTPUT
 
+      # Pull the latest docker image. Its layers might be reused during the build.
+      - name: Docker Pull
+        run: docker pull ghcr.io/consensus-shipyard/fendermint:latest
+
       - name: Docker Deps
         run: |
           cd fendermint && make docker-deps

--- a/.github/workflows/fendermint-test.yaml
+++ b/.github/workflows/fendermint-test.yaml
@@ -90,5 +90,9 @@ jobs:
           path: ./contracts/out
           key: contracts-abi-${{ hashFiles('./contracts/src/**/*.sol') }}
 
+      # Pull the latest docker image. Its layers might be reused during the build.
+      - name: Docker Pull
+        run: docker pull ghcr.io/consensus-shipyard/fendermint:latest
+
       - name: ${{ matrix.make.name }}
         run: cd fendermint && make ${{ matrix.make.task }}


### PR DESCRIPTION
Addresses https://github.com/consensus-shipyard/ipc/issues/685

Pull the latest docker image on CI, which might help with the layer based caching. When I added that caching I forgot that new runners on github won't have the earlier docker registry artifacts at hand.