### PR TITLE
Several fixes related to the token supply source

### DIFF
--- a/contracts/src/gateway/GatewayManagerFacet.sol
+++ b/contracts/src/gateway/GatewayManagerFacet.sol
@@ -159,6 +159,11 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
     /// @param to The funded address.
     /// @param amount The amount of ERC20 tokens to be sent.
     function fundWithToken(SubnetID calldata subnetId, FvmAddress calldata to, uint256 amount) external nonReentrant {
+        if (amount == 0) {
+            // prevent spamming if there's no value to fund.
+            revert InvalidXnetMessage(InvalidXnetMessageReason.Value);
+        }
+
         // Check that the supply strategy is ERC20.
         // There is no need to check whether the subnet exists. If it doesn't exist, the call to getter will revert.
         // LibGateway.commitTopDownMsg will also revert if the subnet doesn't exist.

--- a/contracts/src/lib/LibGateway.sol
+++ b/contracts/src/lib/LibGateway.sol
@@ -28,8 +28,6 @@ library LibGateway {
     /// @dev event emitted when there is a new bottom-up message batch to be signed.
     event NewBottomUpMsgBatch(uint256 indexed epoch, BottomUpMsgBatch batch);
 
-    error CannotCreateIpcReceipt();
-
     /// @notice returns the current bottom-up checkpoint
     /// @return exists - whether the checkpoint exists
     /// @return epoch - the epoch of the checkpoint
@@ -442,20 +440,22 @@ library LibGateway {
     /// failing network.
     /// (we could optionally trigger a receipt from `Transfer`s to, but without
     /// multi-level execution it would be adding unnecessary overhead).
-    function sendReceipt(IpcEnvelope memory crossMsg, OutcomeType outcomeType, bytes memory ret) internal {
-        if (crossMsg.isEmpty()) {
-            revert CannotCreateIpcReceipt();
+    function sendReceipt(IpcEnvelope memory original, OutcomeType outcomeType, bytes memory ret) internal {
+        if (original.isEmpty()) {
+            // This should not happen as previous validation should prevent empty messages arriving here.
+            // If it does, we simply ignore.
+            return;
         }
 
         // if we get a `Receipt` do nothing, no need to send receipts.
         // - And sending a `Receipt` to a `Receipt` could lead to amplification loops.
-        if (crossMsg.kind == IpcMsgKind.Result) {
+        if (original.kind == IpcMsgKind.Result) {
             return;
         }
 
         // commmit the receipt for propagation
         // slither-disable-next-line unused-return
-        commitCrossMessage(crossMsg.createResultMsg(outcomeType, ret));
+        commitCrossMessage(original.createResultMsg(outcomeType, ret));
     }
 
     /**

--- a/ipc/cli/Cargo.toml
+++ b/ipc/cli/Cargo.toml
@@ -26,6 +26,7 @@ hex = { workspace = true }
 libsecp256k1 = { workspace = true }
 log = { workspace = true }
 num-derive = "0.3.3"
+num-bigint = { workspace = true }
 num-traits = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
* Reject zero-value token deposits in the gateway.
* Do not revert when unable to create a receipt (see commit message for more details).
* ipc-cli: fund-with-token no longer makes arbitrary assumptions about unit precision.