### PR TITLE
FIX: Add default to deserializer for app_version

### DIFF
--- a/fendermint/vm/interpreter/src/fvm/state/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/exec.rs
@@ -60,6 +60,7 @@ pub struct FvmStateParams {
     /// Conversion from collateral to voting power.
     pub power_scale: PowerScale,
     /// The application protocol version.
+    #[serde(default)]
     pub app_version: u64,
 }
 


### PR DESCRIPTION
https://github.com/consensus-shipyard/ipc/pull/717 added the `app_version` field to `FvmStateParams` but did it as a breaking change. Nodes that already had data in RocksDB are unable to start. 

This fixes it by letting them fill in the default 0 value. 