### PR TITLE
CONFIG: Make the configuration directory configurable

### DIFF
--- a/fendermint/app/options/src/lib.rs
+++ b/fendermint/app/options/src/lib.rs
@@ -94,6 +94,10 @@ pub struct Options {
     )]
     pub home_dir: PathBuf,
 
+    /// Set a custom directory for configuration files
+    #[arg(long, env = "FM_CONFIG_DIR")]
+    config_dir: Option<PathBuf>,
+
     /// Set a custom directory for ipc log files.
     #[arg(long, env = "FM_LOG_DIR")]
     pub log_dir: Option<PathBuf>,
@@ -154,8 +158,14 @@ impl Options {
         }
     }
 
+    /// Path to the configuration directories.
+    ///
+    /// If not specified then returns the default under the home directory.
     pub fn config_dir(&self) -> PathBuf {
-        self.home_dir.join("config")
+        self.config_dir
+            .as_ref()
+            .cloned()
+            .unwrap_or(self.home_dir.join("config"))
     }
 }
 


### PR DESCRIPTION
Currently the configuration directory is expected to be under the `--home-dir` (by default `~/.fendermint`) named `config`, with the following content:

* `default.toml` always expected
* `<mode>.toml`  optional, where `<mode>` comes from the [--mode](https://github.com/consensus-shipyard/ipc/blob/7715c04c3ad9b1da4a39f332d0f6080f39db5622/fendermint/app/options/src/lib.rs#L106-L107) CLI option
* `local.toml` also optional

The `default.toml` is copied into the `fendermint` container, and it was expected that operators can _mount_ a custom configuration as a volume under `/fendermint/config/local.toml` for example. However if someone wants to modify the `FM_HOME_DIR` to an empty volume, then it is inconvenient that they have to procure a `default.toml` that has all the right fields. 

This PR adds a `--config-dir` CLI option (with an `FM_CONFIG_DIR` env var) which by default is empty, falling back to the current approach, but if set, expects the `default.toml` to be present there. The idea is that you can mount an empty volume for the `--home-dir`, and redirect the `--config-dir` _back_ to `/fendermint/config`.

```console
❯ cargo run -q -p fendermint_app -- --help
Usage: fendermint [OPTIONS] <COMMAND>
...

Options:
  -d, --home-dir <HOME_DIR>
          Set a custom directory for data and configuration files [env: FM_HOME_DIR=] [default: ~/.fendermint]
      --config-dir <CONFIG_DIR>
          Set a custom directory for configuration files [env: FM_CONFIG_DIR=]
      --log-dir <LOG_DIR>
          Set a custom directory for ipc log files [env: FM_LOG_DIR=]
```