### PR TITLE
fix(scripts/deploy): git submodule sync.

### DIFF
--- a/scripts/deploy_subnet_under_calibration_net/deploy.sh
+++ b/scripts/deploy_subnet_under_calibration_net/deploy.sh
@@ -117,6 +117,7 @@ if ! $local_deploy ; then
   git stash
   git checkout $head_ref
   git pull --rebase origin $head_ref
+  git submodule sync
   git submodule update --init --recursive
 fi
 


### PR DESCRIPTION
This makes the deploy script more resilient in the edge case that:

1. It's refreshing an existing environment where a local working copy exists.
2. Upstream altered the URLs of submodules.

Thanks to @snissn for suggesting this.