### PR TITLE
bugfix: use a more compatible syntax with bsd sed for mac users

### DIFF
--- a/scripts/deploy_subnet_under_calibration_net/deploy.sh
+++ b/scripts/deploy_subnet_under_calibration_net/deploy.sh
@@ -227,8 +227,8 @@ bootstrap_output=$(cargo make --makefile infra/fendermint/Makefile.toml \
     -e FM_PULL_SKIP=1 \
     child-validator 2>&1)
 echo "$bootstrap_output"
-bootstrap_node_id=$(echo "$bootstrap_output" | sed -n '/CometBFT node ID:/ {n;p}' | tr -d "[:blank:]")
-bootstrap_peer_id=$(echo "$bootstrap_output" | sed -n '/IPLD Resolver Multiaddress:/ {n;p}' | tr -d "[:blank:]" | sed 's/.*\/p2p\///')
+bootstrap_node_id=$(echo "$bootstrap_output" | sed -n '/CometBFT node ID:/ {n;p;}' | tr -d "[:blank:]")
+bootstrap_peer_id=$(echo "$bootstrap_output" | sed -n '/IPLD Resolver Multiaddress:/ {n;p;}' | tr -d "[:blank:]" | sed 's/.*\/p2p\///')
 echo "Bootstrap node started. Node id ${bootstrap_node_id}, peer id ${bootstrap_peer_id}"
 
 bootstrap_node_endpoint=${bootstrap_node_id}@validator-0-cometbft:${CMT_P2P_HOST_PORTS[0]}


### PR DESCRIPTION
This fixes an issue I have with the file `scripts/deploy_subnet_under_calibration_net/deploy.sh` failing on my mac with the error

```
sed: 1: "/CometBFT node ID:/ {n;p}": extra characters at the end of p command
```
The open bsd instance of sed on my mac expects a `;` after the `n;p` part of the sed command