### PR TITLE
FIX: emit event name as a field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,6 +2859,7 @@ dependencies = [
  "fendermint_vm_actor_interface",
  "fendermint_vm_core",
  "fendermint_vm_encoding",
+ "fendermint_vm_event",
  "fendermint_vm_genesis",
  "fendermint_vm_interpreter",
  "fendermint_vm_message",

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -49,6 +49,7 @@ fendermint_tracing = { path = "../tracing" }
 fendermint_vm_actor_interface = { path = "../vm/actor_interface" }
 fendermint_vm_core = { path = "../vm/core" }
 fendermint_vm_encoding = { path = "../vm/encoding" }
+fendermint_vm_event = { path = "../vm/event" }
 fendermint_vm_genesis = { path = "../vm/genesis" }
 fendermint_vm_interpreter = { path = "../vm/interpreter", features = [
     "bundle",

--- a/fendermint/app/src/events.rs
+++ b/fendermint/app/src/events.rs
@@ -3,6 +3,9 @@
 
 use crate::BlockHeight;
 
+/// Re-export other events, just to provide the visibility of where they are.
+pub use fendermint_vm_event::{NewBottomUpCheckpoint, NewParentView, ParentFinalityCommitted};
+
 pub struct ProposalProcessed<'a> {
     pub is_accepted: bool,
     pub block_height: BlockHeight,

--- a/fendermint/tracing/src/lib.rs
+++ b/fendermint/tracing/src/lib.rs
@@ -10,6 +10,14 @@
 /// Once the [valuable](https://github.com/tokio-rs/tracing/discussions/1906) feature is stable,
 /// we won't have the restriction of flat events.
 ///
+/// The emitted [tracing::Event] will contain the name of the event twice:
+/// in the [tracing::metadata::Metadata::name] field and under the `event` key in the [tracing::field::ValueSet].
+/// The rationale is that we can write a [tracing::Subscriber] that looks for the events it is interested in using
+/// the `name`, which by default would be `event <file>:<line>`. But it turns out it's impossible to ask the
+/// [log formatter](https://github.com/tokio-rs/tracing/blob/908cc432a5994f6e17c8f36e13c217dc40085704/tracing-subscriber/src/fmt/format/mod.rs#L930)
+/// to output the name, and for all other traces it would be redundant with the filename and line we print,
+/// which are available separately on the metadata, hence the `event` key which will be displayed instead.
+///
 /// ### Example
 ///
 /// ```ignore

--- a/fendermint/tracing/src/lib.rs
+++ b/fendermint/tracing/src/lib.rs
@@ -38,7 +38,7 @@ macro_rules! emit {
         tracing::event!(
             name: stringify!($event),
             tracing::Level::INFO,
-            { event = stringify!($event), $($field $(= $value)?),* }
+            { event = tracing::field::display(stringify!($event)), $($field $(= $value)?),* }
         )
     }};
 }

--- a/fendermint/tracing/src/lib.rs
+++ b/fendermint/tracing/src/lib.rs
@@ -38,7 +38,7 @@ macro_rules! emit {
         tracing::event!(
             name: stringify!($event),
             tracing::Level::INFO,
-            { $($field $(= $value)?),* }
+            { event = stringify!($event), $($field $(= $value)?),* }
         )
     }};
 }

--- a/fendermint/tracing/src/lib.rs
+++ b/fendermint/tracing/src/lib.rs
@@ -30,11 +30,11 @@
 macro_rules! emit {
     ($event:ident { $($field:ident $(: $value:expr)?),* $(,)? } ) => {{
         // Make sure the emitted fields match the schema of the event.
-        let _dummy = || {
+        if false {
             let _event = $event {
                 $($field $(: $value)?),*
             };
-        };
+        }
         tracing::event!(
             name: stringify!($event),
             tracing::Level::INFO,


### PR DESCRIPTION
Followup for https://github.com/consensus-shipyard/ipc/pull/796

Adds back the name of the event as `event = <name>` because it turns out that there is [no way to configure](https://github.com/tokio-rs/tracing/blob/908cc432a5994f6e17c8f36e13c217dc40085704/tracing-subscriber/src/fmt/format/mod.rs#L930) the subscriber to display the `name` - which would be useless in other cases anyway as it defaults to filename and line which are already displayed.