### PR TITLE
CLI: Add env var for config path

### DIFF
--- a/ipc/cli/src/commands/mod.rs
+++ b/ipc/cli/src/commands/mod.rs
@@ -113,7 +113,7 @@ struct GlobalOptions {
 /// ```
 pub async fn cli() -> anyhow::Result<()> {
     let global = GlobalOptions::parse();
-    set_current_network(global.global_params.network);
+    set_current_network(global.global_params.network());
 
     // parse the arguments
     let args = IPCAgentCliCommands::parse();

--- a/ipc/cli/src/lib.rs
+++ b/ipc/cli/src/lib.rs
@@ -34,13 +34,18 @@ pub trait CommandLineHandler {
 pub struct GlobalArguments {
     #[arg(
         long,
-        help = "The toml config file path for IPC Agent, default to ${HOME}/.ipc-agent/config.toml"
+        help = "The toml config file path for IPC Agent, default to ${HOME}/.ipc/config.toml",
+        env = "IPC_CLI_CONFIG_PATH"
     )]
     config_path: Option<String>,
 
     /// Set the FVM Address Network. It's value affects whether `f` (main) or `t` (test) prefixed addresses are accepted.
-    #[arg(long, default_value = "testnet", env = "NETWORK", value_parser = parse_network)]
-    pub network: Network,
+    #[arg(long, default_value = "testnet", env = "IPC_NETWORK", value_parser = parse_network)]
+    _network: Network,
+
+    /// Legacy env var for network
+    #[arg(hide = true, env = "NETWORK", value_parser = parse_network)]
+    __network: Option<Network>,
 }
 
 impl GlobalArguments {
@@ -53,6 +58,10 @@ impl GlobalArguments {
     pub fn config(&self) -> Result<Config> {
         let config_path = self.config_path();
         Config::from_file(config_path)
+    }
+
+    pub fn network(&self) -> Network {
+        self.__network.unwrap_or(self._network)
     }
 }
 


### PR DESCRIPTION
> Also would be awesome so be able to specify ipc config path with env variable

Adds the `IPC_CLI_CONFIG_PATH` env var for the `config.toml` path and an `IPC_NETWORK` as a prefixed version of `NETWORK`. 

Fendermint has `FM_NETWORK` which I admit isn't ideal. I think people would frown on `FM_` prefixes in the `ipc-cli`, so this PR also changes `fendermint` to look for some environment variable aliases, preferring the `FM_` version but also accepting `IPC_` in this case, as well as the non-prefixed version. The same treatment is added to the `FM_LOG_LEVEL`, which allowed me to remove the `_log_level` field; it also looks for `RUST_LOG` now, which is the variable the `ipc-cli` uses (and might be tried based on intuition for those used to Rust libraries).