### PR TITLE
CI: Build and test

### DIFF
--- a/.github/workflows/fendermint-test.yaml
+++ b/.github/workflows/fendermint-test.yaml
@@ -46,8 +46,13 @@ jobs:
         make:
           - name: Clippy
             task: check-clippy
-          - name: Test
-            task: test
+          # Technically it's not necessary to build, testing would be fine on its own.
+          # However, tests bring in dev-dependencies, and without them something might not compile,
+          # which we want to catch as it would mean the `cargo build` in the docs would fail.
+          # Doing it a one step so build artifacts can be reused by the tests, minimising the overhead.
+          - name: Build and Test
+            task: build test
+          # Tests that involve docker.
           - name: End-to-End
             task: e2e
         exclude:

--- a/fendermint/Makefile
+++ b/fendermint/Makefile
@@ -26,7 +26,7 @@ BUILDX_FLAGS ?=
 # Set to the `<repo>/<image>:<tag>` label the image.
 BUILDX_TAG   ?= fendermint:latest
 
-all: test build diagrams
+all: lint build test diagrams docker-build
 
 diagrams:
 	make -C  ../docs/fendermint/diagrams diagrams

--- a/fendermint/testing/materializer/Cargo.toml
+++ b/fendermint/testing/materializer/Cargo.toml
@@ -16,6 +16,7 @@ bollard = { workspace = true }
 ethers = { workspace = true }
 fvm_shared = { workspace = true }
 hex = { workspace = true }
+lazy_static = { workspace = true }
 multihash = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
@@ -25,7 +26,6 @@ tendermint-rpc = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
-lazy_static = { workspace = true, optional = true }
 arbitrary = { workspace = true, optional = true }
 quickcheck = { workspace = true, optional = true }
 
@@ -60,7 +60,6 @@ default = []
 arb = [
   "arbitrary",
   "quickcheck",
-  "lazy_static",
   "fvm_shared/arb",
   "fendermint_testing/arb",
   "fendermint_vm_genesis/arb",


### PR DESCRIPTION
Changes the `fendermint-test` workflow to run `make build test` rather than just `make test`, so that we can catch any problems with the build when the tests are not enabled. Hopefully this results in minimal overhead, although that might not be the case if adding the optional features enabled by testing means the artifacts aren't reused. 

With caching tests run as fast as 11 minutes, so let's see how it goes. The `e2e` tests take much longer anyway. 