### PR TITLE
ENG-749: Try to parse any revert coming from the EVM as string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,7 +3183,7 @@ dependencies = [
 name = "fendermint_vm_event"
 version = "0.1.0"
 dependencies = [
- "strum 0.25.0",
+ "strum 0.26.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2959,6 +2959,7 @@ dependencies = [
  "clap 4.5.1",
  "erased-serde",
  "ethers",
+ "ethers-contract",
  "ethers-core",
  "fendermint_crypto",
  "fendermint_rpc",

--- a/fendermint/eth/api/Cargo.toml
+++ b/fendermint/eth/api/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
 ethers-core = { workspace = true }
+ethers-contract = { workspace = true }
 erased-serde = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -635,7 +635,11 @@ where
         // Ok(et::TxHash::from_slice(res.hash.as_bytes()))
         Ok(msghash)
     } else {
-        error_with_revert(ExitCode::new(res.code.value()), res.log, res.data.to_vec())
+        error_with_revert(
+            ExitCode::new(res.code.value()),
+            res.log,
+            Some(res.data.to_vec()),
+        )
     }
 }
 
@@ -657,10 +661,10 @@ where
     if deliver_tx.code.is_err() {
         // There might be some revert data encoded as ABI in the response.
         let (msg, data) = match decode_fevm_invoke(&deliver_tx) {
-            Ok(h) => (deliver_tx.info, h),
+            Ok(h) => (deliver_tx.info, Some(h)),
             Err(e) => (
                 format!("{}\nfailed to decode return data: {:#}", deliver_tx.info, e),
-                Vec::new(),
+                None,
             ),
         };
         error_with_revert(ExitCode::new(deliver_tx.code.value()), msg, data)
@@ -715,8 +719,8 @@ where
         // There might be some revert data encoded as ABI in the response.
         let msg = format!("failed to estimate gas: {}", estimate.info);
         let (msg, data) = match decode_fevm_return_data(estimate.return_data) {
-            Ok(h) => (msg, h),
-            Err(e) => (format!("{msg}\n{e:#}"), Vec::new()),
+            Ok(h) => (msg, Some(h)),
+            Err(e) => (format!("{msg}\n{e:#}"), None),
         };
         error_with_revert(estimate.exit_code, msg, data)
     } else {


### PR DESCRIPTION
Followup for https://github.com/consensus-shipyard/ipc/pull/728

The PR tries to parse the message coming from Solidity `revert` and `require` and attach it to the message returned in the JSON-RPC response, so we don't have to eyeball the hexadecimal output (if there is one) and parse it (how?).