### PR TITLE
DEBUG: Add logs between fetch data and caching

### DIFF
--- a/fendermint/vm/topdown/src/sync/mod.rs
+++ b/fendermint/vm/topdown/src/sync/mod.rs
@@ -174,6 +174,7 @@ fn start_syncing<T, C, P>(
     P: ParentQueryProxy + Send + Sync + 'static,
 {
     let mut interval = tokio::time::interval(config.polling_interval);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     tokio::spawn(async move {
         let lotus_syncer =

--- a/fendermint/vm/topdown/src/sync/syncer.rs
+++ b/fendermint/vm/topdown/src/sync/syncer.rs
@@ -193,7 +193,17 @@ where
 
             let data = self.fetch_data(to_confirm_height, to_confirm_hash).await?;
 
+            tracing::debug!(
+                height,
+                staking_requests = data.1.len(),
+                cross_messages = data.2.len(),
+                "fetched data"
+            );
+
             atomically_or_err::<_, Error, _>(|| {
+                // This is here so we see if there is abnormal amount of retries for some reason.
+                tracing::debug!(height, "adding data to the cache");
+
                 // we only push the null block in cache when we confirmed a block so that in cache
                 // the latest height is always a confirmed non null block.
                 let latest_height = self


### PR DESCRIPTION
Following the log debug session on [Slack](https://filecoinproject.slack.com/archives/C04JR5R1UL8/p1709136261858299?thread_ts=1709059894.660889&cid=C04JR5R1UL8) I see that [these lines](https://github.com/consensus-shipyard/ipc/blob/3bcef484642775c3c259c603af534708ef3d329f/fendermint/vm/topdown/src/sync/syncer.rs#L191-L217) can take up to 15 minutes to execute. It could be some freakishly slow API calls or (:confounded:) STM live- or deadlocking. 

The PR adds some logging in between these. 

Suspicious logs:

```
"2024-02-27T19:44:01.278908Z", "message":"syncing heights","chain_head":1391238,"pointers":"{tail: {height: 1391199, hash: 9bdf3eae78d33514b3cf262cc16eca91a75845361a906606b660afadbba72390}, head: 1391199}"},"filename":"fendermint/vm/topdown/src/sync/syncer.rs","line_number":96}
"2024-02-27T19:44:01.278919Z", "message":"previous non null parent is the pending confirmation block","pending_height":1391199},"filename":"fendermint/vm/topdown/src/sync/syncer.rs","line_number":276}
"2024-02-27T19:44:01.278923Z", "message":"polling height with parent hash","height":1391200,"parent_block_hash":"9bdf3eae78d33514b3cf262cc16eca91a75845361a906606b660afadbba72390"},"filename":"fendermint/vm/topdown/src/sync/syncer.rs","line_number":156}
"2024-02-27T19:57:35.657267Z", "message":"non-null round at height, confirmed previous height","height":1391200,"confirm":1391199},"filename":"fendermint/vm/topdown/src/sync/syncer.rs","line_number":188}
"2024-02-27T19:57:38.369043Z", "message":"non-null block pushed to cache","height":1391199},"filename":"fendermint/vm/topdown/src/sync/syncer.rs","line_number":217}
```

In this :point_up: instance it looks like 12 minutes spent between [polling the parent hash](https://github.com/consensus-shipyard/ipc/blob/3bcef484642775c3c259c603af534708ef3d329f/fendermint/vm/topdown/src/sync/syncer.rs#L159) and [just before fetching the data](https://github.com/consensus-shipyard/ipc/blob/3bcef484642775c3c259c603af534708ef3d329f/fendermint/vm/topdown/src/sync/syncer.rs#L191), then 3s to fetch the data and write to cache. 


```
"2024-02-27T19:58:31.807000Z", "message":"previous non null parent is the pending confirmation block","pending_height":1391211},"filename":"fendermint/vm/topdown/src/sync/syncer.rs","line_number":276}
"2024-02-27T19:58:31.807003Z", "message":"polling height with parent hash","height":1391212,"parent_block_hash":"dd0bb9a330d94a6d2de94f496192bf4eee57930dfaac2b59cc03ea388488d3eb"},"filename":"fendermint/vm/topdown/src/sync/syncer.rs","line_number":156}
"2024-02-27T19:58:32.996770Z", "message":"non-null round at height, confirmed previous height","height":1391212,"confirm":1391211},"filename":"fendermint/vm/topdown/src/sync/syncer.rs","line_number":188}
"2024-02-27T20:15:04.075883Z", "message":"non-null block pushed to cache","height":1391211},"filename":"fendermint/vm/topdown/src/sync/syncer.rs","line_number":217}
```
In this :point_up: one 17 minutes go past that include fetching data and writing it to the cache.