### PR TITLE
Update metamask instructions to use ipc-cli

### DIFF
--- a/docs/ipc/contracts.md
+++ b/docs/ipc/contracts.md
@@ -8,12 +8,12 @@ IPC subnets have the same exact support for the deployment of EVM contracts as t
 In order to connect the Ethereum tooling to your subnet, you'll need to get the RPC endpoint of your subnet peer and the subnet's `chainID`. For this, you can use the following command from your IPC agent to retrieve the RPC endpoint for a specific subnet: 
 
 ```bash
-./bin/ipc-agent subnet rpc --subnet <subnet-id>
+ipc-cli subnet rpc --network <subnet-id>
 
 # Sample command
-$ ./bin/ipc-agent subnet rpc --subnet /r31415926/t2xwzbdu7z5sam6hc57xxwkctciuaz7oe5omipwbq
-rpc: http://127.0.0.1:1240/rpc/v1
-chainID: 31415926
+$ ipc-cli subnet rpc --network /r31415926/t2xwzbdu7z5sam6hc57xxwkctciuaz7oe5omipwbq
+rpc: "http://0.0.0.0:8545/"
+chainID: "1874254988642837"
 ```
 
 
@@ -35,6 +35,7 @@ To connect Metamask to your subnet, you need to add it as a new network. To do t
 
 With this your Metamask should be successfully connected to your subnet, and you should be able to interact with it seamlessly as described in the [Filecoin docs](https://docs.filecoin.io/smart-contracts/fundamentals/overview/).
 
+>💡 Note that your browser may require an HTTPS endpoint or CORS headers. In that case, you may need to perform additional configuration, e.g. deploy a reverse proxy in front of your endpoint.
 
 ## Deploying a contract in your subnet
 
@@ -43,9 +44,9 @@ To deploy a smart contract in your subnet the only pre-requirement is to have so
 It is important to note that the IPC agent doesn't understand Ethereum addresses directly, which means that to send funds to an Ethereum address, you will need to send funds to their underlying f4 address. You can use the following command from the IPC agent to get the f4 address for an Ethereum address: 
 
 ```bash
-./bin/ipc-agent util eth-to-f4-addr --addr <eth-adddress>
+ipc-cli util eth-to-f4-addr --addr <eth-adddress>
 
-$ ./bin/ipc-agent util eth-to-f4-addr --addr 0x6BE1Ccf648c74800380d0520D797a170c808b624
+$ ipc-cli util eth-to-f4-addr --addr 0x6BE1Ccf648c74800380d0520D797a170c808b624
 t410fnpq4z5siy5eaaoanauqnpf5bodearnren5fxyoi
 ```
 


### PR DESCRIPTION
contracts.md still referred to ipc-agent and wrong params. There is an inbound link from the [quickstart](https://docs.ipc.space/quickstarts/deploy-a-subnet#step-8-interact-with-your-the-eth-rpc).

I would actually prefer to close this PR and just delete these stale docs. We should no longer have docs in this repo at this stage.