### PR TITLE
ENG-578: IT (Part 7) - Import secret key into testnet

### DIFF
--- a/fendermint/app/options/src/materializer.rs
+++ b/fendermint/app/options/src/materializer.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
-use fendermint_materializer::TestnetId;
+use fendermint_materializer::{AccountId, TestnetId};
 
 #[derive(Args, Debug)]
 pub struct MaterializerArgs {
@@ -35,6 +35,8 @@ pub enum MaterializerCommands {
     Setup(MaterializerSetupArgs),
     /// Tear down a testnet.
     Remove(MaterializerRemoveArgs),
+    /// Import an existing secret key into a testnet; for example to use an already funded account on Calibration net.
+    ImportKey(MaterializerImportKeyArgs),
 }
 
 #[derive(Args, Debug)]
@@ -66,4 +68,21 @@ pub struct MaterializerRemoveArgs {
     /// ID of the testnet to remove.
     #[arg(long, short)]
     pub testnet_id: TestnetId,
+}
+
+#[derive(Args, Debug)]
+pub struct MaterializerImportKeyArgs {
+    /// Path to the manifest file.
+    ///
+    /// This is used to determine the testnet ID as well as to check that the account exists.
+    #[arg(long, short)]
+    pub manifest_file: PathBuf,
+
+    /// Path to the Secp256k1 private key exported in base64 or hexadecimal format.
+    #[arg(long, short)]
+    pub secret_key: PathBuf,
+
+    /// Run validation before attempting to set up the testnet.
+    #[arg(long, short)]
+    pub account_id: AccountId,
 }

--- a/fendermint/app/src/cmd/key.rs
+++ b/fendermint/app/src/cmd/key.rs
@@ -8,7 +8,7 @@ use fendermint_vm_actor_interface::eam::EthAddress;
 use fvm_shared::address::Address;
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 use serde_json::json;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tendermint_config::NodeKey;
 
 use crate::{
@@ -159,13 +159,13 @@ fn b64_to_secret(b64: &str) -> anyhow::Result<SecretKey> {
     Ok(sk)
 }
 
-pub fn read_public_key(public_key: &PathBuf) -> anyhow::Result<PublicKey> {
+pub fn read_public_key(public_key: &Path) -> anyhow::Result<PublicKey> {
     let b64 = std::fs::read_to_string(public_key).context("failed to read public key")?;
     let pk = b64_to_public(&b64).context("failed to parse public key")?;
     Ok(pk)
 }
 
-pub fn read_secret_key_hex(private_key: &PathBuf) -> anyhow::Result<SecretKey> {
+pub fn read_secret_key_hex(private_key: &Path) -> anyhow::Result<SecretKey> {
     let hex_str = std::fs::read_to_string(private_key).context("failed to read private key")?;
     let mut hex_str = hex_str.trim();
     if hex_str.starts_with("0x") {
@@ -176,7 +176,7 @@ pub fn read_secret_key_hex(private_key: &PathBuf) -> anyhow::Result<SecretKey> {
     Ok(sk)
 }
 
-pub fn read_secret_key(secret_key: &PathBuf) -> anyhow::Result<SecretKey> {
+pub fn read_secret_key(secret_key: &Path) -> anyhow::Result<SecretKey> {
     let b64 = std::fs::read_to_string(secret_key).context("failed to read secret key")?;
     let sk = b64_to_secret(&b64).context("failed to parse secret key")?;
     Ok(sk)

--- a/fendermint/testing/materializer/src/docker/mod.rs
+++ b/fendermint/testing/materializer/src/docker/mod.rs
@@ -429,7 +429,7 @@ impl Materializer<DockerMaterials> for DockerMaterializer {
                 validators: validators
                     .into_iter()
                     .map(|(v, c)| Validator {
-                        public_key: ValidatorKey(v.public_key),
+                        public_key: ValidatorKey(v.public_key().clone()),
                         power: c,
                     })
                     .collect(),

--- a/fendermint/testing/materializer/src/docker/mod.rs
+++ b/fendermint/testing/materializer/src/docker/mod.rs
@@ -429,7 +429,7 @@ impl Materializer<DockerMaterials> for DockerMaterializer {
                 validators: validators
                     .into_iter()
                     .map(|(v, c)| Validator {
-                        public_key: ValidatorKey(v.public_key().clone()),
+                        public_key: ValidatorKey(*v.public_key()),
                         power: c,
                     })
                     .collect(),

--- a/fendermint/testing/materializer/src/materials/defaults.rs
+++ b/fendermint/testing/materializer/src/materials/defaults.rs
@@ -50,11 +50,11 @@ pub struct DefaultSubnet {
 
 #[derive(PartialEq, Eq)]
 pub struct DefaultAccount {
-    pub name: AccountName,
-    pub secret_key: SecretKey,
-    pub public_key: PublicKey,
+    name: AccountName,
+    secret_key: SecretKey,
+    public_key: PublicKey,
     /// Path to the directory where the keys are exported.
-    pub path: PathBuf,
+    path: PathBuf,
 }
 
 impl PartialOrd for DefaultAccount {
@@ -96,18 +96,17 @@ impl DefaultAccount {
         let dir = root.as_ref().join(name.path());
         let sk = dir.join("secret.hex");
 
-        let (sk, pk, is_new) = if sk.exists() {
+        let (sk, is_new) = if sk.exists() {
             let sk = std::fs::read_to_string(sk).context("failed to read private key")?;
             let sk = hex::decode(sk).context("cannot decode hex private key")?;
             let sk = SecretKey::try_from(sk).context("failed to parse secret key")?;
-            let pk = sk.public_key();
-            (sk, pk, false)
+            (sk, false)
         } else {
             let sk = SecretKey::random(rng);
-            let pk = sk.public_key();
-            (sk, pk, true)
+            (sk, true)
         };
 
+        let pk = sk.public_key();
         let acc = Self {
             name: name.clone(),
             secret_key: sk,
@@ -116,22 +115,51 @@ impl DefaultAccount {
         };
 
         if is_new {
-            let sk = acc.secret_key.serialize();
-            let pk = acc.public_key.serialize();
-
-            export(&acc.path, "secret", "b64", to_b64(sk.as_ref()))?;
-            export(&acc.path, "secret", "hex", hex::encode(sk))?;
-            export(&acc.path, "public", "b64", to_b64(pk.as_ref()))?;
-            export(&acc.path, "public", "hex", hex::encode(pk))?;
-            export(&acc.path, "eth-addr", "", format!("{:?}", acc.eth_addr()))?;
-            export(&acc.path, "fvm-addr", "", acc.fvm_addr().to_string())?;
+            acc.export()?;
         }
 
         Ok(acc)
     }
 
+    /// Create (or overwrite) an account with a given secret key.
+    pub fn create(
+        root: impl AsRef<Path>,
+        name: &AccountName,
+        sk: SecretKey,
+    ) -> anyhow::Result<Self> {
+        let pk = sk.public_key();
+        let dir = root.as_ref().join(name.path());
+        let acc = Self {
+            name: name.clone(),
+            secret_key: sk,
+            public_key: pk,
+            path: dir,
+        };
+        acc.export()?;
+        Ok(acc)
+    }
+
+    /// Write the keys to files.
+    fn export(&self) -> anyhow::Result<()> {
+        let sk = self.secret_key.serialize();
+        let pk = self.public_key.serialize();
+
+        export(&self.path, "secret", "b64", to_b64(sk.as_ref()))?;
+        export(&self.path, "secret", "hex", hex::encode(sk))?;
+        export(&self.path, "public", "b64", to_b64(pk.as_ref()))?;
+        export(&self.path, "public", "hex", hex::encode(pk))?;
+        export(&self.path, "eth-addr", "", format!("{:?}", self.eth_addr()))?;
+        export(&self.path, "fvm-addr", "", self.fvm_addr().to_string())?;
+
+        Ok(())
+    }
+
     pub fn secret_key_path(&self) -> PathBuf {
         self.path.join("secret.b64")
+    }
+
+    pub fn public_key(&self) -> &PublicKey {
+        &self.public_key
     }
 }
 


### PR DESCRIPTION
Adds a new command to import an existing secret key to be used in a testnet. 

The use case is that we have already funded via the faucet some keys on Calibration and we want to use them in a test. This PR doesn't implement the skipping of the faucet step, but at least makes it easier to put the keys in the expected places.

### `--help`

```console
❯ cargo run -q -p fendermint_app -- materializer import-key --help
Import an existing secret key into a testnet; for example to use an already funded account on Calibration net

Usage: fendermint materializer import-key --manifest-file <MANIFEST_FILE> --secret-key <SECRET_KEY> --account-id <ACCOUNT_ID>

Options:
  -m, --manifest-file <MANIFEST_FILE>
          Path to the manifest file.
          
          This is used to determine the testnet ID as well as to check that the account exists.

  -s, --secret-key <SECRET_KEY>
          Path to the Secp256k1 private key exported in base64 or hexadecimal format

  -a, --account-id <ACCOUNT_ID>
          Run validation before attempting to set up the testnet

  -h, --help
          Print help (see a summary with '-h')
```

### Example

```console
❯ cargo run -q -p fendermint_app -- materializer --data-dir $PWD/testing/materializer/tests/docker-materializer-data/ import-key --manifest-file ./testing/materializer/tests/manifests/root-only.yaml --account-id adam --secret-key ~/.ipc/validator_1.sk
2024-03-04T13:45:15.272670Z ERROR fendermint/app/src/main.rs:100: failed to execute Options { home_dir: "~/.fendermint", log_dir: None, log_file_prefix: None, mode: "dev", log_level: Info, _log_level: None, log_file_level: None, global: GlobalArgs { network: Mainnet }, command: Materializer(MaterializerArgs { data_dir: "/home/aakoshh/projects/consensuslab/ipc/fendermint/testing/materializer/tests/docker-materializer-data/", seed: 0, command: ImportKey(MaterializerImportKeyArgs { manifest_file: "./testing/materializer/tests/manifests/root-only.yaml", secret_key: "/home/aakoshh/.ipc/validator_1.sk", account_id: 'adam' }) }) }: account 'adam' cannot be found in the manifest at ./testing/materializer/tests/manifests/root-only.yaml

❯ ls $PWD/testing/materializer/tests/docker-materializer-data/testnets/root-only/accounts
alice/  bob/  charlie/

❯ rm -rf $PWD/testing/materializer/tests/docker-materializer-data/testnets/root-only/accounts/alice

❯ cargo run -q -p fendermint_app -- materializer --data-dir $PWD/testing/materializer/tests/docker-materializer-data/ import-key --manifest-file ./testing/materializer/tests/manifests/root-only.yaml --account-id alice --secret-key ~/.ipc/validator_1.sk

❯ ls $PWD/testing/materializer/tests/docker-materializer-data/testnets/root-only/accounts/alice
eth-addr  fvm-addr  public.b64  public.hex  secret.b64  secret.hex

❯ cat ~/.ipc/validator_1.sk
ec4818b129f09adbe3a233a9dde4c4f6794d2dfea7d3ef1f9795c4293bcb6745⏎                                                                                                                                                  

❯ cat $PWD/testing/materializer/tests/docker-materializer-data/testnets/root-only/accounts/alice/secret.hex
ec4818b129f09adbe3a233a9dde4c4f6794d2dfea7d3ef1f9795c4293bcb6745⏎          
```