### PR TITLE
ENG-769 Add CLI command for setting federated power

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -317,7 +317,7 @@ const config: HardhatUserConfig = {
             timeout: 1000000,
         },
         localnet: {
-            chainId: 31415926,
+            chainId: 31337,
             url: process.env.RPC_URL!,
             accounts: [process.env.PRIVATE_KEY!],
         },

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -317,7 +317,7 @@ const config: HardhatUserConfig = {
             timeout: 1000000,
         },
         localnet: {
-            chainId: 31337,
+            chainId: 31415926,
             url: process.env.RPC_URL!,
             accounts: [process.env.PRIVATE_KEY!],
         },

--- a/ipc/cli/src/commands/subnet/mod.rs
+++ b/ipc/cli/src/commands/subnet/mod.rs
@@ -9,13 +9,13 @@ pub use crate::commands::subnet::leave::{LeaveSubnet, LeaveSubnetArgs};
 use crate::commands::subnet::list_subnets::{ListSubnets, ListSubnetsArgs};
 use crate::commands::subnet::rpc::{RPCSubnet, RPCSubnetArgs};
 use crate::commands::subnet::send_value::{SendValue, SendValueArgs};
+use crate::commands::subnet::set_federated_power::{SetFederatedPower, SetFederatedPowerArgs};
 use crate::commands::subnet::show_gateway_contract_commit_sha::{
     ShowGatewayContractCommitSha, ShowGatewayContractCommitShaArgs,
 };
 use crate::commands::subnet::validator::{ValidatorInfo, ValidatorInfoArgs};
 use crate::{CommandLineHandler, GlobalArguments};
 use clap::{Args, Subcommand};
-use crate::commands::subnet::set_federated_power::{SetFederatedPower, SetFederatedPowerArgs};
 
 use self::bootstrap::{AddBootstrap, AddBootstrapArgs, ListBootstraps, ListBootstrapsArgs};
 use self::join::{StakeSubnet, StakeSubnetArgs, UnstakeSubnet, UnstakeSubnetArgs};
@@ -31,9 +31,9 @@ pub mod leave;
 pub mod list_subnets;
 pub mod rpc;
 pub mod send_value;
+mod set_federated_power;
 pub mod show_gateway_contract_commit_sha;
 mod validator;
-mod set_federated_power;
 
 #[derive(Debug, Args)]
 #[command(

--- a/ipc/cli/src/commands/subnet/mod.rs
+++ b/ipc/cli/src/commands/subnet/mod.rs
@@ -15,6 +15,7 @@ use crate::commands::subnet::show_gateway_contract_commit_sha::{
 use crate::commands::subnet::validator::{ValidatorInfo, ValidatorInfoArgs};
 use crate::{CommandLineHandler, GlobalArguments};
 use clap::{Args, Subcommand};
+use crate::commands::subnet::set_federated_power::{SetFederatedPower, SetFederatedPowerArgs};
 
 use self::bootstrap::{AddBootstrap, AddBootstrapArgs, ListBootstraps, ListBootstrapsArgs};
 use self::join::{StakeSubnet, StakeSubnetArgs, UnstakeSubnet, UnstakeSubnetArgs};
@@ -32,6 +33,7 @@ pub mod rpc;
 pub mod send_value;
 pub mod show_gateway_contract_commit_sha;
 mod validator;
+mod set_federated_power;
 
 #[derive(Debug, Args)]
 #[command(
@@ -65,6 +67,7 @@ impl SubnetCommandsArgs {
             Commands::ShowGatewayContractCommitSha(args) => {
                 ShowGatewayContractCommitSha::handle(global, args).await
             }
+            Commands::SetFederatedPower(args) => SetFederatedPower::handle(global, args).await,
         }
     }
 }
@@ -86,5 +89,9 @@ pub(crate) enum Commands {
     ListBootstraps(ListBootstrapsArgs),
     GenesisEpoch(GenesisEpochArgs),
     GetValidator(ValidatorInfoArgs),
+<<<<<<< HEAD
     ShowGatewayContractCommitSha(ShowGatewayContractCommitShaArgs),
+=======
+    SetFederatedPower(SetFederatedPowerArgs),
+>>>>>>> b762e9f0 (Rough work)
 }

--- a/ipc/cli/src/commands/subnet/mod.rs
+++ b/ipc/cli/src/commands/subnet/mod.rs
@@ -89,9 +89,6 @@ pub(crate) enum Commands {
     ListBootstraps(ListBootstrapsArgs),
     GenesisEpoch(GenesisEpochArgs),
     GetValidator(ValidatorInfoArgs),
-<<<<<<< HEAD
     ShowGatewayContractCommitSha(ShowGatewayContractCommitShaArgs),
-=======
     SetFederatedPower(SetFederatedPowerArgs),
->>>>>>> b762e9f0 (Rough work)
 }

--- a/ipc/cli/src/commands/subnet/set_federated_power.rs
+++ b/ipc/cli/src/commands/subnet/set_federated_power.rs
@@ -19,10 +19,6 @@ impl CommandLineHandler for crate::commands::subnet::SetFederatedPower {
         let provider = get_ipc_provider(global)?;
         let subnet = SubnetID::from_str(&arguments.subnet)?;
 
-        // let from = match &arguments.from {
-        //     Some(address) => Some(require_fil_addr_from_str(address)?),
-        //     None => None,
-        // };
         let addresses: Vec<Address> = arguments.validator_addresses.iter().map(
             |address| require_fil_addr_from_str(address).unwrap()
         ).collect();
@@ -30,13 +26,6 @@ impl CommandLineHandler for crate::commands::subnet::SetFederatedPower {
         let public_keys: Vec<Vec<u8>> = arguments.validator_pubkeys.iter().map(
             |key| hex::decode(key).unwrap()
         ).collect();
-
-        // let federated_power:
-
-        // let to = match &arguments.to {
-        //     Some(address) => Some(require_fil_addr_from_str(address)?),
-        //     None => None,
-        // };
 
         provider.set_federated_power(&subnet, &addresses, &public_keys, &arguments.validator_power).await
     }

--- a/ipc/cli/src/commands/subnet/set_federated_power.rs
+++ b/ipc/cli/src/commands/subnet/set_federated_power.rs
@@ -1,0 +1,56 @@
+use std::str::FromStr;
+use async_trait::async_trait;
+use clap::Args;
+use fvm_shared::address::Address;
+use ipc_api::subnet_id::SubnetID;
+use crate::{CommandLineHandler, GlobalArguments};
+use crate::commands::{f64_to_token_amount, get_ipc_provider, require_fil_addr_from_str};
+
+/// The command to set federated power.
+pub struct SetFederatedPower;
+
+#[async_trait]
+impl CommandLineHandler for crate::commands::subnet::SetFederatedPower {
+    type Arguments = crate::commands::subnet::SetFederatedPowerArgs;
+
+    async fn handle(global: &GlobalArguments, arguments: &Self::Arguments) -> anyhow::Result<()> {
+        log::debug!("set federated power with args: {:?}", arguments);
+
+        let provider = get_ipc_provider(global)?;
+        let subnet = SubnetID::from_str(&arguments.subnet)?;
+
+        // let from = match &arguments.from {
+        //     Some(address) => Some(require_fil_addr_from_str(address)?),
+        //     None => None,
+        // };
+        let addresses: Vec<Address> = arguments.validator_addresses.iter().map(
+            |address| require_fil_addr_from_str(address).unwrap()
+        ).collect();
+
+        let public_keys: Vec<Vec<u8>> = arguments.validator_pubkeys.iter().map(
+            |key| hex::decode(key).unwrap()
+        ).collect();
+
+        // let federated_power:
+
+        // let to = match &arguments.to {
+        //     Some(address) => Some(require_fil_addr_from_str(address)?),
+        //     None => None,
+        // };
+
+        provider.set_federated_power(&subnet, &addresses, &public_keys, &arguments.validator_power).await
+    }
+}
+
+#[derive(Debug, Args)]
+#[command(name = "stake", about = "Set federated power for validators")]
+pub struct SetFederatedPowerArgs {
+    #[arg(long, help = "The subnet to release collateral from")]
+    pub subnet: String,
+    #[arg(long, num_args = 1.., help = "Addresses of validators, separated by space")]
+    pub validator_addresses: Vec<String>,
+    #[arg(long, num_args = 1.., help = "Public keys of validators, separated by space")]
+    pub validator_pubkeys: Vec<String>,
+    #[arg(long, num_args = 1.., help = "Federated of validators, separated by space")]
+    pub validator_power: Vec<u128>,
+}

--- a/ipc/cli/src/commands/subnet/set_federated_power.rs
+++ b/ipc/cli/src/commands/subnet/set_federated_power.rs
@@ -1,10 +1,10 @@
-use std::str::FromStr;
+use crate::commands::{get_ipc_provider, require_fil_addr_from_str};
+use crate::{CommandLineHandler, GlobalArguments};
 use async_trait::async_trait;
 use clap::Args;
 use fvm_shared::address::Address;
 use ipc_api::subnet_id::SubnetID;
-use crate::{CommandLineHandler, GlobalArguments};
-use crate::commands::{get_ipc_provider, require_fil_addr_from_str};
+use std::str::FromStr;
 
 /// The command to set federated power.
 pub struct SetFederatedPower;
@@ -19,17 +19,29 @@ impl CommandLineHandler for crate::commands::subnet::SetFederatedPower {
         let provider = get_ipc_provider(global)?;
         let subnet = SubnetID::from_str(&arguments.subnet)?;
 
-        let addresses: Vec<Address> = arguments.validator_addresses.iter().map(
-            |address| require_fil_addr_from_str(address).unwrap()
-        ).collect();
+        let addresses: Vec<Address> = arguments
+            .validator_addresses
+            .iter()
+            .map(|address| require_fil_addr_from_str(address).unwrap())
+            .collect();
 
-        let public_keys: Vec<Vec<u8>> = arguments.validator_pubkeys.iter().map(
-            |key| hex::decode(key).unwrap()
-        ).collect();
+        let public_keys: Vec<Vec<u8>> = arguments
+            .validator_pubkeys
+            .iter()
+            .map(|key| hex::decode(key).unwrap())
+            .collect();
 
         let from_address = require_fil_addr_from_str(&arguments.from).unwrap();
 
-        let chain_epoch = provider.set_federated_power(&from_address, &subnet, &addresses, &public_keys, &arguments.validator_power).await?;
+        let chain_epoch = provider
+            .set_federated_power(
+                &from_address,
+                &subnet,
+                &addresses,
+                &public_keys,
+                &arguments.validator_power,
+            )
+            .await?;
         println!("New federated power is set at epoch {chain_epoch}");
 
         Ok(())

--- a/ipc/cli/src/commands/subnet/set_federated_power.rs
+++ b/ipc/cli/src/commands/subnet/set_federated_power.rs
@@ -1,3 +1,7 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: MIT
+//! Set federated power cli handler
+
 use crate::commands::{get_ipc_provider, require_fil_addr_from_str};
 use crate::{CommandLineHandler, GlobalArguments};
 use async_trait::async_trait;

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -770,20 +770,22 @@ impl IpcProvider {
         conn.manager().latest_parent_finality().await
     }
 
-
     pub async fn set_federated_power(
         &self,
         from: &Address,
         subnet: &SubnetID,
-        validators: &Vec<Address>,
-        public_keys: &Vec<Vec<u8>>,
-        federated_power: &Vec<u128>) -> anyhow::Result<ChainEpoch> {
+        validators: &[Address],
+        public_keys: &[Vec<u8>],
+        federated_power: &[u128],
+    ) -> anyhow::Result<ChainEpoch> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
         let conn = match self.connection(&parent) {
             None => return Err(anyhow!("target parent subnet not found")),
             Some(conn) => conn,
         };
-        conn.manager().set_federated_power(from, subnet, validators, public_keys, federated_power).await
+        conn.manager()
+            .set_federated_power(from, subnet, validators, public_keys, federated_power)
+            .await
     }
 }
 

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -777,11 +777,11 @@ impl IpcProvider {
         validators: &Vec<Address>,
         public_keys: &Vec<Vec<u8>>,
         federated_power: &Vec<u128>) -> anyhow::Result<()> {
-        let conn = match self.connection(subnet) {
-            None => return Err(anyhow!("target subnet not found")),
+        let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
+        let conn = match self.connection(&parent) {
+            None => return Err(anyhow!("target parent subnet not found")),
             Some(conn) => conn,
         };
-
         conn.manager().set_federated_power(subnet, validators, public_keys, federated_power).await
     }
 }

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -769,6 +769,21 @@ impl IpcProvider {
 
         conn.manager().latest_parent_finality().await
     }
+
+
+    pub async fn set_federated_power(
+        &self,
+        subnet: &SubnetID,
+        validators: &Vec<Address>,
+        public_keys: &Vec<Vec<u8>>,
+        federated_power: &Vec<u128>) -> anyhow::Result<()> {
+        let conn = match self.connection(subnet) {
+            None => return Err(anyhow!("target subnet not found")),
+            Some(conn) => conn,
+        };
+
+        conn.manager().set_federated_power(subnet, validators, public_keys, federated_power).await
+    }
 }
 
 /// Lotus JSON keytype format

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -773,16 +773,17 @@ impl IpcProvider {
 
     pub async fn set_federated_power(
         &self,
+        from: &Address,
         subnet: &SubnetID,
         validators: &Vec<Address>,
         public_keys: &Vec<Vec<u8>>,
-        federated_power: &Vec<u128>) -> anyhow::Result<()> {
+        federated_power: &Vec<u128>) -> anyhow::Result<ChainEpoch> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
         let conn = match self.connection(&parent) {
             None => return Err(anyhow!("target parent subnet not found")),
             Some(conn) => conn,
         };
-        conn.manager().set_federated_power(subnet, validators, public_keys, federated_power).await
+        conn.manager().set_federated_power(from, subnet, validators, public_keys, federated_power).await
     }
 }
 

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -820,19 +820,19 @@ impl SubnetManager for EthSubnetManager {
         let addresses: Vec<ethers::core::types::Address> = validators.iter().map(
             |validator_address| payload_to_evm_address(validator_address.payload()).unwrap()
         ).collect();
-        log::info!("converted addresses {:?}:", addresses);
+        log::debug!("converted addresses {:?}:", addresses);
 
         let pubkeys: Vec<ethers::core::types::Bytes> = public_keys.iter().map(
             |key| ethers::core::types::Bytes::from(key.clone())
         ).collect();
-        log::info!("converted pubkeys {:?}:", pubkeys);
+        log::debug!("converted pubkeys {:?}:", pubkeys);
 
         let power_u256: Vec<ethers::core::types::U256> = federated_power.iter().map(
             |power| ethers::core::types::U256::from(*power)
         ).collect();
-        log::info!("converted power {:?}:", power_u256);
+        log::debug!("converted power {:?}:", power_u256);
 
-        log::info!("from address {:?}:", from);
+        log::debug!("from address {:?}:", from);
 
         let signer = Arc::new(self.get_signer(from)?);
         let call = contract.set_federated_power(addresses, pubkeys, power_u256);

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -816,28 +816,16 @@ impl SubnetManager for EthSubnetManager {
             Arc::new(self.ipc_contract_info.provider.clone()),
         );
 
-        // let mut addresses: Vec<ethers::core::types::Address> = Vec::new();
-        // for address in validators {
-        //     addresses.push(payload_to_evm_address(address.payload())?)
-        // }
         let addresses: Vec<ethers::core::types::Address> = validators.iter().map(
             |validator_address| payload_to_evm_address(validator_address.payload()).unwrap()
         ).collect();
         log::info!("converted addresses {:?}:", addresses);
 
-        // let mut pubkeys: Vec<ethers::core::types::Bytes> = Vec::new();
-        // for key in public_keys {
-        //     pubkeys.push(ethers::core::types::Bytes::from(key.clone()))
-        // }
         let pubkeys: Vec<ethers::core::types::Bytes> = public_keys.iter().map(
             |key| ethers::core::types::Bytes::from(key.clone())
         ).collect();
         log::info!("converted pubkeys {:?}:", pubkeys);
 
-        // let mut power_u256: Vec<ethers::core::types::U256> = Vec::new();
-        // for power in federated_power {
-        //     power_u256.push(ethers::core::types::U256::from(*power))
-        // }
         let power_u256: Vec<ethers::core::types::U256> = federated_power.iter().map(
             |power| ethers::core::types::U256::from(*power)
         ).collect();

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -803,33 +803,34 @@ impl SubnetManager for EthSubnetManager {
         &self,
         from: &Address,
         subnet: &SubnetID,
-        validators: &Vec<Address>,
-        public_keys: &Vec<Vec<u8>>,
-        federated_power: &Vec<u128>,
+        validators: &[Address],
+        public_keys: &[Vec<u8>],
+        federated_power: &[u128],
     ) -> Result<ChainEpoch> {
-        let address = contract_address_from_subnet(&subnet)?;
-        log::info!(
-            "interacting with evm subnet contract: {address:}"
-        );
+        let address = contract_address_from_subnet(subnet)?;
+        log::info!("interacting with evm subnet contract: {address:}");
 
         let contract = subnet_actor_manager_facet::SubnetActorManagerFacet::new(
             address,
             Arc::new(self.ipc_contract_info.provider.clone()),
         );
 
-        let addresses: Vec<ethers::core::types::Address> = validators.iter().map(
-            |validator_address| payload_to_evm_address(validator_address.payload()).unwrap()
-        ).collect();
+        let addresses: Vec<ethers::core::types::Address> = validators
+            .iter()
+            .map(|validator_address| payload_to_evm_address(validator_address.payload()).unwrap())
+            .collect();
         log::debug!("converted addresses {:?}:", addresses);
 
-        let pubkeys: Vec<ethers::core::types::Bytes> = public_keys.iter().map(
-            |key| ethers::core::types::Bytes::from(key.clone())
-        ).collect();
+        let pubkeys: Vec<ethers::core::types::Bytes> = public_keys
+            .iter()
+            .map(|key| ethers::core::types::Bytes::from(key.clone()))
+            .collect();
         log::debug!("converted pubkeys {:?}:", pubkeys);
 
-        let power_u256: Vec<ethers::core::types::U256> = federated_power.iter().map(
-            |power| ethers::core::types::U256::from(*power)
-        ).collect();
+        let power_u256: Vec<ethers::core::types::U256> = federated_power
+            .iter()
+            .map(|power| ethers::core::types::U256::from(*power))
+            .collect();
         log::debug!("converted power {:?}:", power_u256);
 
         log::debug!("from address {:?}:", from);

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -162,9 +162,9 @@ pub trait SubnetManager: Send + Sync + TopDownFinalityQuery + BottomUpCheckpoint
         &self,
         from: &Address,
         subnet: &SubnetID,
-        validators: &Vec<Address>,
-        public_keys: &Vec<Vec<u8>>,
-        federated_power: &Vec<u128>,
+        validators: &[Address],
+        public_keys: &[Vec<u8>],
+        federated_power: &[u128],
     ) -> Result<ChainEpoch>;
 }
 

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -160,11 +160,12 @@ pub trait SubnetManager: Send + Sync + TopDownFinalityQuery + BottomUpCheckpoint
 
     async fn set_federated_power(
         &self,
+        from: &Address,
         subnet: &SubnetID,
         validators: &Vec<Address>,
         public_keys: &Vec<Vec<u8>>,
         federated_power: &Vec<u128>,
-    ) -> Result<()>;
+    ) -> Result<ChainEpoch>;
 }
 
 #[derive(Debug)]

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -157,6 +157,14 @@ pub trait SubnetManager: Send + Sync + TopDownFinalityQuery + BottomUpCheckpoint
         subnet: &SubnetID,
         validator: &Address,
     ) -> Result<ValidatorInfo>;
+
+    async fn set_federated_power(
+        &self,
+        subnet: &SubnetID,
+        validators: &Vec<Address>,
+        public_keys: &Vec<Vec<u8>>,
+        federated_power: &Vec<u128>,
+    ) -> Result<()>;
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This closes ENG-769

Usage example:

(Against a local ETH net)
```bash
$ ../target/release/ipc-cli subnet set-federated-power --subnet /r31337/t410f6gbdxrbehnaeeo4mrq7wc5hgq6smnefys4qanwi --validator-addresses 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc 0x70997970c51812dc3a010c7d01b50e0d17dc79c8 --validator-pubkeys 048318535b54105d4a7aae60c08fc45f9687181b4fdfc625bd1a753fa7397fed753547f11ca8696646f2f3acb08e31016afac23e630c5d11f59f61fef57b0d2aa5 049d9031e97dd78ff8c15aa86939de9b1e791066a0224e331bc962a2099a7b1f0464b8bbafe1535f2301c72c2cb3535b172da30b02686ab0393d348614f157fbdb 04ba5734d8f7091719471e7f7ed6b9df170dc70cc661ca05e688601ad984f068b0d67351e5f06073092499336ab0839ef8a521afd334e53807205fa2f08eec74f4 --validator-power 10 20 30 --from 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266

[2024-03-15T21:08:00Z INFO  ipc_provider::manager::evm::manager] interacting with evm subnet contract: 0xf182…90b8
New federated power is set at epoch 36
```