### PR TITLE
Fix Gateway & Registry Diamond Upgrade script

### DIFF
--- a/contracts/scripts/util.ts
+++ b/contracts/scripts/util.ts
@@ -89,9 +89,10 @@ export async function getFacets(diamondAddress: string): Promise<FacetMap> {
 async function startGanache() {
     return new Promise((resolve, reject) => {
         const server = ganache.server({
-            gasPrice: '0x0', // Set gas price to 0
+            miner: { defaultGasPrice: '0x0' },
+            chain: { hardfork: 'berlin' },
         })
-        server.listen(8545, (err) => {
+        server.listen(18678, (err) => {
             if (err) reject(err)
             else resolve(server)
         })
@@ -114,10 +115,10 @@ export async function getRuntimeBytecode(bytecode) {
     }
     const ganacheServer = await startGanache()
 
-    const provider = new providers.JsonRpcProvider('http://127.0.0.1:8545')
+    const provider = new providers.JsonRpcProvider('http://127.0.0.1:18678')
     const wallet = new Wallet(process.env.PRIVATE_KEY, provider)
     const contractFactory = new ContractFactory([], bytecode, wallet)
-    const contract = await contractFactory.deploy()
+    const contract = await contractFactory.deploy({ gasPrice: 0 })
     await contract.deployed()
 
     const runtimeBytecode = await provider.getCode(contract.address)

--- a/contracts/scripts/util.ts
+++ b/contracts/scripts/util.ts
@@ -9,6 +9,8 @@ const fs = require('fs')
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
+const isolatedPort = 18678;
+
 export async function deployContractWithDeployer(
     deployer: SignerWithAddress,
     contractName: string,
@@ -93,7 +95,7 @@ async function startGanache() {
             chain: { hardfork: 'berlin' },
             logging: { quiet: true },
         })
-        server.listen(18678, (err) => {
+        server.listen(isolatedPort, (err) => {
             if (err) reject(err)
             else resolve(server)
         })
@@ -116,7 +118,7 @@ export async function getRuntimeBytecode(bytecode) {
     }
     const ganacheServer = await startGanache()
 
-    const provider = new providers.JsonRpcProvider('http://127.0.0.1:18678')
+    const provider = new providers.JsonRpcProvider(`http://127.0.0.1:${isolatedPort}`);
     const wallet = new Wallet(process.env.PRIVATE_KEY, provider)
     const contractFactory = new ContractFactory([], bytecode, wallet)
     const contract = await contractFactory.deploy({ gasPrice: 0 })

--- a/contracts/scripts/util.ts
+++ b/contracts/scripts/util.ts
@@ -91,6 +91,7 @@ async function startGanache() {
         const server = ganache.server({
             miner: { defaultGasPrice: '0x0' },
             chain: { hardfork: 'berlin' },
+            logging: { quiet: true },
         })
         server.listen(18678, (err) => {
             if (err) reject(err)
@@ -122,9 +123,7 @@ export async function getRuntimeBytecode(bytecode) {
     await contract.deployed()
 
     const runtimeBytecode = await provider.getCode(contract.address)
-
-    await stopGanache(ganacheServer)
-
+    stopGanache(ganacheServer)
     return runtimeBytecode
 }
 

--- a/contracts/scripts/util.ts
+++ b/contracts/scripts/util.ts
@@ -9,7 +9,7 @@ const fs = require('fs')
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
-const isolatedPort = 18678;
+const isolatedPort = 18678
 
 export async function deployContractWithDeployer(
     deployer: SignerWithAddress,
@@ -118,7 +118,9 @@ export async function getRuntimeBytecode(bytecode) {
     }
     const ganacheServer = await startGanache()
 
-    const provider = new providers.JsonRpcProvider(`http://127.0.0.1:${isolatedPort}`);
+    const provider = new providers.JsonRpcProvider(
+        `http://127.0.0.1:${isolatedPort}`,
+    )
     const wallet = new Wallet(process.env.PRIVATE_KEY, provider)
     const contractFactory = new ContractFactory([], bytecode, wallet)
     const contract = await contractFactory.deploy({ gasPrice: 0 })


### PR DESCRIPTION
I think there was a ganache update that lead to our code being out of date. I have upgraded the code that uses ganache to use the new config format. 

Below is an example of how the code works and how you can verify it is working. In the demo below I deploy a gateway using make, edit one of the facets, upgrade the facet, then revert the change locally and upgrade the facet again to the new bytecode.

```
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ source .env
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ git status
On branch mikers/diamondUpgradeFixes
Your branch is up to date with 'origin/mikers/diamondUpgradeFixes'.

nothing to commit, working tree clean
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ git diff
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ make
./ops/deploy.sh auto
[*] Automatically getting chainID for network
[*] Target network Chain ID: 0xc8407b57bf423
[*] Deploying libraries
[*] Output libraries available in /home/mikers/dev/consensus-shipyard/ipc/contracts/scripts/libraries.out
[*] Populating deploy-gateway script
[*] Gateway script in /home/mikers/dev/consensus-shipyard/ipc/contracts/scripts/deploy-gateway.ts
[*] Gateway deployed: 
{
  "ChainID": 31415926,
  "Gateway": "0x595112283892f4Df6b176d21556ED37178EEB25B",
  "Facets": [
    {
      "name": "GatewayGetterFacet",
      "libs": {
        "SubnetIDHelper": "0xdC130d4FB326D77c0a300Fbb1cbcE8b7de7E9C9F",
        "LibQuorum": "0x06B9bb8e59F0169A3d936AaA651cd33B4Aa3D380"
      },
      "address": "0xb2B31e93c64f8f036191d12fe994975359C0F506"
    },
    {
      "name": "DiamondLoupeFacet",
      "libs": {},
      "address": "0x519bC3AC622AB3345bFa95F617783d07a75e8AF8"
    },
    {
      "name": "DiamondCutFacet",
      "libs": {},
      "address": "0xe8F3148d6eA60aBd6aE94B95c3D3338458f49aB7"
    },
    {
      "name": "GatewayManagerFacet",
      "libs": {
        "CrossMsgHelper": "0x3091b62Fcc14Fb62B39319cAfb8284e2e633e2B6",
        "SubnetIDHelper": "0xdC130d4FB326D77c0a300Fbb1cbcE8b7de7E9C9F"
      },
      "address": "0x69Bc522f9Fc8e683cEaEe4e22e26Ebda120e4178"
    },
    {
      "name": "GatewayMessengerFacet",
      "libs": {
        "SubnetIDHelper": "0xdC130d4FB326D77c0a300Fbb1cbcE8b7de7E9C9F",
        "CrossMsgHelper": "0x3091b62Fcc14Fb62B39319cAfb8284e2e633e2B6"
      },
      "address": "0xDB72EC4227093cCad3B423f5c22dda303E32D403"
    },
    {
      "name": "CheckpointingFacet",
      "libs": {
        "AccountHelper": "0xa7c71aDEde14dA8E04BA8aA7ADFBc91710e27971",
        "SubnetIDHelper": "0xdC130d4FB326D77c0a300Fbb1cbcE8b7de7E9C9F",
        "CrossMsgHelper": "0x3091b62Fcc14Fb62B39319cAfb8284e2e633e2B6"
      },
      "address": "0xcEee13d07ac1DFDA253f554Ad7e43e5f36c58FBe"
    },
    {
      "name": "XnetMessagingFacet",
      "libs": {
        "AccountHelper": "0xa7c71aDEde14dA8E04BA8aA7ADFBc91710e27971",
        "CrossMsgHelper": "0x3091b62Fcc14Fb62B39319cAfb8284e2e633e2B6",
        "SubnetIDHelper": "0xdC130d4FB326D77c0a300Fbb1cbcE8b7de7E9C9F"
      },
      "address": "0xA3521BbFab40e2985E08cFC33E923bE76b972a2E"
    },
    {
      "name": "TopDownFinalityFacet",
      "libs": {
        "AccountHelper": "0xa7c71aDEde14dA8E04BA8aA7ADFBc91710e27971"
      },
      "address": "0x035f5F498EedA25628d59Ce16CEe4569ccdCdCF1"
    }
  ]
}
[*] Output gateway address in /home/mikers/dev/consensus-shipyard/ipc/contracts/scripts/gateway.out
[*] Populating deploy-registry script
[*] Registry script in /home/mikers/dev/consensus-shipyard/ipc/contracts/scripts/deploy-registry.ts
Deploying contracts with account: 0x115D8aF2aDfe91B9c4CC5081763c7c980fcC620f and balance: 97189775160000000000
{
  "SubnetRegistry": "0xD56c2b5814241AAA17D40b87b8F302DBDEa16D3f",
  "Facets": [
    {
      "name": "RegisterSubnetFacet",
      "libs": {
        "SubnetIDHelper": "0xdC130d4FB326D77c0a300Fbb1cbcE8b7de7E9C9F"
      },
      "address": "0xec7F3560Ff22E2347E947E9a5928b7d072E26feB"
    },
    {
      "name": "SubnetGetterFacet",
      "libs": {},
      "address": "0x36A63efECC8cf1f6CB37A8a4806B0e7210e07fE9"
    },
    {
      "name": "DiamondLoupeFacet",
      "libs": {},
      "address": "0xD234f59287F6589DBED1ada4712f4f4f5aC56345"
    },
    {
      "name": "DiamondCutFacet",
      "libs": {},
      "address": "0x7Af3590549F742CDCBf87b34967Ca17cfB8C78D3"
    }
  ]
}
[*] IPC actors successfully deployed
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ make upgrade-gw-diamond 
./ops/upgrade-gw-diamond.sh auto
[*] Automatically getting chainID for network
[*] Target network Chain ID: 0xc8407b57bf423
Nothing to compile
No need to generate any newer typings.
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ # nothing new is deployed so no changes are made
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ vim ^C
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ vim src/gateway/GatewayManagerFacet.sol 
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ git diff
diff --git a/contracts/src/gateway/GatewayManagerFacet.sol b/contracts/src/gateway/GatewayManagerFacet.sol
index 561270b3..5482f871 100644
--- a/contracts/src/gateway/GatewayManagerFacet.sol
+++ b/contracts/src/gateway/GatewayManagerFacet.sol
@@ -33,7 +33,7 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
     function register(uint256 genesisCircSupply) external payable {
         // If L2+ support is not enabled, only allow the registration of new
         // subnets in the root
-        if (s.networkName.route.length + 1 >= s.maxTreeDepth) {
+        if (s.networkName.route.length + 9999 >= s.maxTreeDepth) {
             revert MethodNotAllowed(ERR_CHILD_SUBNET_NOT_ALLOWED);
         }
 
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ make upgrade-gw-diamond 
./ops/upgrade-gw-diamond.sh auto
[*] Automatically getting chainID for network
[*] Target network Chain ID: 0xc8407b57bf423
Generating typings for: 1 artifacts in dir: typechain for target: ethers-v5
Successfully generated 5 typings!
Compiled 1 Solidity file successfully (evm target: paris).

Facet Bytecode Not Found:
---------------------------------
Facet Name: GatewayManagerFacet
Libraries:
  - CrossMsgHelper: 0x3091b62Fcc14Fb62B39319cAfb8284e2e633e2B6
  - SubnetIDHelper: 0xdC130d4FB326D77c0a300Fbb1cbcE8b7de7E9C9F
Address: 0x69Bc522f9Fc8e683cEaEe4e22e26Ebda120e4178


Diamond Facet Upgrade:
-----------------------------------
Diamond Address: 0x595112283892f4Df6b176d21556ED37178EEB25B
Replacement Facet Name: GatewayManagerFacet


Deployment Status:
-------------------------
New replacement facet (GatewayManagerFacet) deployed.

mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ git diff
diff --git a/contracts/src/gateway/GatewayManagerFacet.sol b/contracts/src/gateway/GatewayManagerFacet.sol
index 561270b3..5482f871 100644
--- a/contracts/src/gateway/GatewayManagerFacet.sol
+++ b/contracts/src/gateway/GatewayManagerFacet.sol
@@ -33,7 +33,7 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
     function register(uint256 genesisCircSupply) external payable {
         // If L2+ support is not enabled, only allow the registration of new
         // subnets in the root
-        if (s.networkName.route.length + 1 >= s.maxTreeDepth) {
+        if (s.networkName.route.length + 9999 >= s.maxTreeDepth) {
             revert MethodNotAllowed(ERR_CHILD_SUBNET_NOT_ALLOWED);
         }
 
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ make upgrade-gw-diamond 
./ops/upgrade-gw-diamond.sh auto
[*] Automatically getting chainID for network
[*] Target network Chain ID: 0xc8407b57bf423
Nothing to compile
No need to generate any newer typings.
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ git checkout -f 
Your branch is up to date with 'origin/mikers/diamondUpgradeFixes'.
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ git diff
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ make upgrade-gw-diamond 
./ops/upgrade-gw-diamond.sh auto
[*] Automatically getting chainID for network
[*] Target network Chain ID: 0xc8407b57bf423
Generating typings for: 1 artifacts in dir: typechain for target: ethers-v5
Successfully generated 5 typings!
Compiled 1 Solidity file successfully (evm target: paris).

Facet Bytecode Not Found:
---------------------------------
Facet Name: GatewayManagerFacet
Libraries:
  - CrossMsgHelper: 0x3091b62Fcc14Fb62B39319cAfb8284e2e633e2B6
  - SubnetIDHelper: 0xdC130d4FB326D77c0a300Fbb1cbcE8b7de7E9C9F
Address: 0x53852A038b39D60B487b684A29Cc322F4060EdC0


Diamond Facet Upgrade:
-----------------------------------
Diamond Address: 0x595112283892f4Df6b176d21556ED37178EEB25B
Replacement Facet Name: GatewayManagerFacet


Deployment Status:
-------------------------
New replacement facet (GatewayManagerFacet) deployed.

```

This code also fixes the registry:

```
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/contracts$ make upgrade-sr-diamond 
./ops/upgrade-sr-diamond.sh auto
[*] Automatically getting chainID for network
[*] Target network Chain ID: 0xc8407b57bf423
Generating typings for: 1 artifacts in dir: typechain for target: ethers-v5
Successfully generated 5 typings!
Compiled 1 Solidity file successfully (evm target: paris).

Facet Bytecode Not Found:
---------------------------------
Facet Name: RegisterSubnetFacet
Libraries:
  - SubnetIDHelper: 0xdC130d4FB326D77c0a300Fbb1cbcE8b7de7E9C9F
Address: 0xec7F3560Ff22E2347E947E9a5928b7d072E26feB


Diamond Facet Upgrade:
-----------------------------------
Diamond Address: 0xD56c2b5814241AAA17D40b87b8F302DBDEa16D3f
Replacement Facet Name: RegisterSubnetFacet


Deployment Status:
-------------------------
New replacement facet (RegisterSubnetFacet) deployed.

```

Future issue we need to develop a strategy for upgrading the subnets because the registry is the owner. I think that having the registry add a function for upgrading a specific subnet is a good start