### PR TITLE
FIX: Adjust query height in the eth api

### DIFF
--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -137,7 +137,10 @@ where
     /// Get the height of the latest commit.
     pub async fn latest_height(&self) -> JsonRpcResult<tendermint::block::Height> {
         let res: commit::Response = self.tm().latest_commit().await?;
-        Ok(res.signed_header.header.height)
+        // Return -1 so we don't risk having no data to serve.
+        let h = res.signed_header.header.height.value();
+        let h = h.saturating_sub(1);
+        Ok(Height::try_from(h).context("decrementing should be fine")?)
     }
 
     /// Get the Tendermint block at a specific height.
@@ -221,10 +224,13 @@ where
 
     /// Return the height of a block which we should send with a query,
     /// or None if it's the latest, to let the node figure it out.
+    ///
+    /// Adjusts the height of the query to +1 so the effects of the block is visible.
     pub async fn query_height(&self, block_id: et::BlockId) -> JsonRpcResult<FvmQueryHeight> {
         match block_id {
             et::BlockId::Number(bn) => match bn {
-                et::BlockNumber::Number(height) => Ok(FvmQueryHeight::from(height.as_u64())),
+                // The client might be asking by height of a block, expecting to see the results.
+                et::BlockNumber::Number(height) => Ok(FvmQueryHeight::from(height.as_u64() + 1)),
                 et::BlockNumber::Finalized | et::BlockNumber::Latest | et::BlockNumber::Safe => {
                     Ok(FvmQueryHeight::Committed)
                 }
@@ -232,8 +238,9 @@ where
                 et::BlockNumber::Earliest => Ok(FvmQueryHeight::Height(1)),
             },
             et::BlockId::Hash(h) => {
+                // The effects of this block are saved at the next height.
                 let header = self.header_by_hash(h).await?;
-                Ok(FvmQueryHeight::Height(header.height.value()))
+                Ok(FvmQueryHeight::Height(header.height.value() + 1))
             }
         }
     }

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -226,6 +226,15 @@ where
     /// or None if it's the latest, to let the node figure it out.
     ///
     /// Adjusts the height of the query to +1 so the effects of the block is visible.
+    /// The node stores the results at height+1 to be consistent with how CometBFT works,
+    /// ie. the way it publishes the state hash in the *next* block.
+    ///
+    /// The assumption here is that the client got the height from one of two sources:
+    /// * by calling the `latest_height` method above, which adjusts it down,
+    ///   so that the returned height is one which is surely executed
+    /// * by getting a block (e.g. from a subscription) which was already executed
+    ///
+    /// In both cases we know that there should be state stored at height + 1.
     pub async fn query_height(&self, block_id: et::BlockId) -> JsonRpcResult<FvmQueryHeight> {
         match block_id {
             et::BlockId::Number(bn) => match bn {


### PR DESCRIPTION
Ethereum tools like The Graph expect that they can query the _effects_ of the execution of block H at height H. This can lead to problems: for example we deploy a contract at H and it will send an `eth_call` to it at H, but it doesn't exist, because the application state is saved at H+1 to be in line with https://docs.cometbft.com/v0.34/spec/abci/abci#query-1

I did it this way because I think it's important that the CometBFT description of what height to set in queries is respected, even if we don't support proofs based on the state hash. I didn't know what ethereum tools expected, only catered for them by lying about what the latest block height is, so they don't ask for results.

Let's see if the integration tests break. 