### PR TITLE
FIX: vm_event cargo.toml warnings

### DIFF
--- a/fendermint/vm/event/Cargo.toml
+++ b/fendermint/vm/event/Cargo.toml
@@ -5,9 +5,8 @@ version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
-license-file.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-strum = { worspace = true }
+strum = { workspace = true }


### PR DESCRIPTION
Fixes build warnings caused by duplicate license key _and_ a typo (`worspace`) causing the strum dependency to be malformed.

```
warning: /home/ubuntu/ipc/fendermint/vm/event/Cargo.toml: only one of `license` or `license-file` is necessary
`license` should be used if the package license can be expressed with a standard SPDX expression.
`license-file` should be used if the package uses a non-standard license.
See https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields for more information.
warning: /home/ubuntu/ipc/fendermint/vm/event/Cargo.toml: dependency (strum) specified without providing a local path, Git repository, version, or workspace dependency to use. This will be considered an error in future versions
warning: /home/ubuntu/ipc/fendermint/vm/event/Cargo.toml: unused manifest key: dependencies.strum.worspace
```