### PR TITLE
Add halt_height option to gracefully stop a node at certain height

### DIFF
--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -15,6 +15,9 @@ builtin_actors_bundle = "bundle.car"
 custom_actors_bundle = "custom_actors_bundle.car"
 # Where to reach CometBFT for queries or broadcasting transactions.
 tendermint_rpc_url = "http://127.0.0.1:26657"
+# Block height where we should gracefully stop the node to perform maintenance or
+# with planning for an upcoming coordinated upgrade. Set to 0 to never halt.
+halt_height = 0
 
 # Secp256k1 private key used for signing transactions. Leave empty if not validating,
 # or if it's not needed to sign and broadcast transactions as a validator.

--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -212,6 +212,9 @@ pub struct Settings {
     /// Where to reach CometBFT for queries or broadcasting transactions.
     tendermint_rpc_url: Url,
 
+    /// Block height where we should gracefully stop the node
+    pub halt_height: i64,
+
     /// Secp256k1 private key used for signing transactions sent in the validator's name. Leave empty if not validating.
     pub validator_key: Option<SigningKey>,
 

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -44,6 +44,7 @@ use tendermint::abci::{request, response};
 use tracing::instrument;
 
 use crate::events::{NewBlock, ProposalProcessed};
+use crate::AppExitCode;
 use crate::BlockHeight;
 use crate::{tmconv::*, VERSION};
 
@@ -111,6 +112,8 @@ pub struct AppConfig<S: KVStore> {
     pub builtin_actors_bundle: PathBuf,
     /// Path to the custom actor WASM bundle.
     pub custom_actors_bundle: PathBuf,
+    /// Block height where we should gracefully stop the node
+    pub halt_height: i64,
 }
 
 /// Handle ABCI requests.
@@ -136,6 +139,8 @@ where
     builtin_actors_bundle: PathBuf,
     /// Path to the custom actor WASM bundle.
     custom_actors_bundle: PathBuf,
+    /// Block height where we should gracefully stop the node
+    halt_height: i64,
     /// Namespace to store app state.
     namespace: S::Namespace,
     /// Collection of past state parameters.
@@ -189,6 +194,7 @@ where
             multi_engine: Arc::new(MultiEngine::new(1)),
             builtin_actors_bundle: config.builtin_actors_bundle,
             custom_actors_bundle: config.custom_actors_bundle,
+            halt_height: config.halt_height,
             namespace: config.app_namespace,
             state_hist: KVCollection::new(config.state_hist_namespace),
             state_hist_size: config.state_hist_size,
@@ -690,6 +696,14 @@ where
             tendermint::Hash::Sha256(h) => h,
             tendermint::Hash::None => return Err(anyhow!("empty block hash").into()),
         };
+
+        if self.halt_height != 0 && block_height == self.halt_height {
+            tracing::info!(
+                height = block_height,
+                "Stopping node due to reaching halt height"
+            );
+            std::process::exit(AppExitCode::Halt as i32);
+        }
 
         let db = self.state_store_clone();
         let state = self.committed_state()?;

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -251,6 +251,7 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
             state_hist_size: settings.db.state_hist_size,
             builtin_actors_bundle: settings.builtin_actors_bundle(),
             custom_actors_bundle: settings.custom_actors_bundle(),
+            halt_height: settings.halt_height,
         },
         db,
         state_store,

--- a/fendermint/app/src/lib.rs
+++ b/fendermint/app/src/lib.rs
@@ -13,3 +13,10 @@ pub use store::{AppStore, BitswapBlockstore};
 pub type BlockHeight = u64;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Debug)]
+pub enum AppExitCode {
+    Ok = 0,
+    UnknownError = 1,
+    Halt = 2,
+}

--- a/fendermint/app/src/lib.rs
+++ b/fendermint/app/src/lib.rs
@@ -16,7 +16,10 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Debug)]
 pub enum AppExitCode {
+    /// Fendermint exited normally
     Ok = 0,
+    /// Fendermint exited with an unknown error
     UnknownError = 1,
+    /// Fendermint exited since it reached a block height equal to halt_height
     Halt = 2,
 }

--- a/fendermint/app/src/main.rs
+++ b/fendermint/app/src/main.rs
@@ -98,7 +98,7 @@ async fn main() {
 
     if let Err(e) = cmd::exec(&opts).await {
         tracing::error!("failed to execute {:?}: {e:?}", opts);
-        std::process::exit(1);
+        std::process::exit(fendermint_app::AppExitCode::UnknownError as i32);
     }
 }
 


### PR DESCRIPTION
This PR introduces `halt_height` to the fendermint config which when set (is non zero) will cause fendermint to halt and exit with a unique exit code.

## Test plan

### Test that setting a halt_height stops fendermint at the specified height

Make sure we have `halt_height` set in our fendermint config (if its not set, you will see a "missing field halt_height" error when starting fendermint). Here we set it to halt at height 450:

```
> cat ~/.fendermint/config/default.toml | grep -B 2 halt_height
# Block height where we should gracefully stop the node to perform maintenance or
# with planning for an upcoming coordinated upgrade. Set to 0 to never halt.
halt_height = 450
```

Start fendermint and observe that once it process block height 450 it stops with an exit code of value `2`:

```
> cargo run -p fendermint_app --release -- run
...
2024-03-19T13:57:51.946154Z  INFO fendermint/app/src/app.rs:786: event=NewBlock block_height=448
2024-03-19T13:57:52.904824Z  INFO fendermint/app/src/app.rs:677: event=ProposalProcessed is_accepted=true block_height=449 block_hash="55E10F55140A995CEE4B540776EF5916CBC5C9D81137FED6788C82F2ACBEA28D" num_txs=0 proposer="BA9ADDB0F298912DB80757EA743C3672AE918FF8"
2024-03-19T13:57:53.006128Z  INFO fendermint/app/src/app.rs:786: event=NewBlock block_height=449
2024-03-19T13:57:53.980298Z  INFO fendermint/app/src/app.rs:677: event=ProposalProcessed is_accepted=true block_height=450 block_hash="7B5830D4F138D4329909B64AE0A71296271AD65C83158DDED59DEB3C01DDC650" num_txs=0 proposer="BA9ADDB0F298912DB80757EA743C3672AE918FF8"
2024-03-19T13:57:54.036789Z  INFO fendermint/app/src/app.rs:701: Stopping node due to reaching halt height height=450

# confirm the exit code 
> echo $?
2
```

## Test replacing fendermint with a newer version that has an upgrade scheduled at the halt height

First, we need to edit the fendermint config and change the `halt_height` from 450 to either 0 or some future halt_height.

```
cat ~/.fendermint/config/default.toml | grep -B 2 halt_height
# Block height where we should gracefully stop the node to perform maintenance or
# with planning for an upcoming coordinated upgrade. Set to 0 to never halt.
halt_height = 0
```

Next we prepare a new version of fendermint which has some Upgrade defined at block_height 450 where we can add in our migration logic. We do this where the `FvmMessageInterpreter` is initialized in `fendermint/app/src/cmd/run.rs`, an example would be:

```rust
    let mut upgrade_scheduler: UpgradeScheduler<NamespaceBlockstore> = UpgradeScheduler::new();
    upgrade_scheduler
        .add(Upgrade::new_by_id(
            1942764459484029.into(), // make sure to adjust to your chain_id
            450,
            None,
            |_state| {
                println!("Applying migration for upgrade at blockheight 450");
                // Here you have access to the state_tree and block store through state param
                // to implement your migration logic
                Ok(())
            },
        ))
        .unwrap();

    let interpreter = FvmMessageInterpreter::<NamespaceBlockstore, _>::new(
        tendermint_client.clone(),
        validator_ctx,
        settings.contracts_dir(),
        settings.fvm.gas_overestimation_rate,
        settings.fvm.gas_search_step,
        settings.fvm.exec_in_check,
        upgrade_scheduler,
    );
```

We start the new fendermint version and observe that it applied the migration at the previous halt_height:

```
>  cargo run -p fendermint_app --release -- run
2024-03-19T14:07:25.688613Z  INFO fendermint/vm/interpreter/src/fvm/exec.rs:220: Executing an upgrade chain_id=ChainID(1942764459484029) height=450
Applying migration for upgrade at blockheight 450
2024-03-19T14:07:25.688632Z  INFO fendermint/app/src/app.rs:786: event=NewBlock block_height=450
2024-03-19T14:07:26.816854Z  INFO fendermint/app/src/app.rs:677: event=ProposalProcessed is_accepted=true block_height=451 block_hash="2D57B7B8B7D617937A110FE4713BC24CA69BE2DA8B50B4C4CDE5316D714A62E2" num_txs=0 proposer="BA9ADDB0F298912DB80757EA743C3672AE918FF8"
2024-03-19T14:07:26.918098Z  INFO fendermint/app/src/app.rs:786: event=NewBlock block_height=451
2024-03-19T14:07:27.876222Z  INFO fendermint/app/src/app.rs:677: event=ProposalProcessed is_accepted=true block_height=452 block_hash="5ACECE5D0A8AB6C1C51A358B5527C9397B6FE580B6D485C0FE9B8B0FAB074E90" num_txs=0 proposer="BA9ADDB0F298912DB80757EA743C3672AE918FF8"
2024-03-19T14:07:27.974140Z  INFO fendermint/app/src/app.rs:786: event=NewBlock block_height=452
```