### PR TITLE
Expand IpcContract.t.sol to test handleIpcMessage

### DIFF
--- a/contracts/test/IntegrationTestBase.sol
+++ b/contracts/test/IntegrationTestBase.sol
@@ -946,7 +946,7 @@ contract IntegrationTestBase is Test, TestParams, TestRegistry, TestSubnetActor,
         return (subnet.id, subnet.stake, subnet.topDownNonce, subnet.appliedBottomUpNonce, subnet.circSupply);
     }
 
-    function getSubnet(address subnetAddress) public returns (SubnetID memory, uint256, uint256, uint256, uint256) {
+    function getSubnet(address subnetAddress) public view returns (SubnetID memory, uint256, uint256, uint256, uint256) {
         return getSubnetGW(subnetAddress, gatewayDiamond);
     }
 }

--- a/contracts/test/IntegrationTestBase.sol
+++ b/contracts/test/IntegrationTestBase.sol
@@ -946,7 +946,9 @@ contract IntegrationTestBase is Test, TestParams, TestRegistry, TestSubnetActor,
         return (subnet.id, subnet.stake, subnet.topDownNonce, subnet.appliedBottomUpNonce, subnet.circSupply);
     }
 
-    function getSubnet(address subnetAddress) public view returns (SubnetID memory, uint256, uint256, uint256, uint256) {
+    function getSubnet(
+        address subnetAddress
+    ) public view returns (SubnetID memory, uint256, uint256, uint256, uint256) {
         return getSubnetGW(subnetAddress, gatewayDiamond);
     }
 }

--- a/contracts/test/sdk/IpcContract.t.sol
+++ b/contracts/test/sdk/IpcContract.t.sol
@@ -258,5 +258,4 @@ contract IpcExchangeTest is Test {
         exch.handleIpcMessage(resultEnvelope);
         require(exch.getLastResultMsg().id != bytes32(""), "_handleIpcResult was not called");
     }
-
 }

--- a/contracts/test/sdk/IpcContract.t.sol
+++ b/contracts/test/sdk/IpcContract.t.sol
@@ -16,8 +16,6 @@ import {IpcHandler, IpcExchange} from "../../sdk/IpcContract.sol";
 import {IGateway} from "../../src/interfaces/IGateway.sol";
 import {CrossMsgHelper} from "../../src/lib/CrossMsgHelper.sol";
 
-import {IntegrationTestBase, TestRegistry} from "../IntegrationTestBase.sol";
-
 interface Foo {
     function foo(string calldata) external returns (string memory);
 }
@@ -86,7 +84,7 @@ contract RecorderIpcExchange is IpcExchange {
     }
 }
 
-contract IpcExchangeTest is Test, IntegrationTestBase {
+contract IpcExchangeTest is Test {
     using CrossMsgHelper for IpcEnvelope;
     address gateway = vm.addr(1);
     SubnetID subnetA;
@@ -100,7 +98,7 @@ contract IpcExchangeTest is Test, IntegrationTestBase {
     IPCAddress ipcAddressA;
     IPCAddress ipcAddressB;
 
-    function setUp() public override {
+    function setUp() public {
         address[] memory pathA = new address[](1);
         pathA[0] = vm.addr(2000);
         address[] memory pathB = new address[](1);
@@ -184,7 +182,7 @@ contract IpcExchangeTest is Test, IntegrationTestBase {
         vm.expectRevert(IpcHandler.UnrecognizedResult.selector);
         exch.handleIpcMessage(callEnvelope);
     }
-    
+
     function test_IpcExchange_successfulCorrelation() public {
         // Perform an outgoing IPC call from within the contract.
         vm.mockCall(

--- a/contracts/test/sdk/IpcContract.t.sol
+++ b/contracts/test/sdk/IpcContract.t.sol
@@ -27,7 +27,6 @@ contract RecorderIpcExchange is IpcExchange {
     CallMsg private lastCallMsg;
     ResultMsg private lastResultMsg;
     bool private shouldRevert;
-    bool public handleIpcResultCalled = false;
 
     constructor(address gatewayAddr_) IpcExchange(gatewayAddr_) {}
 
@@ -43,16 +42,12 @@ contract RecorderIpcExchange is IpcExchange {
     }
 
     function _handleIpcResult(
-        IpcEnvelope storage original,
+        IpcEnvelope storage,
         IpcEnvelope memory result,
         ResultMsg memory resultMsg
     ) internal override {
-        // indicate this method was called
-        handleIpcResultCalled = true;
-
         require(!shouldRevert, "revert requested");
         console.log("handling ipc result");
-        require(keccak256(abi.encode(original)) == keccak256(abi.encode(lastEnvelope)));
         lastEnvelope = result;
         lastResultMsg = resultMsg;
     }
@@ -141,7 +136,7 @@ contract IpcExchangeTest is Test, IntegrationTestBase {
         exch = new RecorderIpcExchange(gateway);
     }
 
-    function test_IpcExchangeTestTransferFails() public {
+    function test_IpcExchange_testTransferFails() public {
         callEnvelope.kind = IpcMsgKind.Transfer;
 
         // a transfer; fails because cannot handle.
@@ -150,13 +145,13 @@ contract IpcExchangeTest is Test, IntegrationTestBase {
         exch.handleIpcMessage(callEnvelope);
     }
 
-    function test_IpcExchangeTestGatewayOnlyFails() public {
+    function test_IpcExchange_testGatewayOnlyFails() public {
         // a call; fails when the caller is not the gateway.
         vm.expectRevert(IpcHandler.CallerIsNotGateway.selector);
         exch.handleIpcMessage(callEnvelope);
     }
 
-    function test_IpcExchange() public {
+    function test_IpcExchange_handleOk() public {
         vm.startPrank(gateway);
         exch.handleIpcMessage(callEnvelope);
 
@@ -167,7 +162,7 @@ contract IpcExchangeTest is Test, IntegrationTestBase {
         require(keccak256(abi.encode(callMsg)) == keccak256(abi.encode(lastCall)), "unexpected callmsg");
     }
 
-    function test_IpcExchangeFlipRevert() public {
+    function test_IpcExchange_revertPropagated() public {
         vm.startPrank(gateway);
         // a revert bubbles up.
         exch.flipRevert();
@@ -175,9 +170,9 @@ contract IpcExchangeTest is Test, IntegrationTestBase {
         exch.handleIpcMessage(callEnvelope);
     }
 
-    function test_IpcExchangeUnexpectedResult() public {
+    function test_IpcExchange_unexpectedResult() public {
         vm.startPrank(gateway);
-        //
+
         // an unrecognized result
         callEnvelope.kind = IpcMsgKind.Result;
         callEnvelope.message = abi.encode(ResultMsg({outcome: OutcomeType.Ok, id: keccak256("foo"), ret: bytes("")}));
@@ -189,27 +184,9 @@ contract IpcExchangeTest is Test, IntegrationTestBase {
         vm.expectRevert(IpcHandler.UnrecognizedResult.selector);
         exch.handleIpcMessage(callEnvelope);
     }
-
-    function test_IpcExchangeTestReceiptCorrelation() public {
-        vm.startPrank(gateway);
-        vm.mockCall(
-            gateway,
-            abi.encodeWithSelector(IGateway.sendContractXnetMessage.selector),
-            abi.encode(callEnvelope)
-        );
-        vm.deal(address(this), 1000);
-        exch.performIpcCall_(callEnvelope.from, CallMsg({method: bytes("1234"), params: bytes("AABB")}), 1);
-
-        // we store the correct callEnvelope in the correlation map.
-        IpcEnvelope memory correlated = exch.getInflight(callEnvelope.toHash());
-        require(correlated.toHash() == callEnvelope.toHash());
-
-        // TODO test receipt correlation
-
-        // TODO test dropMessages
-    }
-
-    function test_IpcExchangeCallResult() public {
+    
+    function test_IpcExchange_successfulCorrelation() public {
+        // Perform an outgoing IPC call from within the contract.
         vm.mockCall(
             gateway,
             abi.encodeWithSelector(IGateway.sendContractXnetMessage.selector),
@@ -217,19 +194,71 @@ contract IpcExchangeTest is Test, IntegrationTestBase {
         );
         vm.deal(address(this), 1000);
         exch.performIpcCall_(ipcAddressA, callMsg, 1);
+        // assert that we stored the correct callEnvelope in the correlation map.
+        IpcEnvelope memory correlated = exch.getInflight(callEnvelope.toHash());
+        require(correlated.toHash() == callEnvelope.toHash());
 
-        //possibly move start prank here
         vm.startPrank(gateway);
-        exch.handleIpcMessage(callEnvelope);
 
-        // succeeds.
-        IpcEnvelope memory lastEnvelope = exch.getLastEnvelope();
-        CallMsg memory lastCall = exch.getLastCallMsg();
-        require(keccak256(abi.encode(callEnvelope)) == keccak256(abi.encode(lastEnvelope)), "unexpected callEnvelope");
-        require(keccak256(abi.encode(callMsg)) == keccak256(abi.encode(lastCall)), "unexpected callmsg");
-
-        // gateway calls callback with result
+        // Simulate an OK incoming result.
         exch.handleIpcMessage(resultEnvelope);
-        require(exch.handleIpcResultCalled(), "_handleIpcResult was not called");
+        require(exch.getLastResultMsg().id != bytes32(""), "_handleIpcResult was not called");
     }
+
+    function test_IpcExchange_dropMessages() public {
+        vm.deal(address(this), 1000);
+
+        // Send three messages from within the contract.
+        bytes32[] memory ids = new bytes32[](3);
+        for (uint64 i = 0; i < 3; i++) {
+            callEnvelope.nonce = i;
+            vm.mockCall(
+                gateway,
+                abi.encodeWithSelector(IGateway.sendContractXnetMessage.selector),
+                abi.encode(callEnvelope)
+            );
+            exch.performIpcCall_(ipcAddressA, callMsg, 1);
+
+            bytes32 id = callEnvelope.toHash();
+            require(exch.getInflight(id).value != 0, "envelope not found in correlation map");
+
+            ids[i] = id;
+        }
+
+        bytes32[] memory params = new bytes32[](2);
+        params[0] = ids[0];
+        params[1] = ids[1];
+
+        // drop a message: unauthorized
+        vm.prank(address(vm.addr(999)));
+        vm.expectRevert();
+        exch.dropMessages(params);
+
+        // drop a message: from the owner
+        vm.prank(address(this));
+        exch.dropMessages(params);
+
+        require(exch.getInflight(ids[0]).value == 0, "did not expect envelope in correlation map");
+        require(exch.getInflight(ids[1]).value == 0, "did not expect envelope in correlation map");
+        require(exch.getInflight(ids[2]).value != 0, "expected envelope in correlation map");
+
+        vm.startPrank(gateway);
+
+        // unrecognized correlation id
+        vm.expectRevert(IpcHandler.UnrecognizedResult.selector);
+        exch.handleIpcMessage(resultEnvelope);
+
+        // only remaining one
+        resultMsg.id = ids[2];
+        resultEnvelope.message = abi.encode(resultMsg);
+
+        // assert that we stored the correct callEnvelope in the correlation map.
+        IpcEnvelope memory correlated = exch.getInflight(callEnvelope.toHash());
+        require(correlated.toHash() == callEnvelope.toHash());
+
+        // Simulate an OK incoming result.
+        exch.handleIpcMessage(resultEnvelope);
+        require(exch.getLastResultMsg().id != bytes32(""), "_handleIpcResult was not called");
+    }
+
 }


### PR DESCRIPTION
Building upon https://github.com/consensus-shipyard/ipc/pull/697 This PR extends beyond the simple refactor of the existing test to add new features.

New tests added:
- add test to `IpcContract.t.sol` to validate `_handleIpcResult` is called when the gateway calls `exch.handleIpcMessage`