### PR TITLE
FIX: Sync as many parent blocks as we can.

### DIFF
--- a/fendermint/vm/topdown/src/sync/tendermint.rs
+++ b/fendermint/vm/topdown/src/sync/tendermint.rs
@@ -26,6 +26,8 @@ where
         }
     }
 
+    /// Sync with the parent, unless CometBFT is still catching up with the network,
+    /// in which case we'll get the changes from the subnet peers in the blocks.
     pub async fn sync(&mut self) -> anyhow::Result<()> {
         if self.is_syncing_peer().await? {
             tracing::debug!("syncing with peer, skip parent finality syncing this round");


### PR DESCRIPTION
The PR changes the `LotusParentSyncer::sync` method to by default sync as many blocks as it can, until it either reaches the top of the finalized chain, or fills the cache to the brim. This is so that we don't sync 1 block per 10s when trying to catch up with a long history, e.g. after opening up a developer laptop in the morning.