### PR TITLE
ipc-cli: use strum for PermissionMode and SupplySourceKind enums.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4732,6 +4732,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tuple",
+ "strum 0.26.1",
  "thiserror",
 ]
 
@@ -4768,7 +4769,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_tuple",
- "strum 0.24.1",
+ "strum 0.26.1",
  "thiserror",
  "tokio",
  "tokio-tungstenite 0.18.0",
@@ -4808,7 +4809,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_tuple",
- "strum 0.24.1",
+ "strum 0.26.1",
  "tempfile",
  "thiserror",
  "tokio",
@@ -8668,15 +8669,6 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros 0.24.3",
-]
-
-[[package]]
-name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
@@ -8685,16 +8677,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum_macros"
-version = "0.24.3"
+name = "strum"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
 dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
+ "strum_macros 0.26.1",
 ]
 
 [[package]]
@@ -8702,6 +8690,19 @@ name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 serde_tuple = "0.5"
 serde_with = "2.3"
 serial_test = "3.0"
+strum = { version = "0.26.1", features = ["derive"] }
 tempfile = "3.7"
 thiserror = "1"
 tokio = { version = "1", features = [

--- a/ipc/api/Cargo.toml
+++ b/ipc/api/Cargo.toml
@@ -22,6 +22,7 @@ cid = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
 serde_tuple = { workspace = true }
+strum = { workspace = true }
 thiserror = { workspace = true }
 ethers = { workspace = true }
 

--- a/ipc/api/src/subnet.rs
+++ b/ipc/api/src/subnet.rs
@@ -17,6 +17,7 @@ pub const MANIFEST_ID: &str = "ipc_subnet_actor";
 /// Determines the permission mode for validators.
 #[repr(u8)]
 #[derive(
+    Copy,
     Debug,
     Clone,
     Serialize_repr,
@@ -48,6 +49,7 @@ pub struct SupplySource {
 /// Determines the type of supply used by the subnet.
 #[repr(u8)]
 #[derive(
+    Copy,
     Debug,
     Clone,
     Serialize_repr,

--- a/ipc/api/src/subnet.rs
+++ b/ipc/api/src/subnet.rs
@@ -7,7 +7,6 @@
 /// However, we should either deprecate the native actors, or make
 /// them use the types from this sdk directly.
 use crate::subnet_id::SubnetID;
-use anyhow::anyhow;
 use fvm_ipld_encoding::repr::*;
 use fvm_shared::{address::Address, clock::ChainEpoch, econ::TokenAmount};
 use serde::{Deserialize, Serialize};
@@ -17,7 +16,17 @@ pub const MANIFEST_ID: &str = "ipc_subnet_actor";
 
 /// Determines the permission mode for validators.
 #[repr(u8)]
-#[derive(Debug, Clone, Serialize_repr, Deserialize_repr, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Clone,
+    Serialize_repr,
+    Deserialize_repr,
+    PartialEq,
+    Eq,
+    strum::EnumString,
+    strum::VariantNames,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum PermissionMode {
     /// Validator power is determined by the collateral staked
     Collateral,
@@ -38,7 +47,17 @@ pub struct SupplySource {
 
 /// Determines the type of supply used by the subnet.
 #[repr(u8)]
-#[derive(Debug, Clone, Serialize_repr, Deserialize_repr, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Clone,
+    Serialize_repr,
+    Deserialize_repr,
+    PartialEq,
+    Eq,
+    strum::EnumString,
+    strum::VariantNames,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum SupplyKind {
     Native,
     ERC20,
@@ -63,54 +82,4 @@ pub struct ConstructParams {
 #[repr(u64)]
 pub enum ConsensusType {
     Fendermint,
-}
-
-impl TryFrom<u8> for PermissionMode {
-    type Error = anyhow::Error;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        Ok(match value {
-            0 => PermissionMode::Collateral,
-            1 => PermissionMode::Federated,
-            2 => PermissionMode::Static,
-            _ => return Err(anyhow!("unknown permission mode {value}")),
-        })
-    }
-}
-
-impl TryFrom<&str> for PermissionMode {
-    type Error = anyhow::Error;
-
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        Ok(match s {
-            "collateral" => PermissionMode::Collateral,
-            "federated" => PermissionMode::Federated,
-            "static" => PermissionMode::Static,
-            _ => return Err(anyhow!("invalid permission mode: {}", s)),
-        })
-    }
-}
-
-impl TryFrom<u8> for SupplyKind {
-    type Error = anyhow::Error;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        Ok(match value {
-            0 => SupplyKind::Native,
-            1 => SupplyKind::ERC20,
-            _ => return Err(anyhow!("unknown supply kind {value}")),
-        })
-    }
-}
-
-impl TryFrom<&str> for SupplyKind {
-    type Error = anyhow::Error;
-
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        Ok(match s {
-            "native" => Self::Native,
-            "erc20" => Self::ERC20,
-            _ => return Err(anyhow!("invalid supply kind type: {}", s)),
-        })
-    }
 }

--- a/ipc/cli/Cargo.toml
+++ b/ipc/cli/Cargo.toml
@@ -32,7 +32,7 @@ serde = { workspace = true }
 serde_bytes = "0.11.9"
 serde_json = { workspace = true }
 serde_tuple = { workspace = true }
-strum = { version = "0.24", features = ["derive"] }
+strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-tungstenite = { workspace = true }

--- a/ipc/provider/Cargo.toml
+++ b/ipc/provider/Cargo.toml
@@ -23,7 +23,7 @@ tokio-tungstenite = { workspace = true }
 num-traits = { workspace = true }
 num-derive = { workspace = true }
 base64 = { workspace = true }
-strum = { version = "0.24", features = ["derive"] }
+strum = { workspace = true }
 toml = { workspace = true }
 url = { workspace = true }
 bytes = { workspace = true }


### PR DESCRIPTION
Follow-up to https://github.com/consensus-shipyard/ipc/pull/684.

This is a bit less pedantic. Ideally we would use clap's [`ValueEnum`](https://docs.rs/clap/latest/clap/trait.ValueEnum.html) going forward, but it's tricky because these types are shared between the cli and the api packages.