### PR TITLE
instrument tracing

### DIFF
--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -40,6 +40,7 @@ use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use tendermint::abci::request::CheckTxKind;
 use tendermint::abci::{request, response};
+use tracing::instrument;
 
 use crate::{tmconv::*, VERSION};
 use crate::{BlockHeight, APP_VERSION};
@@ -743,6 +744,7 @@ where
     }
 
     /// Signals the end of a block.
+    #[instrument(skip(self))]
     async fn end_block(&self, request: request::EndBlock) -> AbciResult<response::EndBlock> {
         tracing::debug!(height = request.height, "end block");
 

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -744,7 +744,7 @@ where
     }
 
     /// Signals the end of a block.
-    #[instrument(skip(self))]
+    #[instrument(name = "new-block", skip(self))]
     async fn end_block(&self, request: request::EndBlock) -> AbciResult<response::EndBlock> {
         tracing::debug!(height = request.height, "end block");
 

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -45,7 +45,7 @@ fn init_tracing(opts: &options::Options) -> Option<WorkerGuard> {
         Some(
             fmt::Layer::new()
                 .json()
-                .with_span_events(FmtSpan::CLOSE)
+                .with_span_events(FmtSpan::FULL)
                 .with_writer(non_blocking.with_max_level(log_level))
                 .with_target(false)
                 .with_file(true)

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -58,7 +58,6 @@ fn init_tracing(opts: &options::Options) -> Option<WorkerGuard> {
     // we also log all traces with level INFO or higher to stdout
     let registry = registry.with(
         tracing_subscriber::fmt::layer()
-            .with_span_events(FmtSpan::CLOSE)
             .with_writer(std::io::stdout.with_max_level(tracing::Level::INFO))
             .with_target(false)
             .with_file(true)

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -11,6 +11,8 @@ use tracing_subscriber::{
     fmt::{self, writer::MakeWriterExt},
     layer::SubscriberExt,
 };
+use tracing_subscriber::fmt::format::FmtSpan;
+
 mod cmd;
 
 fn init_tracing(opts: &options::Options) -> Option<WorkerGuard> {
@@ -55,6 +57,7 @@ fn init_tracing(opts: &options::Options) -> Option<WorkerGuard> {
     // we also log all traces with level INFO or higher to stdout
     let registry = registry.with(
         tracing_subscriber::fmt::layer()
+            .with_span_events(FmtSpan::CLOSE)
             .with_writer(std::io::stdout.with_max_level(tracing::Level::INFO))
             .with_target(false)
             .with_file(true)

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -45,6 +45,7 @@ fn init_tracing(opts: &options::Options) -> Option<WorkerGuard> {
         Some(
             fmt::Layer::new()
                 .json()
+                .with_span_events(FmtSpan::CLOSE)
                 .with_writer(non_blocking.with_max_level(log_level))
                 .with_target(false)
                 .with_file(true)

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -7,11 +7,11 @@ use tracing_appender::{
     non_blocking::WorkerGuard,
     rolling::{RollingFileAppender, Rotation},
 };
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::{
     fmt::{self, writer::MakeWriterExt},
     layer::SubscriberExt,
 };
-use tracing_subscriber::fmt::format::FmtSpan;
 
 mod cmd;
 

--- a/fendermint/vm/interpreter/src/fvm/state/ipc.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/ipc.rs
@@ -29,6 +29,8 @@ use ipc_actors_abis::{checkpointing_facet, top_down_finality_facet, xnet_messagi
 use ipc_api::cross::IpcEnvelope;
 use ipc_api::staking::{ConfigurationNumber, StakingChangeRequest};
 
+use tracing::instrument;
+
 use super::{
     fevm::{ContractCaller, MockProvider, NoRevert},
     FvmExecState,
@@ -122,6 +124,7 @@ impl<DB: Blockstore + Clone> GatewayCaller<DB> {
     }
 
     /// Insert a new checkpoint at the period boundary.
+    #[instrument(skip(self, state))]
     pub fn create_bottom_up_checkpoint(
         &self,
         state: &mut FvmExecState<DB>,
@@ -151,6 +154,7 @@ impl<DB: Blockstore + Clone> GatewayCaller<DB> {
     }
 
     /// Apply all pending validator changes, returning the newly adopted configuration number, or 0 if there were no changes.
+    #[instrument(skip(self, state))]
     pub fn apply_validator_changes(&self, state: &mut FvmExecState<DB>) -> anyhow::Result<u64> {
         self.topdown.call(state, |c| c.apply_finality_changes())
     }
@@ -225,6 +229,7 @@ impl<DB: Blockstore + Clone> GatewayCaller<DB> {
 
     /// Commit the parent finality to the gateway and returns the previously committed finality.
     /// None implies there is no previously committed finality.
+    #[instrument(skip(self, state))]
     pub fn commit_parent_finality(
         &self,
         state: &mut FvmExecState<DB>,
@@ -262,6 +267,7 @@ impl<DB: Blockstore + Clone> GatewayCaller<DB> {
     }
 
     /// Call this function to mint some FIL to the gateway contract
+    #[instrument(name = "increase_circulation", skip(self, state))]
     pub fn mint_to_gateway(
         &self,
         state: &mut FvmExecState<DB>,

--- a/fendermint/vm/interpreter/src/fvm/state/ipc.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/ipc.rs
@@ -124,7 +124,7 @@ impl<DB: Blockstore + Clone> GatewayCaller<DB> {
     }
 
     /// Insert a new checkpoint at the period boundary.
-    #[instrument(skip(self, state))]
+    #[instrument(name = "new-bottomup_checkpoint", skip(self, state))]
     pub fn create_bottom_up_checkpoint(
         &self,
         state: &mut FvmExecState<DB>,
@@ -154,7 +154,7 @@ impl<DB: Blockstore + Clone> GatewayCaller<DB> {
     }
 
     /// Apply all pending validator changes, returning the newly adopted configuration number, or 0 if there were no changes.
-    #[instrument(skip(self, state))]
+    #[instrument(name = "validator-changes", skip(self, state))]
     pub fn apply_validator_changes(&self, state: &mut FvmExecState<DB>) -> anyhow::Result<u64> {
         self.topdown.call(state, |c| c.apply_finality_changes())
     }
@@ -229,7 +229,7 @@ impl<DB: Blockstore + Clone> GatewayCaller<DB> {
 
     /// Commit the parent finality to the gateway and returns the previously committed finality.
     /// None implies there is no previously committed finality.
-    #[instrument(skip(self, state))]
+    #[instrument(name = "new-parent-finality", skip(self, state))]
     pub fn commit_parent_finality(
         &self,
         state: &mut FvmExecState<DB>,
@@ -267,7 +267,6 @@ impl<DB: Blockstore + Clone> GatewayCaller<DB> {
     }
 
     /// Call this function to mint some FIL to the gateway contract
-    #[instrument(name = "increase_circulation", skip(self, state))]
     pub fn mint_to_gateway(
         &self,
         state: &mut FvmExecState<DB>,

--- a/fendermint/vm/topdown/src/finality/fetch.rs
+++ b/fendermint/vm/topdown/src/finality/fetch.rs
@@ -12,6 +12,7 @@ use async_stm::{Stm, StmResult};
 use ipc_api::cross::IpcEnvelope;
 use ipc_api::staking::StakingChangeRequest;
 use std::sync::Arc;
+use tracing::instrument;
 
 /// The finality provider that performs io to the parent if not found in cache
 #[derive(Clone)]
@@ -119,6 +120,7 @@ impl<T: ParentQueryProxy + Send + Sync + 'static> ParentFinalityProvider
         self.inner.check_proposal(proposal)
     }
 
+    #[instrument(skip(self))]
     fn set_new_finality(
         &self,
         finality: IPCParentFinality,

--- a/fendermint/vm/topdown/src/finality/fetch.rs
+++ b/fendermint/vm/topdown/src/finality/fetch.rs
@@ -120,7 +120,7 @@ impl<T: ParentQueryProxy + Send + Sync + 'static> ParentFinalityProvider
         self.inner.check_proposal(proposal)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "new-topdown-finality", skip(self))]
     fn set_new_finality(
         &self,
         finality: IPCParentFinality,

--- a/fendermint/vm/topdown/src/finality/null.rs
+++ b/fendermint/vm/topdown/src/finality/null.rs
@@ -67,7 +67,7 @@ impl FinalityWithNull {
         self.last_committed_finality.write(Some(finality))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "new-parent-view", skip(self))]
     pub fn new_parent_view(
         &self,
         height: BlockHeight,

--- a/fendermint/vm/topdown/src/finality/null.rs
+++ b/fendermint/vm/topdown/src/finality/null.rs
@@ -9,6 +9,7 @@ use async_stm::{abort, atomically, Stm, StmResult, TVar};
 use ipc_api::cross::IpcEnvelope;
 use ipc_api::staking::StakingChangeRequest;
 use std::cmp::min;
+use tracing::instrument;
 
 /// Finality provider that can handle null blocks
 #[derive(Clone)]
@@ -66,6 +67,7 @@ impl FinalityWithNull {
         self.last_committed_finality.write(Some(finality))
     }
 
+    #[instrument(skip(self))]
     pub fn new_parent_view(
         &self,
         height: BlockHeight,


### PR DESCRIPTION
Closing ENG-657

Adding instrument attribute to emit IPC events in fendermint. Currently the span include the full span lifecycle such as `enter` and all the way to `close`, example:
```
{"timestamp":"2024-02-19T10:45:08.270754Z","level":"INFO","fields":{"message":"enter"},"filename":"fendermint/app/src/app.rs","line_number":747,"span":{"request":"EndBlock { height: 984 }","name":"new-block"},"spans":[{"request":"EndBlock { height: 984 }","name":"new-block"}]}
{"timestamp":"2024-02-19T10:45:08.273989Z","level":"INFO","fields":{"message":"exit"},"filename":"fendermint/app/src/app.rs","line_number":747,"span":{"request":"EndBlock { height: 984 }","name":"new-block"},"spans":[]}
```
We can tune this in the future once we have grafana up to save log spaces, but so far it should work now.