### PR TITLE
FIX: Fix the name of the --network parameter in ipc-cli

### DIFF
--- a/ipc/cli/src/lib.rs
+++ b/ipc/cli/src/lib.rs
@@ -40,11 +40,11 @@ pub struct GlobalArguments {
     config_path: Option<String>,
 
     /// Set the FVM Address Network. It's value affects whether `f` (main) or `t` (test) prefixed addresses are accepted.
-    #[arg(long, default_value = "testnet", env = "IPC_NETWORK", value_parser = parse_network)]
+    #[arg(long = "network", default_value = "testnet", env = "IPC_NETWORK", value_parser = parse_network)]
     _network: Network,
 
     /// Legacy env var for network
-    #[arg(hide = true, env = "NETWORK", value_parser = parse_network)]
+    #[arg(long = "__network", hide = true, env = "NETWORK", value_parser = parse_network)]
     __network: Option<Network>,
 }
 


### PR DESCRIPTION
https://github.com/consensus-shipyard/ipc/pull/787 introduced a bug by not including a `long` name for the hidden network argument, which now captured the _following_ word even if it wasn't present, so it tried to interpret a subcommand as a network. 


In the future, https://github.com/consensus-shipyard/ipc/pull/769 will exercise the `ipc-cli` in CI and catch this kind of bug.

### Testing

Before:
```console
$ alias ipc-cli="docker run -it --rm -u $(id -u) -v $HOME/.ipc:/fendermint/.ipc fendermint:latest ipc-cli"
$ ipc-cli -- --help
error: invalid value '--help' for '[NETWORK]': expected 0 or 1 for network: invalid digit found in string
```

After:
```console
$ cargo run -q -p ipc-cli -- --help
The IPC agent command line tool

Usage: ipc-cli [OPTIONS] [COMMAND]
...
```