### PR TITLE
ENG-770: Accept log filter expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,6 +2905,7 @@ dependencies = [
 name = "fendermint_app_options"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bytes",
  "cid",
  "clap 4.5.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,9 +2916,11 @@ dependencies = [
  "hex",
  "ipc-api",
  "ipc-types",
+ "lazy_static",
  "num-traits",
  "tendermint-rpc",
  "tracing",
+ "tracing-subscriber",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ bollard = "0.15"
 blake2b_simd = "1.0"
 bloom = "0.3"
 bytes = "1.4"
-clap = { version = "4.1", features = ["derive", "env"] }
+clap = { version = "4.1", features = ["derive", "env", "string"] }
 config = "0.13"
 dirs = "5.0"
 dircpy = "0.3"

--- a/fendermint/.gitignore
+++ b/fendermint/.gitignore
@@ -8,3 +8,4 @@ testing/materializer/tests/docker-materializer-data
 .idea
 .make
 .contracts-gen
+.vscode

--- a/fendermint/app/options/Cargo.toml
+++ b/fendermint/app/options/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true }
 hex = { workspace = true }

--- a/fendermint/app/options/Cargo.toml
+++ b/fendermint/app/options/Cargo.toml
@@ -13,9 +13,11 @@ license.workspace = true
 bytes = { workspace = true }
 clap = { workspace = true }
 hex = { workspace = true }
+lazy_static = { workspace = true }
 num-traits = { workspace = true }
 tendermint-rpc = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 cid = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/fendermint/app/options/src/log.rs
+++ b/fendermint/app/options/src/log.rs
@@ -35,18 +35,11 @@ impl LogLevel {
         }
     }
 
-    pub fn to_filter(&self) -> anyhow::Result<Option<EnvFilter>> {
-        if let LogLevel::Off = self {
-            // NOTE: We could just pass "off" to `EnvFilter` and return non-optional.
-            return Ok(None);
-        }
-
+    pub fn to_filter(&self) -> anyhow::Result<EnvFilter> {
         // At this point the filter should have been parsed before,
         // but if we created a log level directly, it can fail.
         // We fail if it doesn't parse because presumably we _want_ to see those things.
-        let filter = EnvFilter::try_new(self.as_str())?;
-
-        Ok(Some(filter))
+        Ok(EnvFilter::try_new(self.as_str())?)
     }
 }
 

--- a/fendermint/app/options/src/log.rs
+++ b/fendermint/app/options/src/log.rs
@@ -21,9 +21,9 @@ pub enum LogLevel {
 }
 
 impl LogLevel {
-    pub fn to_filter(&self) -> Option<EnvFilter> {
+    pub fn to_filter(&self) -> anyhow::Result<Option<EnvFilter>> {
         let filter = match self {
-            LogLevel::Off => return None,
+            LogLevel::Off => return Ok(None),
             LogLevel::Filter(s) => s,
             LogLevel::Error => "error",
             LogLevel::Warn => "warn",
@@ -31,7 +31,13 @@ impl LogLevel {
             LogLevel::Debug => "debug",
             LogLevel::Trace => "trace",
         };
-        Some(EnvFilter::new(filter))
+
+        // At this point the filter should have been parsed before,
+        // but if we created a log level directly, it can fail.
+        // We fail if it doesn't parse because presumably we _want_ to see those things.
+        let filter = EnvFilter::try_new(filter)?;
+
+        Ok(Some(filter))
     }
 }
 

--- a/fendermint/app/options/src/log.rs
+++ b/fendermint/app/options/src/log.rs
@@ -1,0 +1,78 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use clap::{builder::PossibleValue, ValueEnum};
+
+use lazy_static::lazy_static;
+use tracing_subscriber::EnvFilter;
+
+/// Standard log levels, or something we can pass to <https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html>
+///
+/// To be fair we could pass of everything except "off" as a filter.
+#[derive(Debug, Clone)]
+pub enum LogLevel {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+    Filter(String),
+}
+
+impl LogLevel {
+    pub fn to_filter(&self) -> Option<EnvFilter> {
+        let filter = match self {
+            LogLevel::Off => return None,
+            LogLevel::Filter(s) => s,
+            LogLevel::Error => "error",
+            LogLevel::Warn => "warn",
+            LogLevel::Info => "info",
+            LogLevel::Debug => "debug",
+            LogLevel::Trace => "trace",
+        };
+        Some(EnvFilter::new(filter))
+    }
+}
+
+impl ValueEnum for LogLevel {
+    fn value_variants<'a>() -> &'a [Self] {
+        lazy_static! {
+            static ref VARIANTS: Vec<LogLevel> = vec![
+                LogLevel::Off,
+                LogLevel::Error,
+                LogLevel::Warn,
+                LogLevel::Info,
+                LogLevel::Debug,
+                LogLevel::Trace,
+            ];
+        }
+
+        &VARIANTS
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        let pv = |name: &str| Some(PossibleValue::new(name.to_lowercase()));
+        match self {
+            LogLevel::Off => pv("Off"),
+            LogLevel::Error => pv("Error"),
+            LogLevel::Warn => pv("Warn"),
+            LogLevel::Info => pv("Info"),
+            LogLevel::Debug => pv("Debug"),
+            LogLevel::Trace => pv("Trace"),
+            LogLevel::Filter(_) => None,
+        }
+    }
+}
+
+pub fn parse_log_level(s: &str) -> Result<LogLevel, String> {
+    if let Ok(lvl) = ValueEnum::from_str(s, true) {
+        return Ok(lvl);
+    }
+    // `EnvFilter` is not `Clone`, so we can't store it, but we can use it to validate early.
+    if let Err(e) = EnvFilter::try_new(s) {
+        Err(e.to_string())
+    } else {
+        Ok(LogLevel::Filter(s.to_string()))
+    }
+}

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -19,7 +19,7 @@ mod cmd;
 fn init_tracing(opts: &options::Options) -> Option<WorkerGuard> {
     let mut guard = None;
 
-    let Some(tracing_filter) = opts.tracing_filter() else {
+    let Some(tracing_filter) = opts.tracing_filter().expect("failed to create filter") else {
         return guard;
     };
 

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -57,10 +57,10 @@ fn init_tracing(opts: &options::Options) -> Option<WorkerGuard> {
         _ => None,
     });
 
-    // we also log all traces to stdout
+    // we also log all traces to stderr (reserving stdout for any actual output such as from the CLI commands)
     let registry = registry.with(console_filter.map(|filter| {
         tracing_subscriber::fmt::layer()
-            .with_writer(std::io::stdout)
+            .with_writer(std::io::stderr)
             .with_target(false)
             .with_file(true)
             .with_line_number(true)


### PR DESCRIPTION
The PR adds support for more complex log filters to be passed and uses an [EnvFilter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) instead of the simple log levels. 

## Original

Is it possible to configure log lever of individual components? I want info level overall but want to see debug metrics of kademlia to check if nodes are connected.
Like it is done in cometbft:
```
CMT_LOG_LEVEL  = "main:info,abci-client:debug,*:error"
```
Is this possible with fendermint?

## Changes

* The default env var we look for is now updated to `FM_LOG_LEVEL`, but `LOG_LEVEL` is still accepted as well. 
* This log level is now applied on the console log, that is, it's no longer restricted to `INFO` level
* Added a separate `FM_LOG_FILE_LEVEL` that governs the filter on the log file. If it's not present, we default to the level of the console. 
* Prints the console logs to `stderr` as it [used to be](https://github.com/consensus-shipyard/fendermint/pull/432/files#diff-8a4e452aee36822f580e7e6fbb305327636546a0f2302b116c3178ee71c0699cL20), so that we can print e.g. JSON in the CLI commands and they don't get mixed up with logs. 
* The log expressions can look like `info,tower_abci=warn,libp2p=warn` - see the docs of [EnvFilter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html). 

The `target` of the filter can be a module like `fendermint_vm_topdown::sync` or it should work just as well on a [prefix](https://github.com/tokio-rs/tracing/blob/0e3577f6f3995b92accee21e0737c25ef0f1953c/tracing-subscriber/src/filter/directive.rs#L247), e.g. just `fendermint` should cover all of our crates, even though there is no explicit `fendermint` module.