### PR TITLE
ENG-771: Add upgrade-info json file to determine when upgrades are applied + rpc + cli

### DIFF
--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -15,6 +15,9 @@ builtin_actors_bundle = "bundle.car"
 custom_actors_bundle = "custom_actors_bundle.car"
 # Where to reach CometBFT for queries or broadcasting transactions.
 tendermint_rpc_url = "http://127.0.0.1:26657"
+# The upgrade_info JSON file contains mapping from block height to upgrade info which is
+# used to determine when to run an upgrade migration while progressing through the chain.
+upgrade_info = "upgrade_info.json"
 
 # Secp256k1 private key used for signing transactions. Leave empty if not validating,
 # or if it's not needed to sign and broadcast transactions as a validator.

--- a/fendermint/app/options/src/lib.rs
+++ b/fendermint/app/options/src/lib.rs
@@ -9,7 +9,7 @@ use tracing_subscriber::EnvFilter;
 
 use self::{
     eth::EthArgs, genesis::GenesisArgs, key::KeyArgs, materializer::MaterializerArgs, rpc::RpcArgs,
-    run::RunArgs,
+    run::RunArgs, upgrade::UpgradeArgs,
 };
 
 pub mod eth;
@@ -18,6 +18,7 @@ pub mod key;
 pub mod materializer;
 pub mod rpc;
 pub mod run;
+pub mod upgrade;
 
 mod log;
 mod parse;
@@ -160,6 +161,8 @@ pub enum Commands {
     /// Subcommands related to the Testnet Materializer.
     #[clap(aliases  = &["mat", "matr", "mate"])]
     Materializer(MaterializerArgs),
+    // Subcommands related to managing the upgrade_info.json file
+    Upgrade(UpgradeArgs),
 }
 
 #[cfg(test)]

--- a/fendermint/app/options/src/rpc.rs
+++ b/fendermint/app/options/src/rpc.rs
@@ -94,6 +94,8 @@ pub enum RpcQueryCommands {
     StateParams,
     /// Query the current upgrade schedule
     UpgradeSchedule,
+    /// Get the current node state
+    NodeState,
 }
 
 #[derive(Subcommand, Debug, Clone)]

--- a/fendermint/app/options/src/rpc.rs
+++ b/fendermint/app/options/src/rpc.rs
@@ -92,6 +92,8 @@ pub enum RpcQueryCommands {
     },
     /// Get the slowly changing state parameters.
     StateParams,
+    /// Query the current upgrade schedule
+    UpgradeSchedule,
 }
 
 #[derive(Subcommand, Debug, Clone)]

--- a/fendermint/app/options/src/upgrade.rs
+++ b/fendermint/app/options/src/upgrade.rs
@@ -1,0 +1,43 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+#[derive(Args, Debug)]
+pub struct UpgradeArgs {
+    /// Path to the upgrade_info JSON file.
+    #[arg(long)]
+    pub upgrade_file: PathBuf,
+
+    #[command(subcommand)]
+    pub command: UpgradeCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum UpgradeCommands {
+    AddUpgrade(AddUpgrade),
+}
+
+#[derive(Args, Debug)]
+pub struct AddUpgrade {
+    /// the height at which to schedule the upgrade
+    #[arg(long)]
+    pub height: u64,
+
+    /// the application version the upgrade will update to
+    #[arg(long)]
+    pub new_app_version: u64,
+
+    /// the required cometbft version for the upgrade
+    #[arg(long)]
+    pub cometbft_version: String,
+
+    /// whether this is a required upgrade or not. A required upgrade
+    /// will cause the node to freeze and not process any more blocks
+    /// if it does not have the corresponding Upgrade defined to
+    /// migrate to that version
+    #[arg(long)]
+    pub required: bool,
+}

--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -206,6 +206,8 @@ pub struct Settings {
     builtin_actors_bundle: PathBuf,
     /// Custom actors CAR file.
     custom_actors_bundle: PathBuf,
+    /// upgrade_info JSON file.
+    pub upgrade_info: PathBuf,
 
     /// Where to reach CometBFT for queries or broadcasting transactions.
     tendermint_rpc_url: Url,
@@ -229,7 +231,8 @@ impl Settings {
         snapshots_dir,
         contracts_dir,
         builtin_actors_bundle,
-        custom_actors_bundle
+        custom_actors_bundle,
+        upgrade_info
     );
 
     /// Load the default configuration from a directory,

--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -207,7 +207,7 @@ pub struct Settings {
     /// Custom actors CAR file.
     custom_actors_bundle: PathBuf,
     /// upgrade_info JSON file.
-    pub upgrade_info: PathBuf,
+    upgrade_info: PathBuf,
 
     /// Where to reach CometBFT for queries or broadcasting transactions.
     tendermint_rpc_url: Url,

--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -16,6 +16,7 @@ pub mod key;
 pub mod materializer;
 pub mod rpc;
 pub mod run;
+pub mod upgrade;
 
 #[async_trait]
 pub trait Cmd {
@@ -66,6 +67,7 @@ pub async fn exec(opts: &Options) -> anyhow::Result<()> {
         Commands::Rpc(args) => args.exec(()).await,
         Commands::Eth(args) => args.exec(settings(opts)?.eth).await,
         Commands::Materializer(args) => args.exec(()).await,
+        Commands::Upgrade(args) => args.exec(()).await,
     }
 }
 

--- a/fendermint/app/src/cmd/rpc.rs
+++ b/fendermint/app/src/cmd/rpc.rs
@@ -108,6 +108,11 @@ async fn query(
             let json = json!({ "response": res });
             print_json(&json)?;
         }
+        RpcQueryCommands::NodeState => {
+            let res = client.node_state(height).await?;
+            let json = json!({ "response": res });
+            print_json(&json)?;
+        }
     };
     Ok(())
 }

--- a/fendermint/app/src/cmd/rpc.rs
+++ b/fendermint/app/src/cmd/rpc.rs
@@ -103,6 +103,11 @@ async fn query(
             let json = json!({ "response": res });
             print_json(&json)?;
         }
+        RpcQueryCommands::UpgradeSchedule => {
+            let res = client.upgrade_schedule(height).await?;
+            let json = json!({ "response": res });
+            print_json(&json)?;
+        }
     };
     Ok(())
 }

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -109,10 +109,10 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
 
     let upgrade_schedule = if settings.upgrade_info().exists() {
         // load existing upgrade schedule
-        UpgradeSchedule::from_file(&settings.upgrade_info())?
+        UpgradeSchedule::from_file(settings.upgrade_info())?
     } else {
         // create an empty upgrade schedule
-        UpgradeSchedule::new().to_file(&settings.upgrade_info())?;
+        UpgradeSchedule::new().to_file(settings.upgrade_info())?;
         UpgradeSchedule::new()
     };
     tracing::info!(

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -107,14 +107,7 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
         ValidatorContext::new(sk, broadcaster)
     });
 
-    let upgrade_schedule = if settings.upgrade_info().exists() {
-        // load existing upgrade schedule
-        UpgradeSchedule::from_file(settings.upgrade_info())?
-    } else {
-        // create an empty upgrade schedule
-        UpgradeSchedule::new().to_file(settings.upgrade_info())?;
-        UpgradeSchedule::new()
-    };
+    let upgrade_schedule = UpgradeSchedule::get_or_create(settings.upgrade_info())?;
     tracing::info!(
         path = settings.upgrade_info().to_string_lossy().into_owned(),
         schedule = ?upgrade_schedule,

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -11,7 +11,7 @@ use fendermint_crypto::SecretKey;
 use fendermint_rocksdb::{blockstore::NamespaceBlockstore, namespaces, RocksDb, RocksDbConfig};
 use fendermint_vm_actor_interface::eam::EthAddress;
 use fendermint_vm_interpreter::chain::ChainEnv;
-use fendermint_vm_interpreter::fvm::upgrades::UpgradeScheduler;
+use fendermint_vm_interpreter::fvm::upgrades::{UpgradeSchedule, Upgrades};
 use fendermint_vm_interpreter::{
     bytes::{BytesMessageInterpreter, ProposalPrepareMode},
     chain::{ChainMessageInterpreter, CheckpointPool},
@@ -114,7 +114,8 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
         settings.fvm.gas_overestimation_rate,
         settings.fvm.gas_search_step,
         settings.fvm.exec_in_check,
-        UpgradeScheduler::new(),
+        UpgradeSchedule::new(),
+        Upgrades::new(),
     );
     let interpreter = SignedMessageInterpreter::new(interpreter);
     let interpreter = ChainMessageInterpreter::<_, NamespaceBlockstore>::new(interpreter);

--- a/fendermint/app/src/cmd/upgrade.rs
+++ b/fendermint/app/src/cmd/upgrade.rs
@@ -30,7 +30,7 @@ cmd! {
             self.required,
         ))?;
 
-        us.to_file(upgrade_file)?;
+        us.export_file(upgrade_file)?;
 
         Ok(())
   }

--- a/fendermint/app/src/cmd/upgrade.rs
+++ b/fendermint/app/src/cmd/upgrade.rs
@@ -22,15 +22,7 @@ cmd! {
 
 cmd! {
     AddUpgrade(self, upgrade_file: PathBuf) {
-        let mut us = if upgrade_file.exists() {
-            // load existing upgrade schedule
-            UpgradeSchedule::from_file(&upgrade_file)?
-        } else {
-            // create an empty upgrade schedule
-            UpgradeSchedule::new().to_file(&upgrade_file)?;
-            UpgradeSchedule::new()
-        };
-
+        let mut us = UpgradeSchedule::get_or_create(&upgrade_file)?;
         us.add(UpgradeInfo::new(
             self.height.try_into().unwrap(),
             self.new_app_version,

--- a/fendermint/app/src/cmd/upgrade.rs
+++ b/fendermint/app/src/cmd/upgrade.rs
@@ -1,0 +1,45 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::path::PathBuf;
+
+use fendermint_app_options::upgrade::AddUpgrade;
+use fendermint_app_options::upgrade::UpgradeArgs;
+use fendermint_app_options::upgrade::UpgradeCommands;
+use fendermint_vm_interpreter::fvm::upgrades::UpgradeSchedule;
+use fendermint_vm_message::ipc::UpgradeInfo;
+
+use crate::cmd;
+
+cmd! {
+    UpgradeArgs(self) {
+        let upgrade_file = self.upgrade_file.clone();
+        match &self.command {
+            UpgradeCommands::AddUpgrade(args) => args.exec(upgrade_file).await,
+        }
+    }
+}
+
+cmd! {
+    AddUpgrade(self, upgrade_file: PathBuf) {
+        let mut us = if upgrade_file.exists() {
+            // load existing upgrade schedule
+            UpgradeSchedule::from_file(&upgrade_file)?
+        } else {
+            // create an empty upgrade schedule
+            UpgradeSchedule::new().to_file(&upgrade_file)?;
+            UpgradeSchedule::new()
+        };
+
+        us.add(UpgradeInfo::new(
+            self.height.try_into().unwrap(),
+            self.new_app_version,
+            self.cometbft_version.clone(),
+            self.required,
+        ))?;
+
+        us.to_file(upgrade_file)?;
+
+        Ok(())
+  }
+}

--- a/fendermint/app/src/tmconv.rs
+++ b/fendermint/app/src/tmconv.rs
@@ -262,6 +262,7 @@ pub fn to_query(ret: FvmQueryRet, block_height: BlockHeight) -> anyhow::Result<r
         FvmQueryRet::Call(_) | FvmQueryRet::EstimateGas(_) => ExitCode::OK,
         FvmQueryRet::StateParams(_) => ExitCode::OK,
         FvmQueryRet::BuiltinActors(_) => ExitCode::OK,
+        FvmQueryRet::UpgradeSchedule(_) => ExitCode::OK,
     };
 
     // The return value has a `key` field which is supposed to be set to the data matched.
@@ -300,6 +301,10 @@ pub fn to_query(ret: FvmQueryRet, block_height: BlockHeight) -> anyhow::Result<r
         }
         FvmQueryRet::BuiltinActors(ba) => {
             let v = ipld_encode!(ba);
+            (Vec::new(), v)
+        }
+        FvmQueryRet::UpgradeSchedule(us) => {
+            let v = ipld_encode!(us);
             (Vec::new(), v)
         }
     };

--- a/fendermint/app/src/tmconv.rs
+++ b/fendermint/app/src/tmconv.rs
@@ -263,6 +263,7 @@ pub fn to_query(ret: FvmQueryRet, block_height: BlockHeight) -> anyhow::Result<r
         FvmQueryRet::StateParams(_) => ExitCode::OK,
         FvmQueryRet::BuiltinActors(_) => ExitCode::OK,
         FvmQueryRet::UpgradeSchedule(_) => ExitCode::OK,
+        FvmQueryRet::NodeState(_) => ExitCode::OK,
     };
 
     // The return value has a `key` field which is supposed to be set to the data matched.
@@ -305,6 +306,10 @@ pub fn to_query(ret: FvmQueryRet, block_height: BlockHeight) -> anyhow::Result<r
         }
         FvmQueryRet::UpgradeSchedule(us) => {
             let v = ipld_encode!(us);
+            (Vec::new(), v)
+        }
+        FvmQueryRet::NodeState(ns) => {
+            let v = ipld_encode!(ns);
             (Vec::new(), v)
         }
     };

--- a/fendermint/docker/runner.Dockerfile
+++ b/fendermint/docker/runner.Dockerfile
@@ -28,6 +28,9 @@ ENV FM_ETH__LISTEN__HOST=0.0.0.0
 RUN mkdir /fendermint/logs
 RUN chmod 777 /fendermint/logs
 
+RUN echo "[]" > /fendermint/upgrade_info.json
+RUN chmod 777 /fendermint/upgrade_info.json
+
 COPY fendermint/docker/.artifacts/bundle.car $FM_HOME_DIR/bundle.car
 COPY fendermint/docker/.artifacts/custom_actors_bundle.car $FM_HOME_DIR/custom_actors_bundle.car
 COPY fendermint/docker/.artifacts/contracts $FM_HOME_DIR/contracts

--- a/fendermint/rpc/src/query.rs
+++ b/fendermint/rpc/src/query.rs
@@ -17,7 +17,7 @@ use fvm_shared::ActorID;
 use fvm_shared::{address::Address, error::ExitCode};
 
 use fendermint_vm_message::query::{
-    ActorState, BuiltinActors, FvmQuery, FvmQueryHeight, GasEstimate, StateParams,
+    ActorState, BuiltinActors, FvmQuery, FvmQueryHeight, GasEstimate, NodeState, StateParams,
 };
 
 use crate::response::encode_data;
@@ -123,7 +123,17 @@ pub trait QueryClient: Sync {
         let height = res.height;
         let value = extract(res, |res| {
             fvm_ipld_encoding::from_slice(&res.value)
-                .context("failed to decode StateParams from query")
+                .context("failed to decode UpgradeSchedule from query")
+        })?;
+        Ok(QueryResponse { height, value })
+    }
+
+    async fn node_state(&self, height: FvmQueryHeight) -> anyhow::Result<QueryResponse<NodeState>> {
+        let res = self.perform(FvmQuery::NodeState, height).await?;
+        let height = res.height;
+        let value = extract(res, |res| {
+            fvm_ipld_encoding::from_slice(&res.value)
+                .context("failed to decode NodeState from query")
         })?;
         Ok(QueryResponse { height, value })
     }

--- a/fendermint/rpc/src/query.rs
+++ b/fendermint/rpc/src/query.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
+use fendermint_vm_message::ipc::UpgradeInfo;
 use fvm_ipld_encoding::serde::Serialize;
 use fvm_shared::message::Message;
 use prost::Message as ProstMessage;
@@ -111,6 +112,19 @@ pub trait QueryClient: Sync {
             })?;
             BuiltinActors { registry }
         };
+        Ok(QueryResponse { height, value })
+    }
+
+    async fn upgrade_schedule(
+        &self,
+        height: FvmQueryHeight,
+    ) -> anyhow::Result<QueryResponse<Vec<UpgradeInfo>>> {
+        let res = self.perform(FvmQuery::UpgradeSchedule, height).await?;
+        let height = res.height;
+        let value = extract(res, |res| {
+            fvm_ipld_encoding::from_slice(&res.value)
+                .context("failed to decode StateParams from query")
+        })?;
         Ok(QueryResponse { height, value })
     }
 

--- a/fendermint/testing/contract-test/src/lib.rs
+++ b/fendermint/testing/contract-test/src/lib.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, Context, Result};
 use byteorder::{BigEndian, WriteBytesExt};
 use cid::Cid;
 use fendermint_vm_core::Timestamp;
+use fendermint_vm_interpreter::fvm::upgrades::{UpgradeSchedule, Upgrades};
 use fendermint_vm_interpreter::fvm::PowerUpdates;
 use fvm_shared::{bigint::Zero, clock::ChainEpoch, econ::TokenAmount, version::NetworkVersion};
 use std::{future::Future, sync::Arc};
@@ -15,7 +16,6 @@ use fendermint_vm_interpreter::{
         bundle::{bundle_path, contracts_path, custom_actors_bundle_path},
         state::{FvmExecState, FvmGenesisState, FvmStateParams, FvmUpdatableParams},
         store::memory::MemoryBlockstore,
-        upgrades::UpgradeScheduler,
         FvmApplyRet, FvmGenesisOutput, FvmMessage, FvmMessageInterpreter,
     },
     ExecInterpreter, GenesisInterpreter,
@@ -56,7 +56,8 @@ pub async fn init_exec_state(
         1.05,
         1.05,
         false,
-        UpgradeScheduler::new(),
+        UpgradeSchedule::new(),
+        Upgrades::new(),
     );
 
     let (state, out) = interpreter

--- a/fendermint/testing/contract-test/tests/run_upgrades.rs
+++ b/fendermint/testing/contract-test/tests/run_upgrades.rs
@@ -62,13 +62,13 @@ async fn test_applying_upgrades() {
 
     let mut upgrade_schedule = UpgradeSchedule::new();
     upgrade_schedule
-        .add(UpgradeInfo::new(1, 11, "0.37", false))
+        .add(UpgradeInfo::new(1, 11, "0.37.1", false))
         .unwrap();
     upgrade_schedule
-        .add(UpgradeInfo::new(2, 12, "0.37", false))
+        .add(UpgradeInfo::new(2, 12, "0.37.1", false))
         .unwrap();
     upgrade_schedule
-        .add(UpgradeInfo::new(3, 13, "0.37", false))
+        .add(UpgradeInfo::new(3, 13, "0.37.1", false))
         .unwrap();
 
     let mut upgrades = Upgrades::new();

--- a/fendermint/testing/contract-test/tests/run_upgrades.rs
+++ b/fendermint/testing/contract-test/tests/run_upgrades.rs
@@ -62,13 +62,13 @@ async fn test_applying_upgrades() {
 
     let mut upgrade_schedule = UpgradeSchedule::new();
     upgrade_schedule
-        .add(UpgradeInfo::new(1, "0.37", 11, false))
+        .add(UpgradeInfo::new(1, 11, "0.37", false))
         .unwrap();
     upgrade_schedule
-        .add(UpgradeInfo::new(2, "0.37", 12, false))
+        .add(UpgradeInfo::new(2, 12, "0.37", false))
         .unwrap();
     upgrade_schedule
-        .add(UpgradeInfo::new(3, "0.37", 13, false))
+        .add(UpgradeInfo::new(3, 13, "0.37", false))
         .unwrap();
 
     let mut upgrades = Upgrades::new();

--- a/fendermint/testing/contract-test/tests/run_upgrades.rs
+++ b/fendermint/testing/contract-test/tests/run_upgrades.rs
@@ -73,7 +73,7 @@ async fn test_applying_upgrades() {
 
     let mut upgrades = Upgrades::new();
     upgrades
-        .add(Upgrade::new(11, |state| {
+        .add(Upgrade::new(11, |upgrade, state| {
             println!(
                 "[Upgrade at height {}] Deploy simple contract",
                 state.block_height()
@@ -111,12 +111,16 @@ async fn test_applying_upgrades() {
                 Address::from_str(CONTRACT_ADDRESS).unwrap()
             );
 
+            state.update_app_version(|app_version| {
+                *app_version = upgrade.new_app_version();
+            });
+
             Ok(())
         }))
         .unwrap();
 
     upgrades
-        .add(Upgrade::new(12, |state| {
+        .add(Upgrade::new(12, |upgrade, state| {
             println!(
                 "[Upgrade at height {}] Sends a balance",
                 state.block_height()
@@ -151,12 +155,16 @@ async fn test_applying_upgrades() {
                 res.failure_info
             );
 
+            state.update_app_version(|app_version| {
+                *app_version = upgrade.new_app_version();
+            });
+
             Ok(())
         }))
         .unwrap();
 
     upgrades
-        .add(Upgrade::new(13, |state| {
+        .add(Upgrade::new(13, |upgrade, state| {
             println!(
                 "[Upgrade at height {}] Returns a balance",
                 state.block_height()
@@ -190,6 +198,10 @@ async fn test_applying_upgrades() {
             let bytes = decode_fevm_return_data(res.msg_receipt.return_data).unwrap();
             let balance = U256::from_big_endian(&bytes);
             assert_eq!(balance, U256::from(SEND_BALANCE_AMOUNT));
+
+            state.update_app_version(|app_version| {
+                *app_version = upgrade.new_app_version();
+            });
 
             Ok(())
         }))

--- a/fendermint/testing/contract-test/tests/run_upgrades.rs
+++ b/fendermint/testing/contract-test/tests/run_upgrades.rs
@@ -58,17 +58,16 @@ async fn test_applying_upgrades() {
     const CONTRACT_ADDRESS: &str = "f410fnz5jdky3zzcj6pejqkomkggw72pcuvkpihz2rwa";
     // the amount we want to send to the contract
     const SEND_BALANCE_AMOUNT: u64 = 1000;
-    const CHAIN_NAME: &str = "mychain";
 
     let mut upgrade_schedule = UpgradeSchedule::new();
     upgrade_schedule
-        .add(UpgradeInfo::new(CHAIN_NAME, 1, "0.37", 11, true).unwrap())
+        .add(UpgradeInfo::new(1, "0.37", 11, true))
         .unwrap();
     upgrade_schedule
-        .add(UpgradeInfo::new(CHAIN_NAME, 2, "0.37", 12, true).unwrap())
+        .add(UpgradeInfo::new(2, "0.37", 12, true))
         .unwrap();
     upgrade_schedule
-        .add(UpgradeInfo::new(CHAIN_NAME, 3, "0.37", 13, true).unwrap())
+        .add(UpgradeInfo::new(3, "0.37", 13, true))
         .unwrap();
 
     let mut upgrades = Upgrades::new();
@@ -209,7 +208,7 @@ async fn test_applying_upgrades() {
     let mut tester = Tester::new(interpreter, MemoryBlockstore::new());
 
     let genesis = Genesis {
-        chain_name: CHAIN_NAME.to_string(),
+        chain_name: "mychain".to_string(),
         timestamp: Timestamp(0),
         network_version: NetworkVersion::V21,
         base_fee: TokenAmount::zero(),

--- a/fendermint/testing/contract-test/tests/run_upgrades.rs
+++ b/fendermint/testing/contract-test/tests/run_upgrades.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use ethers::types::U256;
 use fendermint_contract_test::Tester;
 use fendermint_rpc::response::decode_fevm_return_data;
+use fendermint_vm_message::ipc::UpgradeInfo;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use std::str::FromStr;
@@ -25,7 +26,7 @@ use fendermint_vm_actor_interface::eam::EthAddress;
 use fendermint_vm_core::Timestamp;
 use fendermint_vm_genesis::{Account, Actor, ActorMeta, Genesis, PermissionMode, SignerAddr};
 use fendermint_vm_interpreter::fvm::store::memory::MemoryBlockstore;
-use fendermint_vm_interpreter::fvm::upgrades::{Upgrade, UpgradeInfo, UpgradeSchedule, Upgrades};
+use fendermint_vm_interpreter::fvm::upgrades::{Upgrade, UpgradeSchedule, Upgrades};
 use fendermint_vm_interpreter::fvm::{bundle::contracts_path, FvmMessageInterpreter};
 
 // returns a seeded secret key which is guaranteed to be the same every time
@@ -61,13 +62,13 @@ async fn test_applying_upgrades() {
 
     let mut upgrade_schedule = UpgradeSchedule::new();
     upgrade_schedule
-        .add(UpgradeInfo::new(1, "0.37", 11, true))
+        .add(UpgradeInfo::new(1, "0.37", 11, false))
         .unwrap();
     upgrade_schedule
-        .add(UpgradeInfo::new(2, "0.37", 12, true))
+        .add(UpgradeInfo::new(2, "0.37", 12, false))
         .unwrap();
     upgrade_schedule
-        .add(UpgradeInfo::new(3, "0.37", 13, true))
+        .add(UpgradeInfo::new(3, "0.37", 13, false))
         .unwrap();
 
     let mut upgrades = Upgrades::new();

--- a/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -212,8 +212,7 @@ where
             PowerUpdates::default()
         };
 
-        let block_height: u64 = state.block_height().try_into().unwrap();
-        if let Some(upgrade_info) = self.upgrade_schedule.get(block_height) {
+        if let Some(upgrade_info) = self.upgrade_schedule.get(state.block_height()) {
             match self.upgrades.get(upgrade_info.new_app_version) {
                 Some(upgrade) => {
                     let new_app_version = upgrade.execute(&mut state).context("upgrade failed")?;

--- a/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -212,9 +212,8 @@ where
             PowerUpdates::default()
         };
 
-        let chain_id = state.chain_id();
         let block_height: u64 = state.block_height().try_into().unwrap();
-        if let Some(upgrade_info) = self.upgrade_schedule.get(chain_id, block_height) {
+        if let Some(upgrade_info) = self.upgrade_schedule.get(block_height) {
             match self.upgrades.get(upgrade_info.new_app_version) {
                 Some(upgrade) => {
                     let new_app_version = upgrade.execute(&mut state).context("upgrade failed")?;

--- a/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use std::{
     collections::HashMap,
     sync::atomic::{AtomicBool, Ordering},
-    thread::sleep,
+    time::Duration,
 };
 
 use fendermint_vm_actor_interface::{chainmetadata, cron, system};
@@ -256,7 +256,7 @@ where
                                 upgrade_info = ?upgrade_info,
                                 "node frozen, please restart with a newer version which has the required upgrade"
                             );
-                            sleep(std::time::Duration::from_secs(60));
+                            tokio::time::sleep(Duration::from_secs(60)).await;
                         }
                     }
                 }

--- a/fendermint/vm/interpreter/src/fvm/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/exec.rs
@@ -230,13 +230,8 @@ where
 
             match self.upgrades.get(upgrade_info.new_app_version) {
                 Some(upgrade) => {
-                    let new_app_version = upgrade.execute(&mut state).context("upgrade failed")?;
-
-                    state.update_app_version(|app_version| {
-                        *app_version = new_app_version;
-                    });
-
-                    tracing::info!(app_version = state.app_version(), "upgrade successful");
+                    upgrade.execute(&mut state).context("upgrade failed")?;
+                    tracing::info!("upgrade successful");
                 }
                 None => {
                     tracing::warn!(

--- a/fendermint/vm/interpreter/src/fvm/genesis.rs
+++ b/fendermint/vm/interpreter/src/fvm/genesis.rs
@@ -531,7 +531,7 @@ mod tests {
             bundle::{bundle_path, contracts_path, custom_actors_bundle_path},
             state::ipc::GatewayCaller,
             store::memory::MemoryBlockstore,
-            upgrades::UpgradeScheduler,
+            upgrades::{UpgradeSchedule, Upgrades},
             FvmMessageInterpreter,
         },
         GenesisInterpreter,
@@ -658,7 +658,8 @@ mod tests {
             1.05,
             1.05,
             false,
-            UpgradeScheduler::new(),
+            UpgradeSchedule::new(),
+            Upgrades::new(),
         )
     }
 

--- a/fendermint/vm/interpreter/src/fvm/mod.rs
+++ b/fendermint/vm/interpreter/src/fvm/mod.rs
@@ -87,6 +87,7 @@ impl<DB, C> FvmMessageInterpreter<DB, C>
 where
     DB: Blockstore + 'static + Clone,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         client: C,
         validator_ctx: Option<ValidatorContext<C>>,

--- a/fendermint/vm/interpreter/src/fvm/mod.rs
+++ b/fendermint/vm/interpreter/src/fvm/mod.rs
@@ -29,8 +29,8 @@ pub use query::FvmQueryRet;
 use tendermint_rpc::Client;
 
 pub use self::broadcast::Broadcaster;
-use self::{state::ipc::GatewayCaller, upgrades::UpgradeScheduler};
-
+use self::state::ipc::GatewayCaller;
+use self::upgrades::{UpgradeSchedule, Upgrades};
 pub type FvmMessage = fvm_shared::message::Message;
 
 #[derive(Clone)]
@@ -77,8 +77,10 @@ where
     /// when they are added to the mempool, or just the most basic ones are performed.
     exec_in_check: bool,
     gateway: GatewayCaller<DB>,
+    /// Upgrade infos to be executed at given heights.
+    upgrade_schedule: UpgradeSchedule,
     /// Upgrade scheduler stores all the upgrades to be executed at given heights.
-    upgrade_scheduler: UpgradeScheduler<DB>,
+    upgrades: Upgrades<DB>,
 }
 
 impl<DB, C> FvmMessageInterpreter<DB, C>
@@ -92,7 +94,8 @@ where
         gas_overestimation_rate: f64,
         gas_search_step: f64,
         exec_in_check: bool,
-        upgrade_scheduler: UpgradeScheduler<DB>,
+        upgrade_schedule: UpgradeSchedule,
+        upgrades: Upgrades<DB>,
     ) -> Self {
         Self {
             client,
@@ -102,7 +105,8 @@ where
             gas_search_step,
             exec_in_check,
             gateway: GatewayCaller::default(),
-            upgrade_scheduler,
+            upgrade_schedule,
+            upgrades,
         }
     }
 }

--- a/fendermint/vm/interpreter/src/fvm/query.rs
+++ b/fendermint/vm/interpreter/src/fvm/query.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use async_trait::async_trait;
 use cid::Cid;
-use fendermint_vm_message::query::{ActorState, FvmQuery, GasEstimate, StateParams};
+use fendermint_vm_message::{
+    ipc::UpgradeInfo,
+    query::{ActorState, FvmQuery, GasEstimate, StateParams},
+};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{
@@ -31,6 +34,8 @@ pub enum FvmQueryRet {
     StateParams(StateParams),
     /// Builtin actors known by the system.
     BuiltinActors(Vec<(String, Cid)>),
+    /// The current upgrade schedule.
+    UpgradeSchedule(Vec<UpgradeInfo>),
 }
 
 #[async_trait]
@@ -154,6 +159,10 @@ where
             FvmQuery::BuiltinActors => {
                 let (state, ret) = state.builtin_actors().await?;
                 Ok((state, FvmQueryRet::BuiltinActors(ret)))
+            }
+            FvmQuery::UpgradeSchedule => {
+                let ret = self.upgrade_schedule.get_all();
+                Ok((state, FvmQueryRet::UpgradeSchedule(ret)))
             }
         }
     }

--- a/fendermint/vm/interpreter/src/fvm/upgrades.rs
+++ b/fendermint/vm/interpreter/src/fvm/upgrades.rs
@@ -18,6 +18,12 @@ pub struct UpgradeSchedule {
     schedule: BTreeMap<ChainEpoch, UpgradeInfo>,
 }
 
+impl Default for UpgradeSchedule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl UpgradeSchedule {
     pub fn new() -> Self {
         Self {
@@ -41,7 +47,7 @@ impl UpgradeSchedule {
     pub fn to_file(&self, path: impl AsRef<Path>) -> anyhow::Result<()> {
         let json = serde_json::to_string_pretty(&self.get_all())
             .context("failed to serialize upgrade_info")?;
-        std::fs::write(path, &json)?;
+        std::fs::write(path, json)?;
 
         Ok(())
     }
@@ -113,6 +119,15 @@ where
 {
     /// a map of all the available hardcoded upgrades
     upgrades: BTreeMap<u64, Upgrade<DB>>,
+}
+
+impl<DB> Default for Upgrades<DB>
+where
+    DB: Blockstore + 'static + Clone,
+{
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<DB> Upgrades<DB>

--- a/fendermint/vm/interpreter/src/fvm/upgrades.rs
+++ b/fendermint/vm/interpreter/src/fvm/upgrades.rs
@@ -37,8 +37,9 @@ impl UpgradeSchedule {
             UpgradeSchedule::from_file(path)
         } else {
             // create an empty upgrade schedule
-            UpgradeSchedule::new().to_file(path)?;
-            Ok(UpgradeSchedule::new())
+            let us = UpgradeSchedule::new();
+            us.export_file(path)?;
+            Ok(us)
         }
     }
 
@@ -55,7 +56,7 @@ impl UpgradeSchedule {
         Ok(us)
     }
 
-    pub fn to_file(&self, path: impl AsRef<Path>) -> anyhow::Result<()> {
+    pub fn export_file(&self, path: impl AsRef<Path>) -> anyhow::Result<()> {
         let json = serde_json::to_string_pretty(&self.get_all())
             .context("failed to serialize upgrade_info")?;
         std::fs::write(path, json).context("failed to write to upgrade_info file")?;

--- a/fendermint/vm/interpreter/src/fvm/upgrades.rs
+++ b/fendermint/vm/interpreter/src/fvm/upgrades.rs
@@ -47,7 +47,7 @@ impl UpgradeSchedule {
     pub fn to_file(&self, path: impl AsRef<Path>) -> anyhow::Result<()> {
         let json = serde_json::to_string_pretty(&self.get_all())
             .context("failed to serialize upgrade_info")?;
-        std::fs::write(path, json)?;
+        std::fs::write(path, json).context("failed to write to upgrade_info file")?;
 
         Ok(())
     }

--- a/fendermint/vm/interpreter/src/fvm/upgrades.rs
+++ b/fendermint/vm/interpreter/src/fvm/upgrades.rs
@@ -31,6 +31,17 @@ impl UpgradeSchedule {
         }
     }
 
+    pub fn get_or_create(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        if path.as_ref().exists() {
+            // load existing upgrade schedule
+            UpgradeSchedule::from_file(path)
+        } else {
+            // create an empty upgrade schedule
+            UpgradeSchedule::new().to_file(path)?;
+            Ok(UpgradeSchedule::new())
+        }
+    }
+
     pub fn from_file(path: impl AsRef<Path>) -> anyhow::Result<UpgradeSchedule> {
         let json = std::fs::read_to_string(path).context("failed to read upgrade_info file")?;
         let schedules = serde_json::from_str::<Vec<UpgradeInfo>>(&json)

--- a/fendermint/vm/message/src/ipc.rs
+++ b/fendermint/vm/message/src/ipc.rs
@@ -103,6 +103,37 @@ pub struct ParentFinality {
     pub block_hash: Vec<u8>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UpgradeInfo {
+    /// the block height at which the upgrade should be executed
+    pub height: ChainEpoch,
+    /// the fendermint app version version this Upgrade will migrate to
+    pub new_app_version: u64,
+    /// the required cometbft version for the upgrade
+    pub cometbft_version: String,
+    /// whether the upgrade is backwards compatible or not. In case a
+    /// non-backwards compatible upgrade is scheduled where we don't have
+    /// the corresponding Upgrade defined to migrate to that version, then
+    /// fendermint will freeze and not process any more blocks.
+    pub backwards_compatible: bool,
+}
+
+impl UpgradeInfo {
+    pub fn new(
+        height: ChainEpoch,
+        cometbft_version: impl ToString,
+        new_app_version: u64,
+        backwards_compatible: bool,
+    ) -> Self {
+        Self {
+            height,
+            cometbft_version: cometbft_version.to_string(),
+            new_app_version,
+            backwards_compatible,
+        }
+    }
+}
+
 #[cfg(feature = "arb")]
 mod arb {
 

--- a/fendermint/vm/message/src/ipc.rs
+++ b/fendermint/vm/message/src/ipc.rs
@@ -121,14 +121,14 @@ pub struct UpgradeInfo {
 impl UpgradeInfo {
     pub fn new(
         height: ChainEpoch,
-        cometbft_version: impl ToString,
         new_app_version: u64,
+        cometbft_version: impl ToString,
         required: bool,
     ) -> Self {
         Self {
             height,
-            cometbft_version: cometbft_version.to_string(),
             new_app_version,
+            cometbft_version: cometbft_version.to_string(),
             required,
         }
     }

--- a/fendermint/vm/message/src/ipc.rs
+++ b/fendermint/vm/message/src/ipc.rs
@@ -111,11 +111,11 @@ pub struct UpgradeInfo {
     pub new_app_version: u64,
     /// the required cometbft version for the upgrade
     pub cometbft_version: String,
-    /// whether the upgrade is backwards compatible or not. In case a
-    /// non-backwards compatible upgrade is scheduled where we don't have
-    /// the corresponding Upgrade defined to migrate to that version, then
-    /// fendermint will freeze and not process any more blocks.
-    pub backwards_compatible: bool,
+    /// whether this is a required upgrade or not. A required upgrade
+    /// will cause the node to freeze and not process any more blocks
+    /// if it does not have the corresponding Upgrade defined to
+    /// migrate to that version
+    pub required: bool,
 }
 
 impl UpgradeInfo {
@@ -123,13 +123,13 @@ impl UpgradeInfo {
         height: ChainEpoch,
         cometbft_version: impl ToString,
         new_app_version: u64,
-        backwards_compatible: bool,
+        required: bool,
     ) -> Self {
         Self {
             height,
             cometbft_version: cometbft_version.to_string(),
             new_app_version,
-            backwards_compatible,
+            required,
         }
     }
 }

--- a/fendermint/vm/message/src/query.rs
+++ b/fendermint/vm/message/src/query.rs
@@ -76,6 +76,8 @@ pub enum FvmQuery {
     StateParams,
     /// Query the built-in actors known by the System actor.
     BuiltinActors,
+    /// Query the current upgrade schedule
+    UpgradeSchedule,
 }
 
 /// State of all actor implementations.

--- a/fendermint/vm/message/src/query.rs
+++ b/fendermint/vm/message/src/query.rs
@@ -78,6 +78,8 @@ pub enum FvmQuery {
     BuiltinActors,
     /// Query the current upgrade schedule
     UpgradeSchedule,
+    /// Query the current node state
+    NodeState,
 }
 
 /// State of all actor implementations.
@@ -150,6 +152,11 @@ pub struct StateParams {
 pub struct BuiltinActors {
     /// Registry of built-in actors known by the system.
     pub registry: Vec<(String, Cid)>,
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+pub struct NodeState {
+    pub frozen: bool,
 }
 
 #[cfg(feature = "arb")]

--- a/fendermint/vm/snapshot/src/manager.rs
+++ b/fendermint/vm/snapshot/src/manager.rs
@@ -318,7 +318,7 @@ mod tests {
             bundle::{bundle_path, contracts_path, custom_actors_bundle_path},
             state::{snapshot::Snapshot, FvmGenesisState, FvmStateParams},
             store::memory::MemoryBlockstore,
-            upgrades::UpgradeScheduler,
+            upgrades::{UpgradeSchedule, Upgrades},
             FvmMessageInterpreter,
         },
         GenesisInterpreter,
@@ -464,7 +464,8 @@ mod tests {
             1.05,
             1.05,
             false,
-            UpgradeScheduler::new(),
+            UpgradeSchedule::new(),
+            Upgrades::new(),
         );
 
         let (state, out) = interpreter


### PR DESCRIPTION
## Context
This PR updates fendermint to support future [ipcvisor](https://linear.app/interplanetary-consensus/issue/ENG-771/investigate-ipc-process-management-for-supporting-breaking-upgrades#comment-cfa0fc1d) tool we are building to make upgrades easier to orchistrate for our partners (see [post](https://filecoinproject.slack.com/archives/C05UA7RALFP/p1708432761811339)).

In order to facilitate the orchistration, this PR updates fendermint to:
- Split the upgrade_scheduler into hardcoded `Upgrade` migrations and separate upgrade schedule (a list of `UpgradeInfo` structs) which maps block heights to the hardcoded upgrade migrations. 
- Stop processing when it reaches a block height which has an associated hardcoded `Upgrade` which is `required` it does not have the source code of.
- Have RPC methods to query the node state (i.e check if its frozen)
- CLI commands to manage the upgrade-info.json file and check node state

This PR introduces all that functionality which should be enough for the `ipcvisor` to do its thing.

Note, the following are not implemented in this PR:
- Add verification of how the app version progresses progresses (ie. should it be strictly incrementing, can it decrease, etc)
- Verify CometBFT version at startup

## Test plan

### Test new functionality, including that fendermint should freeze and that rpc/cli work as expected
By default when fendermint starts it will automatically create an empty upgrade-migration.json file:

```
# start fenderming
cargo run -p fendermint_app --release -- run
...
2024-03-13T13:54:55.515089Z  INFO fendermint/app/src/cmd/run.rs:118: loaded upgrade_schedule path="/Users/fridrik/.fendermint/upgrade_info.json" schedule=UpgradeSchedule { schedule: {} }
...
CTRL-C

# confirm the upgrade_info.json file was created
cat ~/.fendermint/upgrade_info.json
[]
```

Lets try adding a new upgrade info which we don't have the hardcoded Upgrade for, lets also make it `required` to make things interisting

```
# add a new required upgrade
cargo run -p fendermint_app --release -- upgrade --upgrade-file=/Users/fridrik/.fendermint/upgrade_info.json  add-upgrade --height=1000 --new-app-version=1 --cometbft-version=0.37 --required

# confirm that the upgrade info was added
cat /Users/fridrik/.fendermint/upgrade_info.json
[
  {
    "height": 1000,
    "new_app_version": 1,
    "cometbft_version": "0.37",
    "required": true
  }
]
```

Now observe that fenderming freezes at the specifiec upgrade height since it does not have the hardcoded upgrade:

```
cargo run -p fendermint_app --release -- run
...
2024-03-13T14:01:42.959472Z  INFO fendermint/app/src/app.rs:771: event=NewBlock height=998
2024-03-13T14:01:43.994470Z  INFO fendermint/app/src/app.rs:771: event=NewBlock height=999
2024-03-13T14:01:45.034063Z  INFO fendermint/vm/interpreter/src/fvm/exec.rs:223: upgrade scheduled app_version=0 new_app_version=1 height=1000 upgrade_info=UpgradeInfo { height: 1000, new_app_version: 1, cometbft_version: "0.37", required: true }
2024-03-13T14:01:45.034080Z  WARN fendermint/vm/interpreter/src/fvm/exec.rs:242: upgrade not found height=1000 upgrade_info=UpgradeInfo { height: 1000, new_app_version: 1, cometbft_version: "0.37", required: true }
2024-03-13T14:01:45.034084Z ERROR fendermint/vm/interpreter/src/fvm/exec.rs:254: node frozen, please restart with a newer version which has the required upgrade height=1000 upgrade_info=UpgradeInfo { height: 1000, new_app_version: 1, cometbft_version: "0.37", required: true }
```

Lets query the rpc and confirm its frozen:

```
cargo run -p fendermint_app --release -- rpc query node-state
{
  "response": {
    "height": "999",
    "value": {
      "frozen": true
    }
  }
}
```

### Verify that updating fendermint with new version can successfully proceed

In the previous test, we confirmed that fendermint stopped once it progressed to a block height which had a `required` upgrade associated that it didn't have.

Here we want to test that when this happens, that when we stop the running (frozen) fendermint with a newer version which has the upgrade, that it will successfully proceed from where the previous version stopped. 

To test this, I created a [test-required-upgrade](https://github.com/consensus-shipyard/ipc/compare/upgrades-and-scheduler...test-required-upgrade?expand=1) branch which employs a custom kernel with new syscall as well with adding support for upgrading to app version 1. 

```
# stop the previous frozen fendermint
CTRL+C

# start the fendermint from the test-required-upgrade branch:
cargo run -p fendermint_app --release -- run
...
2024-03-13T15:42:09.886900Z  INFO fendermint/vm/interpreter/src/fvm/exec.rs:223: upgrade scheduled app_version=0 new_app_version=1 height=1010 upgrade_info=UpgradeInfo { height: 1010, new_app_version: 1, cometbft_version: "0.37", required: true }
2024-03-13T15:42:09.886931Z  INFO fendermint/vm/interpreter/src/fvm/exec.rs:239: upgrade successful app_version=1
2024-03-13T15:42:09.886940Z  INFO fendermint/app/src/app.rs:771: event=NewBlock height=1010
2024-03-13T15:42:10.249421Z  INFO fendermint/app/src/app.rs:670: event=ProposalProcessed is_accepted=true height=1011 size=0 hash="7EDD19B7B473CA1B006B4D694BF3B5D7771702C72D8F7F3352AC9245A5D6FD4C" proposer="9CDE756FDEFC4FAC219F01844D80309D8D800C32"
2024-03-13T15:42:12.614231Z  INFO fendermint/app/src/app.rs:771: event=NewBlock height=1011
2024-03-13T15:42:12.642061Z  INFO fendermint/app/src/app.rs:670: event=ProposalProcessed is_accepted=true height=1012 size=0 hash="EF9CC72C12A5DC33430CCBF2F4D6CD37BE0A80B71C5B722EF94C6B6BBEA0873F" proposer="9CDE756FDEFC4FAC219F01844D80309D8D800C32"
2024-03-13T15:42:12.675509Z  INFO fendermint/app/src/app.rs:771: event=NewBlock height=1012
2024-03-13T15:42:13.683986Z  INFO fendermint/app/src/app.rs:670: event=ProposalProcessed is_accepted=true height=1013 size=0 hash="A1D6DB8BF88F616426783667CEA3415D12F42875340F310F99E41391FE3920C7" proposer="9CDE756FDEFC4FAC219F01844D80309D8D800C32"
2024-03-13T15:42:13.710567Z  INFO fendermint/app/src/app.rs:771: event=NewBlock height=1013
2024-03-13T15:42:14.712736Z  INFO fendermint/app/src/app.rs:670: event=ProposalProcessed is_accepted=true height=1014 size=0 hash="CEC377F99B00787E909939D3C845DBE68463FE491834F4DB215D0DF0FF817AB5" proposer="9CDE756FDEFC4FAC219F01844D80309D8D800C32"
2024-03-13T15:42:14.736308Z  INFO fendermint/app/src/app.rs:771: event=NewBlock height=1014
...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/consensus-shipyard/ipc/793)
<!-- Reviewable:end -->
