### PR TITLE
SIG: Allow eth to send to non-eth with regular signature

### DIFF
--- a/fendermint/rpc/examples/transfer.rs
+++ b/fendermint/rpc/examples/transfer.rs
@@ -27,7 +27,7 @@ use tracing::Level;
 use fvm_shared::econ::TokenAmount;
 
 use fendermint_rpc::client::FendermintClient;
-use fendermint_rpc::message::{GasParams, MessageFactory};
+use fendermint_rpc::message::{GasParams, SignedMessageFactory};
 use fendermint_rpc::tx::{TxClient, TxCommit};
 
 lazy_static! {
@@ -81,7 +81,9 @@ async fn main() {
 
     let client = FendermintClient::new_http(opts.url, None).expect("error creating client");
 
-    let sk = MessageFactory::read_secret_key(&opts.secret_key).expect("error reading secret key");
+    let sk =
+        SignedMessageFactory::read_secret_key(&opts.secret_key).expect("error reading secret key");
+
     let pk = sk.public_key();
 
     let f1_addr = Address::new_secp256k1(&pk.serialize()).expect("valid public key");
@@ -100,7 +102,7 @@ async fn main() {
         .value
         .chain_id;
 
-    let mf = MessageFactory::new(sk, f410_addr, sn, ChainID::from(chain_id));
+    let mf = SignedMessageFactory::new(sk, f410_addr, sn, ChainID::from(chain_id));
 
     let mut client = client.bind(mf);
 

--- a/fendermint/rpc/examples/transfer.rs
+++ b/fendermint/rpc/examples/transfer.rs
@@ -1,0 +1,132 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+//! Example of using the RPC library to send tokens from an f410 account to an f1 account.
+//!
+//! The example assumes that Tendermint and Fendermint have been started
+//! and are running locally.
+//!
+//! # Usage
+//! ```text
+//! cargo run -p fendermint_rpc --release --example transfer -- --secret-key test-network/keys/eric.sk --verbose
+//! ```
+
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context};
+use clap::Parser;
+use fendermint_rpc::query::QueryClient;
+use fendermint_vm_actor_interface::eam::EthAddress;
+use fendermint_vm_message::query::FvmQueryHeight;
+use fvm_shared::address::Address;
+use fvm_shared::chainid::ChainID;
+use lazy_static::lazy_static;
+use tendermint_rpc::Url;
+use tracing::Level;
+
+use fvm_shared::econ::TokenAmount;
+
+use fendermint_rpc::client::FendermintClient;
+use fendermint_rpc::message::{GasParams, MessageFactory};
+use fendermint_rpc::tx::{TxClient, TxCommit};
+
+lazy_static! {
+    /// Default gas params based on the testkit.
+    static ref GAS_PARAMS: GasParams = GasParams {
+        gas_limit: 10_000_000_000,
+        gas_fee_cap: TokenAmount::default(),
+        gas_premium: TokenAmount::default(),
+    };
+}
+
+#[derive(Parser, Debug)]
+pub struct Options {
+    /// The URL of the Tendermint node's RPC endpoint.
+    #[arg(
+        long,
+        short,
+        default_value = "http://127.0.0.1:26657",
+        env = "TENDERMINT_RPC_URL"
+    )]
+    pub url: Url,
+
+    /// Enable DEBUG logs.
+    #[arg(long, short)]
+    pub verbose: bool,
+
+    /// Path to the secret key to deploy with, expected to be in Base64 format,
+    /// and that it has a corresponding f410 account in genesis.
+    #[arg(long, short)]
+    pub secret_key: PathBuf,
+}
+
+impl Options {
+    pub fn log_level(&self) -> Level {
+        if self.verbose {
+            Level::DEBUG
+        } else {
+            Level::INFO
+        }
+    }
+}
+
+/// See the module docs for how to run.
+#[tokio::main]
+async fn main() {
+    let opts: Options = Options::parse();
+
+    tracing_subscriber::fmt()
+        .with_max_level(opts.log_level())
+        .init();
+
+    let client = FendermintClient::new_http(opts.url, None).expect("error creating client");
+
+    let sk = MessageFactory::read_secret_key(&opts.secret_key).expect("error reading secret key");
+    let pk = sk.public_key();
+
+    let f1_addr = Address::new_secp256k1(&pk.serialize()).expect("valid public key");
+    let f410_addr = Address::from(EthAddress::from(pk));
+
+    // Query the account nonce from the state, so it doesn't need to be passed as an arg.
+    let sn = sequence(&client, &f410_addr)
+        .await
+        .expect("error getting sequence");
+
+    // Query the chain ID, so it doesn't need to be passed as an arg.
+    let chain_id = client
+        .state_params(FvmQueryHeight::default())
+        .await
+        .expect("error getting state params")
+        .value
+        .chain_id;
+
+    let mf = MessageFactory::new(sk, f410_addr, sn, ChainID::from(chain_id));
+
+    let mut client = client.bind(mf);
+
+    let res = TxClient::<TxCommit>::transfer(
+        &mut client,
+        f1_addr,
+        TokenAmount::from_whole(1),
+        GAS_PARAMS.clone(),
+    )
+    .await
+    .expect("transfer failed");
+
+    assert!(res.response.check_tx.code.is_ok(), "check is ok");
+    assert!(res.response.deliver_tx.code.is_ok(), "deliver is ok");
+    assert!(res.return_data.is_some());
+}
+
+/// Get the next sequence number (nonce) of an account.
+async fn sequence(client: &impl QueryClient, addr: &Address) -> anyhow::Result<u64> {
+    let state = client
+        .actor_state(&addr, FvmQueryHeight::default())
+        .await
+        .context("failed to get actor state")?;
+
+    match state.value {
+        Some((_id, state)) => Ok(state.sequence),
+        None => Err(anyhow!("cannot find actor {addr}")),
+    }
+}

--- a/fendermint/testing/smoke-test/Makefile.toml
+++ b/fendermint/testing/smoke-test/Makefile.toml
@@ -30,15 +30,26 @@ EOF
 clear = true
 dependencies = [
   "simplecoin-example",
+  "transfer-example",
   "ethers-example",
   "query-blockhash-example",
 ]
+
 
 [tasks.simplecoin-example]
 script = """
 cd ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/fendermint
 cargo run -p fendermint_rpc --example simplecoin -- \
   --secret-key testing/smoke-test/test-data/keys/alice.sk \
+  ${VERBOSITY}
+"""
+
+
+[tasks.transfer-example]
+script = """
+cd ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/fendermint
+cargo run -p fendermint_rpc --example transfer -- \
+  --secret-key testing/smoke-test/test-data/keys/eric.sk \
   ${VERBOSITY}
 """
 

--- a/fendermint/vm/interpreter/src/signed.rs
+++ b/fendermint/vm/interpreter/src/signed.rs
@@ -1,6 +1,6 @@
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 
 use fendermint_vm_core::chainid::HasChainID;
@@ -148,7 +148,9 @@ where
                 Ok((state, Err(InvalidSignature(s))))
             }
             Ok(()) => {
-                let domain_hash = msg.domain_hash(&chain_id)?;
+                let domain_hash = msg
+                    .domain_hash(&chain_id)
+                    .context("failed to compute domain hash")?;
                 let (state, ret) = self.inner.deliver(state, msg.into_message()).await?;
                 let ret = SignedMessageApplyRet {
                     fvm: ret,

--- a/fendermint/vm/message/src/signed.rs
+++ b/fendermint/vm/message/src/signed.rs
@@ -7,11 +7,13 @@ use cid::multihash::MultihashDigest;
 use cid::Cid;
 use ethers_core::types as et;
 use ethers_core::types::transaction::eip2718::TypedTransaction;
-use fendermint_crypto::SecretKey;
+use fendermint_crypto::{PublicKey, SecretKey};
+use fendermint_vm_actor_interface::eam::EthAddress;
 use fendermint_vm_actor_interface::{eam, evm};
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
 use fvm_shared::address::{Address, Payload};
 use fvm_shared::chainid::ChainID;
+use fvm_shared::crypto::signature::ops::recover_secp_public_key;
 use fvm_shared::crypto::signature::{Signature, SignatureType, SECP_SIG_LEN};
 use fvm_shared::message::Message;
 
@@ -24,6 +26,9 @@ enum Signable {
     Ethereum((et::H256, et::H160)),
     /// Bytes to be passed to the FVM Signature for hashing or verification.
     Regular(Vec<u8>),
+    /// Same signature as `Regular` but using an Ethereum account hash as sender.
+    /// This is used if the recipient of the message is not an Ethereum account.
+    RegularFromEth((Vec<u8>, et::H160)),
 }
 
 #[derive(Error, Debug)]
@@ -77,6 +82,7 @@ impl SignedMessage {
         let signature = match Self::signable(&message, chain_id)? {
             Signable::Ethereum((hash, _)) => sign_eth(sk, hash),
             Signable::Regular(data) => sign_regular(sk, &data),
+            Signable::RegularFromEth((data, _)) => sign_regular(sk, &data),
         };
         Ok(Self { message, signature })
     }
@@ -104,13 +110,23 @@ impl SignedMessage {
         // so at least for now they are easy to tell apart: any `f410` address is coming from Ethereum API and must have
         // been signed according to the Ethereum scheme, and it could not have been signed by an `f1` address, it doesn't
         // work with regular accounts.
+
+        // Detect the case where the recipient is not an ethereum address. If that is the case then use regular signing rules,
+        // which should allow messages from ethereum accounts to go to any other type of account, e.g. custom Wasm actors.
+        let is_to_eth = || from_fvm::to_eth_address(&message.to).is_ok();
+
         match maybe_eth_address(&message.from) {
-            Some(addr) => {
+            Some(addr) if is_to_eth() => {
                 let tx: TypedTransaction = from_fvm::to_eth_transaction_request(message, chain_id)
                     .map_err(SignedMessageError::Ethereum)?
                     .into();
 
                 Ok(Signable::Ethereum((tx.sighash(), addr)))
+            }
+            Some(addr) => {
+                let mut data = Self::cid(message)?.to_bytes();
+                data.extend(chain_id_bytes(chain_id).iter());
+                Ok(Signable::RegularFromEth((data, addr)))
             }
             None => {
                 let mut data = Self::cid(message)?.to_bytes();
@@ -148,6 +164,18 @@ impl SignedMessage {
                 signature
                     .verify(&data, &message.from)
                     .map_err(SignedMessageError::InvalidSignature)
+            }
+            Signable::RegularFromEth((data, from)) => {
+                let rec = recover_secp256k1(signature, &data)
+                    .map_err(SignedMessageError::InvalidSignature)?;
+
+                let rec_addr = EthAddress::from(rec);
+
+                if rec_addr.0 == from.0 {
+                    Ok(())
+                } else {
+                    Err(SignedMessageError::InvalidSignature("the Ethereum delegated address did not match the one recovered from the signature".to_string()))
+                }
             }
         }
     }
@@ -280,6 +308,36 @@ pub fn sign_secp256k1(sk: &SecretKey, hash: &[u8; 32]) -> Signature {
         sig_type: SignatureType::Secp256k1,
         bytes: signature.to_vec(),
     }
+}
+
+/// Recover the public key from a Secp256k1
+///
+/// Based on how `Signature` does it, but without the final address hashing.
+fn recover_secp256k1(signature: &Signature, data: &[u8]) -> Result<PublicKey, String> {
+    let signature = &signature.bytes;
+
+    if signature.len() != SECP_SIG_LEN {
+        return Err(format!(
+            "Invalid Secp256k1 signature length. Was {}, must be 65",
+            signature.len()
+        ));
+    }
+
+    // blake2b 256 hash
+    let hash = blake2b_simd::Params::new()
+        .hash_length(32)
+        .to_state()
+        .update(data)
+        .finalize();
+
+    let mut sig = [0u8; SECP_SIG_LEN];
+    sig[..].copy_from_slice(signature);
+
+    let rec_key =
+        recover_secp_public_key(hash.as_bytes().try_into().expect("fixed array size"), &sig)
+            .map_err(|e| e.to_string())?;
+
+    Ok(rec_key)
 }
 
 /// Signed message with an invalid random signature.

--- a/fendermint/vm/message/src/signed.rs
+++ b/fendermint/vm/message/src/signed.rs
@@ -443,4 +443,19 @@ mod tests {
         }
         Ok(())
     }
+
+    /// Check that we can send from an ethereum account to a non-ethereum one and sign it.
+    #[quickcheck]
+    fn eth_to_non_eth_sign_and_verify(msg: EthMessage, chain_id: u64, from: KeyPair, to: KeyPair) {
+        let chain_id = ChainID::from(chain_id);
+        let mut msg = msg.0;
+
+        msg.from = Address::from(EthAddress::from(from.pk));
+        msg.to = Address::new_secp256k1(&to.pk.serialize()).expect("f1 address");
+
+        let signed =
+            SignedMessage::new_secp256k1(msg, &from.sk, &chain_id).expect("message can be signed");
+
+        signed.verify(&chain_id).expect("signature should be valid")
+    }
 }


### PR DESCRIPTION
This change changes the signature checks to allow the case where an ethereum account wants to send a message to a non-ethereum account, e.g. to fund an `f1` account from an `f410` account, where the `f410` address was funded on the subnet by the `ipc-cli`.

So far this has not been allowed because if `message.from` was an ethereum address then the method number had to be `evm::Method::InvokeContract`, which didn't work with custom actors (although an `Account` would have been able to receive funds this way), but due to the vulnearability fixed in https://github.com/consensus-shipyard/ipc/pull/772 a message sent from the EthAPI can only go to an Ethereum account, so f1 wasn't allowed (or, should not have been allowed). 

The solution on Filecoin is https://docs.filecoin.io/smart-contracts/filecoin-evm-runtime/filforwarder which is a Solidity contract that does the forwarding and need to be deployed on an IPC subnet.

With the change in this PR, we should be able to use use the raw Fendermint RPC to produce a message signed by the Secp256k1 public key of the `f410` account, but set the `message.to` to an `f1` address, and sign it as a regular message with `SignedMessage::new_secp256k1` (as in the unit test), and it should not hit the restrictions on eth-to-eth transactions.


### Testing 

I added a new integration test to check this works; it's part of the `smoke-tests` now:

```shell
cd testing/smoke-test/
cargo make setup
cargo make transfer-example
docker logs smoke-fendermint
cargo make teardown
```

The container logs show that the transaction was indeed delivered:
```console
$ docker logs smoke-fendermint
...
2024-03-05T14:13:22.848200Z  INFO query{request=Query { data: b"\xa1jActorStateV\x04\n%X\x1f\n\x8a\x0eA\xca`\xedw\x04\xef7\x91~*\x06Z\xa5", path: "", height: block::Height(0), prove: false }}: fendermint/vm/interpreter/src/fvm/query.rs:66: query actor state height=43 pending=false addr="f410fevmb6cukbza4uyhno4co6n4rpyvamwvfd6grqfa" found=true
2024-03-05T14:13:22.857919Z  INFO fendermint/vm/interpreter/src/fvm/check.rs:51: check transaction exit_code=0 from="f410fevmb6cukbza4uyhno4co6n4rpyvamwvfd6grqfa" to="f1cwd2uvx62r44smul6bwt7byxobphhnc5uvusayy" method_num=0 gas_limit=10000000000 gas_used=5667215 info=""
2024-03-05T14:13:23.043714Z  INFO fendermint/app/src/app.rs:668: event=ProposalProcessed is_accepted=true height=44 size=1 hash="5657862577158E5ECAE51062F00935C416BCD7FEC9948C66923E8E0D99A91AE6" proposer="3FD7936E572A42FB9B8693B543AA93B46149E558"
2024-03-05T14:13:23.075544Z  INFO fendermint/vm/interpreter/src/fvm/exec.rs:143: tx delivered height=44 from="f410fevmb6cukbza4uyhno4co6n4rpyvamwvfd6grqfa" to="f1cwd2uvx62r44smul6bwt7byxobphhnc5uvusayy" method_num=0 exit_code=0 gas_used=5667215
...
```

You can see `from="f410fevmb6cukbza4uyhno4co6n4rpyvamwvfd6grqfa" to="f1cwd2uvx62r44smul6bwt7byxobphhnc5uvusayy" method_num=0` indicates a simple transfer from f410 to f1.