### PR TITLE
Change argument --subnet into --network for some of the ipc-cli subnet commands

### DIFF
--- a/ipc/cli/src/commands/subnet/list_subnets.rs
+++ b/ipc/cli/src/commands/subnet/list_subnets.rs
@@ -21,7 +21,7 @@ impl CommandLineHandler for ListSubnets {
         log::debug!("list subnets with args: {:?}", arguments);
 
         let provider = get_ipc_provider(global)?;
-        let subnet = SubnetID::from_str(&arguments.subnet)?;
+        let subnet = SubnetID::from_str(&arguments.network)?;
 
         let gateway_addr = match &arguments.gateway_address {
             Some(address) => Some(require_fil_addr_from_str(address)?),
@@ -49,6 +49,6 @@ impl CommandLineHandler for ListSubnets {
 pub(crate) struct ListSubnetsArgs {
     #[arg(long, help = "The gateway address to query subnets")]
     pub gateway_address: Option<String>,
-    #[arg(long, help = "The subnet id to query child subnets")]
-    pub subnet: String,
+    #[arg(long, help = "The network id to query child subnets")]
+    pub network: String,
 }

--- a/ipc/cli/src/commands/subnet/list_subnets.rs
+++ b/ipc/cli/src/commands/subnet/list_subnets.rs
@@ -21,7 +21,7 @@ impl CommandLineHandler for ListSubnets {
         log::debug!("list subnets with args: {:?}", arguments);
 
         let provider = get_ipc_provider(global)?;
-        let subnet = SubnetID::from_str(&arguments.network)?;
+        let subnet = SubnetID::from_str(&arguments.parent)?;
 
         let gateway_addr = match &arguments.gateway_address {
             Some(address) => Some(require_fil_addr_from_str(address)?),
@@ -50,5 +50,5 @@ pub(crate) struct ListSubnetsArgs {
     #[arg(long, help = "The gateway address to query subnets")]
     pub gateway_address: Option<String>,
     #[arg(long, help = "The network id to query child subnets")]
-    pub network: String,
+    pub parent: String,
 }

--- a/ipc/cli/src/commands/subnet/rpc.rs
+++ b/ipc/cli/src/commands/subnet/rpc.rs
@@ -21,7 +21,7 @@ impl CommandLineHandler for RPCSubnet {
         log::debug!("get rpc for subnet with args: {:?}", arguments);
 
         let provider = get_ipc_provider(global)?;
-        let subnet = SubnetID::from_str(&arguments.subnet)?;
+        let subnet = SubnetID::from_str(&arguments.network)?;
         let conn = match provider.connection(&subnet) {
             None => return Err(anyhow::anyhow!("target subnet not found")),
             Some(conn) => conn,
@@ -36,8 +36,8 @@ impl CommandLineHandler for RPCSubnet {
 #[derive(Debug, Args)]
 #[command(name = "rpc", about = "RPC endpoint for a subnet")]
 pub struct RPCSubnetArgs {
-    #[arg(long, help = "The subnet to get the ChainId from")]
-    pub subnet: String,
+    #[arg(long, help = "The network to get the ChainId from")]
+    pub network: String,
 }
 
 /// The command to get the chain ID for a subnet
@@ -51,7 +51,7 @@ impl CommandLineHandler for ChainIdSubnet {
         log::debug!("get chain-id for subnet with args: {:?}", arguments);
 
         let provider = get_ipc_provider(global)?;
-        let subnet = SubnetID::from_str(&arguments.subnet)?;
+        let subnet = SubnetID::from_str(&arguments.network)?;
         let conn = match provider.connection(&subnet) {
             None => return Err(anyhow::anyhow!("target subnet not found")),
             Some(conn) => conn,
@@ -65,6 +65,6 @@ impl CommandLineHandler for ChainIdSubnet {
 #[derive(Debug, Args)]
 #[command(name = "chain-id", about = "Chain ID endpoint for a subnet")]
 pub struct ChainIdSubnetArgs {
-    #[arg(long, help = "The subnet to get the Chain ID from")]
-    pub subnet: String,
+    #[arg(long, help = "The network to get the Chain ID from")]
+    pub network: String,
 }


### PR DESCRIPTION
Closes ENG-639

Please the discussion in linear ticket. Not sure what other subnet commands should adopt this change.