### PR TITLE
FIX: Serve empty log_type

### DIFF
--- a/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/eth/api/examples/ethers.rs
@@ -600,7 +600,7 @@ where
     let receipt = request(
         "eth_sendRawTransaction",
         send_transaction(&mw, coin_send.tx, "coin_send").await,
-        |receipt| !receipt.logs.is_empty(),
+        |receipt| !receipt.logs.is_empty() && receipt.logs.iter().all(|l| l.log_type.is_none()),
     )?;
 
     tracing::info!(tx_hash = ?receipt.transaction_hash, "coin sent");

--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -493,6 +493,9 @@ pub fn to_logs(
         let (topics, data) =
             to_topics_and_data(&event.attributes).context("failed to collect topics and data")?;
 
+        // Blockscout doesn't recognise the `logType` field since https://github.com/blockscout/blockscout/pull/9007
+        let log_type = None; // Some(event.kind.clone()),
+
         let log = et::Log {
             address,
             topics,
@@ -503,7 +506,7 @@ pub fn to_logs(
             transaction_index: Some(transaction_index),
             log_index: Some(et::U256::from(idx + log_index_start)),
             transaction_log_index: Some(et::U256::from(idx)),
-            log_type: Some(event.kind.clone()),
+            log_type,
             removed: Some(false),
         };
 


### PR DESCRIPTION
Fixes https://filecoinproject.slack.com/archives/C04JR5R1UL8/p1708372636330179

Blockscout stopped being able to process logs, with errors such as these:

```json
{
  "time": "2024-02-19T19:50:44.490Z",
  "severity": "error",
  "message": "Task #PID<0.4936.0> started from #PID<0.4911.0> terminating\n** (FunctionClauseError) no function clause matching in EthereumJSONRPC.Log.entry_to_elixir/1\n    (ethereum_jsonrpc 6.1.0) lib/ethereum_jsonrpc/log.ex:165: EthereumJSONRPC.Log.entry_to_elixir({\"logType\", \"event\"})\n    (elixir 1.14.5) lib/enum.ex:1662: anonymous fn/3 in Enum.map/2\n    (stdlib 3.17) maps.erl:410: :maps.fold_1/3\n    (elixir 1.14.5) lib/enum.ex:2480: Enum.map/2\n    (elixir 1.14.5) lib/enum.ex:1552: Enum.into/3\n    (elixir 1.14.5) lib/enum.ex:1658: Enum.\"-map/2-lists^map/1-0-\"/2\n    (ethereum_jsonrpc 6.1.0) lib/ethereum_jsonrpc/receipt.ex:272: EthereumJSONRPC.Receipt.entry_to_elixir/1\n    (ethereum_jsonrpc 6.1.0) lib/ethereum_jsonrpc/receipt.ex:218: EthereumJSONRPC.Receipt.entry_reducer/2\nFunction: &:erlang.apply/2\n    Args: [#Function<0.13489359/1 in Indexer.Block.Fetcher.Receipts.fetch/2>, [[%{block_hash: \"0xa12245f66ddd516f84ec5de888455e262117b74e0a2b5cab3003d70545559f35\", block_number: 5304, block_timestamp: ~U[2024-02-19 14:30:03Z], from_address_hash: \"0x53deb1c404e73fe95bd293b8f9321d0e8722ab0f\", gas: 46818870, gas_price: 6000002000, hash: \"0x57cb76b7b90e790e2128f8ed0fb0ca794e25b6dff973793cff43a018e3a383c0\", index: 0, input: \"0x604060808152610410908138038061001681610218565b93843982019181818403126102135780516001600160a01b038116808203610213576020838101516001600160401b0394919391858211610213570186601f820112156102135780519061007161006c83610253565b610218565b918083528583019886828401011161021357888661008f930161026e565b813b156101b9577f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc80546001600160a01b031916841790556000927fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b8480a28051158015906101b2575b61010b575b855160cb90816103458239f35b855194606086019081118682101761019e578697849283926101889952602788527f416464726573733a206c6f772d6c6576656c2064656c65676174652063616c6c87890152660819985a5b195960ca1b8a8901525190845af4913d15610194573d9061017a61006c83610253565b91825281943d92013e610291565b508038808080806100fe565b5060609250610291565b634e487b7160e01b84526041600452602484fd5b50826100f9565b855162461bcd60e51b815260048101859052602d60248201527f455243313936373a206e657720696d706c656d656e746174696f6e206973206e60448201526c1bdd08184818dbdb9d1c9858dd609a1b6064820152608490fd5b600080fd5b6040519190601f01601f191682016001600160401b0381118382101761023d57604052565b634e487b7160e01b600052604160045260246000fd5b6001600160401b03811161023d57601f01601f191660200190565b60005b8381106102815750506000910152565b8181015183820152602001610271565b919290156102f357508151156102a5575090565b3b156102ae5790565b60405162461bcd60e51b815260206004820152601d60248201527f416464726573733a2063616c6c20746f206e6f6e2d636f6e74726163740000006044820152606490fd5b8251909150156103065750805190602001fd5b6044604051809262461bcd60e51b825260206004830152610336815180928160248601526020868601910161026e565b601f01601f19168101030190fdfe60806040523615604157600080516020607683398151915254600090819081906001600160a01b0316368280378136915af43d82803e15603d573d90f35b3d90fd5b600080516020607683398151915254600090819081906001600160a01b0316368280378136915af43d82803e15603d573d90f3fe360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbca2646970667358221220774b5970662b364ea702b36815a26800b8290f5fea74f8be4a1fafb2ccbcb61164736f6c6343000818003300000000000000000000000047987772feec0243518192ed32e0e54a78d70190000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000841f8d519d000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000006c3b3d676383aed5d9938c2268f1821f37d95b4900000000000000000000000000000000000000000000000000000000\", max_fee_per_gas: 3000002000, max_priority_fee_per_gas: 3000000000, nonce: 7, r: 41755926856674111601920176952942002958207143647180126155556419052983500325282, s: 20437137014078734918667417796416390771409529666095457085102554709025917242016, to_address_hash: nil, transaction_index: 0, type: 2, v: 0, value: 0}]]]",
  "metadata": {
    "error": {
      "initial_call": null,
      "reason": "** (FunctionClauseError) no function clause matching in EthereumJSONRPC.Log.entry_to_elixir/1\n    (ethereum_jsonrpc 6.1.0) lib/ethereum_jsonrpc/log.ex:165: EthereumJSONRPC.Log.entry_to_elixir({\"logType\", \"event\"})\n    (elixir 1.14.5) lib/enum.ex:1662: anonymous fn/3 in Enum.map/2\n    (stdlib 3.17) maps.erl:410: :maps.fold_1/3\n    (elixir 1.14.5) lib/enum.ex:2480: Enum.map/2\n    (elixir 1.14.5) lib/enum.ex:1552: Enum.into/3\n    (elixir 1.14.5) lib/enum.ex:1658: Enum.\"-map/2-lists^map/1-0-\"/2\n    (ethereum_jsonrpc 6.1.0) lib/ethereum_jsonrpc/receipt.ex:272: EthereumJSONRPC.Receipt.entry_to_elixir/1\n    (ethereum_jsonrpc 6.1.0) lib/ethereum_jsonrpc/receipt.ex:218: EthereumJSONRPC.Receipt.entry_reducer/2\n"
    }
  }
}
```

The crucial part is that `EthereumJSONRPC.Log.entry_to_elixir({\"logType\", \"event\"})` doesn't match any predicate.

The acceptable keys in logs are [here](https://github.com/blockscout/blockscout/blob/77d984d9155d24d93cdc34efd2bdb10f8a66251a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex#L166-L169). As it turns out `logType` was removed in https://github.com/blockscout/blockscout/pull/9007

This PR changes the ethereum API facade to return `None` in the log type, instead of the `event.kind` that we filled with some [provenance](https://github.com/consensus-shipyard/ipc/blob/c0ff059b03d7a2e7422368fbc61a272c93c1618f/fendermint/app/src/tmconv.rs#L82) that isn't really useful anyway, it was just to put in there something.