### PR TITLE
BUILD: Enable main-like behaviour on tagged commits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+    # Pattern matched against refs/tags
+    tags:
+      # Push events to every git tag not containing /
+      # NOTE: '**' would match tags with / in them, e.g. "foo/bar",
+      # but we want to use the tag as a docker tag as well, so it's best avoided.
+      - '*'
+
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,8 @@ jobs:
     needs: [changes]
     if: >-
       needs.changes.outputs.contracts == 'true' ||
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/main' ||
+      github.ref_type == 'tag'
 
   contracts-deployment-test:
     uses: ./.github/workflows/contracts-deployment-test.yaml
@@ -90,7 +91,8 @@ jobs:
       needs.changes.outputs.workspace == 'true' ||
       needs.changes.outputs.contracts == 'true' ||
       needs.changes.outputs.ipc == 'true' ||
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/main' ||
+      github.ref_type == 'tag'
 
   ipld-resolver:
     uses: ./.github/workflows/ipld-resolver.yaml
@@ -98,7 +100,8 @@ jobs:
     if: >-
       needs.changes.outputs.workspace == 'true' ||
       needs.changes.outputs.ipld-resolver == 'true' ||
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/main' ||
+      github.ref_type == 'tag'
 
   fendermint-test:
     uses: ./.github/workflows/fendermint-test.yaml
@@ -110,7 +113,8 @@ jobs:
       needs.changes.outputs.ipc == 'true' ||
       needs.changes.outputs.ipld-resolver == 'true' ||
       needs.changes.outputs.fendermint == 'true' ||
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/main' ||
+      github.ref_type == 'tag'
 
   fevm-contract-tests:
     uses: ./.github/workflows/fevm-contract-tests.yaml
@@ -122,7 +126,8 @@ jobs:
       needs.changes.outputs.ipc == 'true' ||
       needs.changes.outputs.ipld-resolver == 'true' ||
       needs.changes.outputs.fendermint == 'true' ||
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/main' ||
+      github.ref_type == 'tag'
 
   fendermint-publish:
     uses: ./.github/workflows/fendermint-publish.yaml
@@ -131,7 +136,9 @@ jobs:
     # It is because of these needs that all the filters are allowed to run on `main` too, otherwise this would be disabled.
     # It could be done in a more granular approach inside the workflows to allow the job to pass but opt-out of testing,
     # but I guess it doesn't hurt to run a final round of unconditional tests, even though it takes longer to publish.
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      github.ref_type == 'tag'
     needs:
       - contracts-test # generates the ABI artifacts (although fendermint can do on its own too)
       - ipc

--- a/.github/workflows/fendermint-publish.yaml
+++ b/.github/workflows/fendermint-publish.yaml
@@ -74,7 +74,7 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
           # This strips the "v" prefix from the tag name.
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
           # This uses the Docker `latest` tag convention.
           [ "$VERSION" == "main" ] && VERSION=latest

--- a/.github/workflows/fendermint-publish.yaml
+++ b/.github/workflows/fendermint-publish.yaml
@@ -17,7 +17,6 @@ jobs:
   # Publish Docker image on the main branch
   publish:
     name: Publish artifacts
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
The PR changes `ci.yaml` that previously on ran on `refs/heads/main` to also execute on tagged commits. The tag will become the tag of the docker release. 

So for example if we do `git tag hackathon` and `git push --tags` then it should build and push a `ghcr.io/consensus-shipyard/fendermint:hackathon` image. 

The code previously wanted to strip the `v` prefix from the tag, e.g. ff the tag was like `v1.2.3` then it would have produced `fendermint:1.2.3` image. I commented this out so it becomes `fendermint:v1.2.3`. CometBFT tags also have `v` in them, so I thought why not leave them as-is.

### Testing

I have done the above actually:
```shell
git checkout docker-push-tagged
git tag hackathon
git push --tagged
```

And it correctly triggered a build on this PR, even though no code changed and the first commit for example didn't run any of the tests. This should result in a docker image being pushed in the end.