### PR TITLE
FIX: Add a retry to result fetching in filters

### DIFF
--- a/fendermint/eth/api/src/conv/from_tm.rs
+++ b/fendermint/eth/api/src/conv/from_tm.rs
@@ -99,7 +99,7 @@ pub fn is_block_zero(block: &tendermint::Block) -> bool {
 
 /// Convert a Tendermint block to Ethereum with only the block hashes in the body.
 pub fn to_eth_block(
-    block: tendermint::Block,
+    block: &tendermint::Block,
     block_results: tendermint_rpc::endpoint::block_results::Response,
     base_fee: TokenAmount,
     chain_id: ChainID,
@@ -449,7 +449,7 @@ pub fn to_eth_block_zero(block: tendermint::Block) -> anyhow::Result<et::Block<s
         validator_updates: Vec::new(),
         consensus_param_updates: None,
     };
-    let block = to_eth_block(block, block_results, TokenAmount::zero(), ChainID::from(0))
+    let block = to_eth_block(&block, block_results, TokenAmount::zero(), ChainID::from(0))
         .context("failed to map block zero to eth")?;
     let block =
         map_rpc_block_txs(block, serde_json::to_value).context("failed to convert to JSON")?;

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -303,7 +303,7 @@ where
     where
         C: Client + Sync + Send,
     {
-        let block = enrich_block(&self.client, block).await?;
+        let block = enrich_block(&self.client, &block).await?;
 
         let block = if full_tx {
             map_rpc_block_txs(block, serde_json::to_value).context("failed to convert to JSON")?
@@ -609,7 +609,7 @@ impl<C> JsonRpcState<C> {
 
 pub async fn enrich_block<C>(
     client: &FendermintClient<C>,
-    block: tendermint::Block,
+    block: &tendermint::Block,
 ) -> JsonRpcResult<et::Block<et::Transaction>>
 where
     C: Client + Sync + Send,


### PR DESCRIPTION
See [Slack](https://filecoinproject.slack.com/archives/C05UA7RALFP/p1710027805432869)


### Problem

```
Mar 09 23:17:37 ip-172-31-40-164 nox[37276]: 2024-03-09T23:17:37.158639Z ERROR tokio-runtime-worker ThreadId(04) chain-listener: newHeads event processing error: newHeads: timestamp field not found; got {"code":23,"message":"failed to process events: Tendermint RPC error: response error\n\nCaused by:\n    Internal error: could not find results for height #1006291 (code: -32603)\n\nLocation:\n    /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/flex-error-0.4.4/src/tracer_impl/eyre.rs:10:9 (code: 0)"}
```

We receive this event when we do `eth_subscribe` for `newHeads`:

```
{"code":23,"message":"failed to process events: Tendermint RPC error: response error\n\nCaused by:\n    Internal error: could not find results for height #1006291 (code: -32603)\n\nLocation:\n    /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/flex-error-0.4.4/src/tracer_impl/eyre.rs:10:9 (code: 0)"}
It did happen before, but it was rare, and now it happens almost constantly. Maybe 1 out of 10 comes a normal Block Header. 
```

Here's how we subscribe
https://github.com/fluencelabs/nox/blob/master/crates/chain-listener/src/listener.rs#L490-L505
```
ws_client.subscribe("eth_subscribe", rpc_params!["newHeads"], "eth_unsubscribe")
```

these are logs from ETH Relay,
```
2024-03-10T00:22:00.942578Z ERROR fendermint/eth/api/src/filters.rs:702: filter subscription error id=15601448746221408946 query="message.to = 'f410fsfsfbk3zkmjid2gjywhl2yebvgrmjuo6gdcqo3i' AND event.t1 = '8e4b27eeb3194deef0b3140997e6b82f53eb7350daceb9355268009b92f70add' AND event.t2 = 'b068321220c4095a955bca5bd4af9612ad80d5456c7cb22adbb1bb224c5a2b74'" error=response error
    /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/flex-error-0.4.4/src/tracer_impl/eyre.rs:10:9
```

```
2024-03-10T01:01:52.336574Z  INFO fendermint/eth/api/src/filters.rs:423: handling filter events id=4280370999387660030

    /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/flex-error-0.4.4/src/tracer_impl/eyre.rs:10:9 (code: 0) id=10488377558512049232
Location:
    Internal error: could not find results for height #1010749 (code: -32603)

Caused by:
2024-03-10T01:01:52.245167Z ERROR fendermint/eth/api/src/filters.rs:604: sending error to WS: failed to process events: Tendermint RPC error: response error
2024-03-10T01:01:01.143922Z  INFO fendermint/eth/api/src/filters.rs:423: handling filter events id=10488377558512049232

    /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/flex-error-0.4.4/src/tracer_impl/eyre.rs:10:9 (code: 0) id=11818235614209661783
Location:
```

### Bandaid

When `eth_subscribe` is used with the WebSocket client it needs full blocks, whereas in the JSON-RPC API it needs block hash. To construct full blocks, we need to fetch transcaction results: even though the block will only contain the hashes when it's sent to the client, to fill the `gas_used` for example we need all the transactions. 

The `NewBlock` event we receive from Tendermint has `result_begin_block` and `result_end_block`, but for some reason the logs above say that height cannot be queried yet. This PR adds a retry loop there, assuming that we procude blocks with ~1 interval, so if we try max 5 times with 1s sleep we should see something.