### PR TITLE
Update genesis validator lifecycle

### DIFF
--- a/contracts/src/GatewayDiamond.sol
+++ b/contracts/src/GatewayDiamond.sol
@@ -67,7 +67,13 @@ contract GatewayDiamond {
         // through the gateway constructor in the future.
         s.maxMsgsPerBottomUpBatch = MAX_MSGS_PER_BATCH;
 
-        LibValidatorTracking.init(s.validatorsTracker, params.activeValidatorsLimit, params.genesisValidators);
+        Validator[] memory validators = LibValidatorTracking.init(
+            s.validatorsTracker,
+            params.activeValidatorsLimit,
+            params.genesisValidators
+        );
+        Membership memory initial = Membership({configurationNumber: 0, validators: validators});
+        LibGateway.updateMembership(initial);
     }
 
     function _fallback() internal {

--- a/contracts/src/lib/LibGenesis.sol
+++ b/contracts/src/lib/LibGenesis.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.23;
+
+import {GenesisValidator, SubnetGenesis, ValidatorInfo, ValidatorSet} from "../structs/Subnet.sol";
+import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
+
+/// @notice Provides convinient util methods to handle genesis states of the subnet
+library LibGenesis {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    /// @notice Dumps the validator's genesis information
+    function getValidatorInfo(SubnetGenesis storage self, address validator) internal view returns(GenesisValidator memory info){
+        info = self.validatorInfo[validator];   
+    }
+
+    function addValidator(SubnetGenesis storage self, address validator) internal {
+        self.validators.add(validator);   
+    }
+
+    function removeValidator(SubnetGenesis storage self, address validator) internal {
+        self.validators.remove(validator);   
+    }
+
+    /// @notice Handles the genesis state when the subnet is bootstrapped. From this point onwards,
+    ///         no genesis state of the subnet can be changed.
+    /// @param validatorInfo The validator staking information from LibStaking
+    function bootstrap(SubnetGenesis storage self, ValidatorSet storage validatorInfo) internal {
+        finalizeValidatorInfo(self, validatorInfo);
+    }
+
+    // ============ Interal functions ==============
+
+    /// @notice Finalizes the genesis validator information as the subnet is bootstrapped. After 
+    ///         this point, the genesis validator info can no longer be changed.
+    /// @param validatorInfo The validator staking information from LibStaking
+    function finalizeValidatorInfo(SubnetGenesis storage self, ValidatorSet storage validatorInfo) internal {
+        address[] memory validators = self.validators.values();
+        
+        for (uint256 i = 0; i < validators.length; ) {
+            address addr = validators[i];
+
+            ValidatorInfo memory info = validatorInfo.validators[addr];
+            GenesisValidator memory genesis = GenesisValidator({
+                collateral: info.totalCollateral,
+                federatedPower: info.federatedPower,
+                addr: addr,
+                metadata: info.metadata
+            });
+
+            self.validatorInfo[addr] = genesis;
+
+            unchecked {
+                i++;
+            }
+        }
+    }
+}

--- a/contracts/src/lib/LibStaking.sol
+++ b/contracts/src/lib/LibStaking.sol
@@ -594,7 +594,7 @@ library LibValidatorTracking {
         // empty validator change logs
         self.changes.startConfigurationNumber = LibStaking.INITIAL_CONFIGURATION_NUMBER;
 
-        initValidators(self, validators);
+        return initValidators(self, validators);
     }
 
     function initValidators(

--- a/contracts/src/lib/LibStaking.sol
+++ b/contracts/src/lib/LibStaking.sol
@@ -174,7 +174,6 @@ library LibValidatorSet {
         collateral += getTotalConfirmedCollateral(validators);
     }
 
-
     /// @notice Get the total power of the validators.
     /// The function reverts if at least one validator is not in the active validator set.
     function getTotalPowerOfValidators(
@@ -518,20 +517,6 @@ library LibStaking {
     }
 
     // =============== Other functions ================
-
-    /// @notice Adds the validator to the list of genesis validators if not already added 
-    function addGenesisValidator(address validator) internal {
-        SubnetActorStorage storage s = LibSubnetActorStorage.appStorage();
-
-        // the address set will perform deduplication
-        s.genesisValidators.add(validator);
-    }
-
-    function removeGenesisValidator(address validator) internal {
-        SubnetActorStorage storage s = LibSubnetActorStorage.appStorage();
-        s.genesisValidators.remove(validator);
-    }
-
     /// @notice Claim the released collateral
     function claimCollateral(address validator) internal {
         SubnetActorStorage storage s = LibSubnetActorStorage.appStorage();
@@ -601,7 +586,7 @@ library LibValidatorTracking {
         ParentValidatorsTracker storage self,
         uint16 activeValidatorsLimit,
         GenesisValidator[] memory validators
-    ) internal returns (Validator[] memory membership) {
+    ) internal returns (Validator[] memory) {
         self.validators.activeLimit = activeValidatorsLimit;
         // Start the next configuration number from 1, 0 is reserved for no change and the genesis membership
         self.changes.nextConfigurationNumber = LibStaking.INITIAL_CONFIGURATION_NUMBER;

--- a/contracts/src/lib/LibSubnetActor.sol
+++ b/contracts/src/lib/LibSubnetActor.sol
@@ -14,7 +14,7 @@ import {LibSubnetActorStorage, SubnetActorStorage} from "./LibSubnetActorStorage
 library LibSubnetActor {
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    event SubnetBootstrapped(Validator[]);
+    event SubnetBootstrapped(address[]);
 
     /// @notice Ensures that the subnet is operating under Collateral-based permission mode.
     /// @dev Reverts if the subnet is not in Collateral mode.
@@ -48,7 +48,7 @@ library LibSubnetActor {
         if (totalCollateral >= s.minActivationCollateral) {
             if (LibStaking.totalActiveValidators() >= s.minValidators) {
                 s.bootstrapped = true;
-                emit SubnetBootstrapped(s.genesisValidators);
+                emit SubnetBootstrapped(s.genesisValidators.values());
 
                 // register adding the genesis circulating supply (if it exists)
                 IGateway(s.ipcGatewayAddr).register{value: totalCollateral + s.genesisCircSupply}(s.genesisCircSupply);
@@ -98,8 +98,7 @@ library LibSubnetActor {
 
             LibStaking.setMetadataWithConfirm(validators[i], publicKeys[i]);
             LibStaking.setFederatedPowerWithConfirm(validators[i], powers[i]);
-
-            s.genesisValidators.push(Validator({addr: validators[i], weight: powers[i], metadata: publicKeys[i]}));
+            LibStaking.addGenesisValidator(validators[i]);
 
             unchecked {
                 ++i;
@@ -107,7 +106,7 @@ library LibSubnetActor {
         }
 
         s.bootstrapped = true;
-        emit SubnetBootstrapped(s.genesisValidators);
+        emit SubnetBootstrapped(s.genesisValidators.values());
 
         // register adding the genesis circulating supply (if it exists)
         IGateway(s.ipcGatewayAddr).register{value: s.genesisCircSupply}(s.genesisCircSupply);

--- a/contracts/src/lib/LibSubnetActorStorage.sol
+++ b/contracts/src/lib/LibSubnetActorStorage.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.23;
 import {ConsensusType} from "../enums/ConsensusType.sol";
 import {NotGateway, SubnetAlreadyKilled} from "../errors/IPCErrors.sol";
 import {BottomUpCheckpoint, BottomUpMsgBatchInfo} from "../structs/CrossNet.sol";
-import {SubnetID, ValidatorSet, StakingChangeLog, StakingReleaseQueue, SupplySource, Validator, PermissionMode} from "../structs/Subnet.sol";
+import {SubnetID, ValidatorSet, StakingChangeLog, StakingReleaseQueue, SupplySource, Validator, SubnetGenesis, PermissionMode} from "../structs/Subnet.sol";
 import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
 
     struct SubnetActorStorage {
@@ -55,8 +55,8 @@ import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.
         EnumerableSet.AddressSet bootstrapOwners;
         /// @notice contains all committed bottom-up checkpoint at specific epoch
         mapping(uint256 => BottomUpCheckpoint) committedCheckpoints;
-        /// @notice initial set of validators joining in genesis
-        EnumerableSet.AddressSet genesisValidators;
+        /// @notice Tracks the subnet genesis state
+        SubnetGenesis genesis;
         /// @notice genesis balance to be allocated to the subnet in genesis.
         mapping(address => uint256) genesisBalance;
         /// @notice genesis balance addresses

--- a/contracts/src/lib/LibSubnetActorStorage.sol
+++ b/contracts/src/lib/LibSubnetActorStorage.sol
@@ -56,7 +56,7 @@ import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.
         /// @notice contains all committed bottom-up checkpoint at specific epoch
         mapping(uint256 => BottomUpCheckpoint) committedCheckpoints;
         /// @notice initial set of validators joining in genesis
-        Validator[] genesisValidators;
+        EnumerableSet.AddressSet genesisValidators;
         /// @notice genesis balance to be allocated to the subnet in genesis.
         mapping(address => uint256) genesisBalance;
         /// @notice genesis balance addresses

--- a/contracts/src/structs/Subnet.sol
+++ b/contracts/src/structs/Subnet.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.23;
 import {FvmAddress} from "./FvmAddress.sol";
 import {MaxPQ} from "../lib/priority/LibMaxPQ.sol";
 import {MinPQ} from "../lib/priority/LibMinPQ.sol";
+import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
 
 /// @notice A subnet identity type.
 struct SubnetID {
@@ -151,6 +152,17 @@ struct GenesisValidator {
     uint256 federatedPower;
     address addr;
     bytes metadata;
+}
+
+/// @notice Maintains the genesis information related to a particular subnet
+struct SubnetGenesis {
+    /// The genesis validators
+    EnumerableSet.AddressSet validators;
+    /// Tracks the validator info. This is only populated when the subnet is bootstrapped
+    mapping(address => GenesisValidator) validatorInfo;
+
+    /// TODO: migrating all the genesis related fields to this struct so that one can handle
+    ///       them all in a library.
 }
 
 /// @notice Validator struct stored in the gateway.

--- a/contracts/src/subnet/SubnetActorGetterFacet.sol
+++ b/contracts/src/subnet/SubnetActorGetterFacet.sol
@@ -56,11 +56,27 @@ contract SubnetActorGetterFacet {
 
     /// @notice Returns the initial set of validators of the genesis block.
     function genesisValidators() external view returns (GenesisValidator[] memory validators) {
-        uint256 total = s.genesisValidators.length();
+        uint256 total = s.genesis.validators.length();
+
         validators = new GenesisValidator[](total);
 
+        if (s.bootstrapped) {
+            // subnet boostrapped, that means validator information at genesis should be locked
+            // and cannot be changed anymore, fetch from s.genesis
+
+            for (uint256 i = 0; i < total; ) {
+                address addr = s.genesis.validators.at(i);
+                validators[i] = s.genesis.validatorInfo[addr];
+
+                unchecked {
+                    i++;
+                }
+            }
+            return validators;
+        }
+
         for (uint256 i = 0; i < total; ) {
-            address addr = s.genesisValidators.at(i);
+            address addr = s.genesis.validators.at(i);
             ValidatorInfo memory info = getValidator(addr);
             validators[i] = GenesisValidator({
                 // for genesis validators, totalCollateral == confirmedCollateral

--- a/contracts/src/subnet/SubnetActorGetterFacet.sol
+++ b/contracts/src/subnet/SubnetActorGetterFacet.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.23;
 import {ConsensusType} from "../enums/ConsensusType.sol";
 import {BottomUpCheckpoint, IpcEnvelope} from "../structs/CrossNet.sol";
 import {SubnetID, SupplySource} from "../structs/Subnet.sol";
-import {SubnetID, ValidatorInfo, Validator, PermissionMode} from "../structs/Subnet.sol";
+import {SubnetID, ValidatorInfo, Validator, GenesisValidator, PermissionMode} from "../structs/Subnet.sol";
 import {SubnetActorStorage} from "../lib/LibSubnetActorStorage.sol";
 import {SubnetIDHelper} from "../lib/SubnetIDHelper.sol";
 import {Address} from "openzeppelin-contracts/utils/Address.sol";
@@ -55,8 +55,24 @@ contract SubnetActorGetterFacet {
     }
 
     /// @notice Returns the initial set of validators of the genesis block.
-    function genesisValidators() external view returns (Validator[] memory) {
-        return s.genesisValidators;
+    function genesisValidators() external view returns (GenesisValidator[] memory validators) {
+        uint256 total = s.genesisValidators.length();
+        validators = new GenesisValidator[](total);
+
+        for (uint256 i = 0; i < total; ) {
+            address addr = s.genesisValidators.at(i);
+            ValidatorInfo memory info = getValidator(addr);
+            validators[i] = GenesisValidator({
+                // for genesis validators, totalCollateral == confirmedCollateral
+                collateral: info.totalCollateral, 
+                federatedPower: info.federatedPower,
+                addr: addr,
+                metadata: info.metadata
+            });
+            unchecked {
+                i++;
+            }
+        }
     }
 
     // @notice Provides the circulating supply of the genesis block.
@@ -114,7 +130,7 @@ contract SubnetActorGetterFacet {
 
     /// @notice Returns detailed information about a specific validator.
     /// @param validatorAddress The address of the validator to query information for.
-    function getValidator(address validatorAddress) external view returns (ValidatorInfo memory validator) {
+    function getValidator(address validatorAddress) public view returns (ValidatorInfo memory validator) {
         validator = s.validatorSet.validators[validatorAddress];
     }
 

--- a/contracts/src/subnet/SubnetActorGetterFacet.sol
+++ b/contracts/src/subnet/SubnetActorGetterFacet.sol
@@ -64,7 +64,7 @@ contract SubnetActorGetterFacet {
             ValidatorInfo memory info = getValidator(addr);
             validators[i] = GenesisValidator({
                 // for genesis validators, totalCollateral == confirmedCollateral
-                collateral: info.totalCollateral, 
+                collateral: info.totalCollateral,
                 federatedPower: info.federatedPower,
                 addr: addr,
                 metadata: info.metadata

--- a/contracts/src/subnet/SubnetActorManagerFacet.sol
+++ b/contracts/src/subnet/SubnetActorManagerFacet.sol
@@ -142,6 +142,7 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
             // confirm validators deposit immediately
             LibStaking.setMetadataWithConfirm(msg.sender, publicKey);
             LibStaking.depositWithConfirm(msg.sender, msg.value);
+            LibStaking.addGenesisValidator(msg.sender);
 
             LibSubnetActor.bootstrapSubnetIfNeeded();
         } else {
@@ -169,6 +170,7 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
 
         if (!s.bootstrapped) {
             LibStaking.depositWithConfirm(msg.sender, msg.value);
+            LibStaking.addGenesisValidator(msg.sender);
 
             LibSubnetActor.bootstrapSubnetIfNeeded();
         } else {
@@ -198,6 +200,12 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
         }
         if (!s.bootstrapped) {
             LibStaking.withdrawWithConfirm(msg.sender, amount);
+
+            uint256 amount = LibStaking.totalValidatorCollateral(msg.sender);
+            if (amount == 0) {
+                LibStaking.removeGenesisValidator(msg.sender);
+            }
+
             return;
         }
 
@@ -237,6 +245,7 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
 
             // interaction must be performed after checks and changes
             LibStaking.withdrawWithConfirm(msg.sender, amount);
+            LibStaking.removeGenesisValidator(msg.sender);
             return;
         }
         LibStaking.withdraw(msg.sender, amount);

--- a/contracts/src/subnet/SubnetActorManagerFacet.sol
+++ b/contracts/src/subnet/SubnetActorManagerFacet.sol
@@ -195,7 +195,7 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
         if (collateral == 0) {
             revert NotValidator(msg.sender);
         }
-        if (collateral <= amount) {
+        if (collateral < amount) {
             revert NotEnoughCollateral();
         }
         if (!s.bootstrapped) {

--- a/contracts/src/subnet/SubnetActorManagerFacet.sol
+++ b/contracts/src/subnet/SubnetActorManagerFacet.sol
@@ -5,11 +5,12 @@ import {VALIDATOR_SECP256K1_PUBLIC_KEY_LENGTH} from "../constants/Constants.sol"
 import {ERR_VALIDATOR_JOINED, ERR_VALIDATOR_NOT_JOINED} from "../errors/IPCErrors.sol";
 import {InvalidFederationPayload, SubnetAlreadyBootstrapped, NotEnoughFunds, CollateralIsZero, CannotReleaseZero, NotOwnerOfPublicKey, EmptyAddress, NotEnoughBalance, NotEnoughCollateral, NotValidator, NotAllValidatorsHaveLeft, InvalidPublicKeyLength, MethodNotAllowed, SubnetNotBootstrapped} from "../errors/IPCErrors.sol";
 import {IGateway} from "../interfaces/IGateway.sol";
-import {Validator, ValidatorSet} from "../structs/Subnet.sol";
+import {Validator, ValidatorSet, SubnetGenesis} from "../structs/Subnet.sol";
 import {LibDiamond} from "../lib/LibDiamond.sol";
 import {ReentrancyGuard} from "../lib/LibReentrancyGuard.sol";
 import {SubnetActorModifiers} from "../lib/LibSubnetActorStorage.sol";
 import {LibValidatorSet, LibStaking} from "../lib/LibStaking.sol";
+import {LibGenesis} from "../lib/LibGenesis.sol";
 import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
 import {Address} from "openzeppelin-contracts/utils/Address.sol";
 import {LibSubnetActor} from "../lib/LibSubnetActor.sol";
@@ -18,6 +19,7 @@ import {Pausable} from "../lib/LibPausable.sol";
 contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausable {
     using EnumerableSet for EnumerableSet.AddressSet;
     using LibValidatorSet for ValidatorSet;
+    using LibGenesis for SubnetGenesis;
     using Address for address payable;
 
     /// @notice method to add some initial balance into a subnet that hasn't yet bootstrapped.
@@ -142,7 +144,7 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
             // confirm validators deposit immediately
             LibStaking.setMetadataWithConfirm(msg.sender, publicKey);
             LibStaking.depositWithConfirm(msg.sender, msg.value);
-            LibStaking.addGenesisValidator(msg.sender);
+            s.genesis.addValidator(msg.sender);
 
             LibSubnetActor.bootstrapSubnetIfNeeded();
         } else {
@@ -170,8 +172,6 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
 
         if (!s.bootstrapped) {
             LibStaking.depositWithConfirm(msg.sender, msg.value);
-            LibStaking.addGenesisValidator(msg.sender);
-
             LibSubnetActor.bootstrapSubnetIfNeeded();
         } else {
             LibStaking.deposit(msg.sender, msg.value);
@@ -201,9 +201,9 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
         if (!s.bootstrapped) {
             LibStaking.withdrawWithConfirm(msg.sender, amount);
 
-            uint256 amount = LibStaking.totalValidatorCollateral(msg.sender);
-            if (amount == 0) {
-                LibStaking.removeGenesisValidator(msg.sender);
+            uint256 total = LibStaking.totalValidatorCollateral(msg.sender);
+            if (total == 0) {
+                s.genesis.removeValidator(msg.sender);
             }
 
             return;
@@ -245,7 +245,7 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
 
             // interaction must be performed after checks and changes
             LibStaking.withdrawWithConfirm(msg.sender, amount);
-            LibStaking.removeGenesisValidator(msg.sender);
+            s.genesis.removeValidator(msg.sender);
             return;
         }
         LibStaking.withdraw(msg.sender, amount);

--- a/contracts/test/helpers/TestUtils.sol
+++ b/contracts/test/helpers/TestUtils.sol
@@ -194,7 +194,7 @@ contract MockIpcContractRevert is IpcHandler {
     bool public reverted = true;
 
     /* solhint-disable-next-line unused-vars */
-    function handleIpcMessage(IpcEnvelope calldata) external payable returns (bytes memory ret) {
+    function handleIpcMessage(IpcEnvelope calldata) external payable returns (bytes memory) {
         // success execution of this methid will set reverted to false, by default it's true
         reverted = false;
 

--- a/contracts/test/integration/MultiSubnet.t.sol
+++ b/contracts/test/integration/MultiSubnet.t.sol
@@ -491,8 +491,6 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
         IpcEnvelope[] memory crossMsgs = new IpcEnvelope[](1);
         crossMsgs[0] = resultMsg;
 
-        GatewayManagerFacet manager = GatewayManagerFacet(nativeSubnet.gatewayAddr);
-
         BottomUpCheckpoint memory checkpoint = callCreateBottomUpCheckpointFromChildSubnet(
             nativeSubnet.id,
             nativeSubnet.gateway,
@@ -533,8 +531,6 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
         IpcEnvelope memory resultMsg = CrossMsgHelper.createResultMsg(crossMsg, OutcomeType.ActorErr, new bytes(0));
         IpcEnvelope[] memory crossMsgs = new IpcEnvelope[](1);
         crossMsgs[0] = resultMsg;
-
-        GatewayManagerFacet manager = GatewayManagerFacet(nativeSubnet.gatewayAddr);
 
         BottomUpCheckpoint memory checkpoint = callCreateBottomUpCheckpointFromChildSubnet(
             nativeSubnet.id,
@@ -580,8 +576,6 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
         IpcEnvelope memory resultMsg = CrossMsgHelper.createResultMsg(crossMsg, OutcomeType.SystemErr, new bytes(0));
         IpcEnvelope[] memory crossMsgs = new IpcEnvelope[](1);
         crossMsgs[0] = resultMsg;
-
-        GatewayManagerFacet manager = GatewayManagerFacet(nativeSubnet.gatewayAddr);
 
         BottomUpCheckpoint memory checkpoint = callCreateBottomUpCheckpointFromChildSubnet(
             nativeSubnet.id,
@@ -652,7 +646,6 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
 
     function testMultiSubnet_Erc20_FundResultOkFromChildToParent() public {
         address caller = address(new MockIpcContract());
-        address recipient = address(new MockIpcContractPayable());
         uint256 amount = 3;
 
         token.transfer(caller, amount);
@@ -698,7 +691,6 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
 
     function testMultiSubnet_Erc20_FundResultSystemErrFromChildToParent() public {
         address caller = address(new MockIpcContract());
-        address recipient = address(new MockIpcContractPayable());
         uint256 amount = 3;
 
         token.transfer(caller, amount);
@@ -744,7 +736,6 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
 
     function testMultiSubnet_Erc20_FundResultActorErrFromChildToParent() public {
         address caller = address(new MockIpcContract());
-        address recipient = address(new MockIpcContractPayable());
         uint256 amount = 3;
 
         token.transfer(caller, amount);
@@ -1220,7 +1211,6 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
     ) internal returns (BottomUpCheckpoint memory checkpoint) {
         uint256 e = getNextEpoch(block.number, DEFAULT_CHECKPOINT_PERIOD);
 
-        GatewayGetterFacet getter = gw.getter();
         CheckpointingFacet checkpointer = gw.checkpointer();
 
         (, address[] memory addrs, uint256[] memory weights) = TestUtils.getFourValidators(vm);

--- a/contracts/test/integration/SubnetActorDiamond.t.sol
+++ b/contracts/test/integration/SubnetActorDiamond.t.sol
@@ -12,7 +12,7 @@ import {METHOD_SEND} from "../../src/constants/Constants.sol";
 import {ConsensusType} from "../../src/enums/ConsensusType.sol";
 import {BottomUpMsgBatch, IpcEnvelope, BottomUpCheckpoint} from "../../src/structs/CrossNet.sol";
 import {FvmAddress} from "../../src/structs/FvmAddress.sol";
-import {SubnetID, PermissionMode, IPCAddress, Subnet, SupplySource, ValidatorInfo} from "../../src/structs/Subnet.sol";
+import {SubnetID, PermissionMode, IPCAddress, Subnet, SupplySource, ValidatorInfo, GenesisValidator} from "../../src/structs/Subnet.sol";
 import {IERC165} from "../../src/interfaces/IERC165.sol";
 import {IGateway} from "../../src/interfaces/IGateway.sol";
 import {IDiamond} from "../../src/interfaces/IDiamond.sol";
@@ -88,6 +88,79 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
             saDiamond.diamondLouper().supportsInterface(type(IDiamondLoupe).interfaceId) == true,
             "IDiamondLoupe not supported"
         );
+    }
+
+    /// @notice Testing the genesis validator's collateral
+    function testSubnetActorDiamond_GenesisValidators() public {
+        (address validator1, , bytes memory publicKey1) = TestUtils.newValidator(100);
+        uint256 validator1Stake = DEFAULT_MIN_VALIDATOR_STAKE / 2;
+
+        // initial validator joins
+        vm.deal(validator1, 10 ether); // gas concern free
+        vm.startPrank(validator1);
+
+        saDiamond.manager().join{value: validator1Stake}(publicKey1);
+
+        GenesisValidator[] memory validators = saDiamond.getter().genesisValidators();
+        require(validators[0].addr == validator1);
+        require(validators[0].collateral == validator1Stake);
+        require(keccak256(validators[0].metadata) == keccak256(publicKey1));
+        require(validators[0].federatedPower == 0);
+
+        // subnet will be bootstrapped
+        saDiamond.manager().stake{value: validator1Stake + 1}();
+        validators = saDiamond.getter().genesisValidators();
+        require(validators[0].addr == validator1);
+        require(validators[0].collateral == validator1Stake * 2 + 1);
+
+        // subnet already bootstrapped, will no longer trigger chanes
+        saDiamond.manager().stake{value: validator1Stake + 1}();
+        validators = saDiamond.getter().genesisValidators();
+        require(validators[0].addr == validator1);
+        require(validators[0].collateral == validator1Stake * 2 + 1);
+
+        saDiamond.manager().leave();
+        validators = saDiamond.getter().genesisValidators();
+        require(validators[0].addr == validator1);
+        require(validators[0].collateral == validator1Stake * 2 + 1);
+    }
+
+    /// @notice Testing the genesis validator's collateral
+    function testSubnetActorDiamond_RemoveGenesisValidators() public {
+        (address validator1, , bytes memory publicKey1) = TestUtils.newValidator(100);
+        uint256 validator1Stake = DEFAULT_MIN_VALIDATOR_STAKE / 2;
+
+        // initial validator joins
+        vm.deal(validator1, 10 ether); // gas concern free
+        vm.startPrank(validator1);
+
+        saDiamond.manager().join{value: validator1Stake}(publicKey1);
+
+        saDiamond.manager().leave();
+        require(saDiamond.getter().genesisValidators().length == 0);
+    }
+
+    /// @notice Testing the genesis validator's collateral
+    function testSubnetActorDiamond_UnstakeGenesisValidators() public {
+        (address validator1, , bytes memory publicKey1) = TestUtils.newValidator(100);
+        uint256 validator1Stake = DEFAULT_MIN_VALIDATOR_STAKE / 2;
+
+        // initial validator joins
+        vm.deal(validator1, 10 ether); // gas concern free
+        vm.startPrank(validator1);
+
+        saDiamond.manager().join{value: validator1Stake}(publicKey1);
+        GenesisValidator[] memory validators = saDiamond.getter().genesisValidators();
+        require(validators[0].addr == validator1);
+
+        saDiamond.manager().unstake(validator1Stake / 2);
+        validators = saDiamond.getter().genesisValidators();
+        require(validators[0].addr == validator1);
+        require(validators[0].collateral == validator1Stake / 2, "collateral not match");
+
+        // unstake everything else
+        saDiamond.manager().unstake(validator1Stake / 2);
+        require(saDiamond.getter().genesisValidators().length == 0, "should not be validator");
     }
 
     /// @notice Testing the basic join, stake, leave lifecycle of validators


### PR DESCRIPTION
Fixing genesis validators not updated when `unstake` and `leave` are called.

Currently in `unstake`, when a validator unstakes all the collateral previuosly staked, then the validator address will not be removed from `genesisValidators`, see [line](https://github.com/consensus-shipyard/ipc/blob/9fe1ee01e85ef430b77aceccc90a934ec947edee/contracts/src/subnet/SubnetActorManagerFacet.sol#L200). The same happens to `leave`.

Note that this PR will fail the CI only when https://github.com/consensus-shipyard/ipc/pull/784 is merged into this branch.