### PR TITLE
fix: missing enum variant for StakingOperation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4962,6 +4962,7 @@ dependencies = [
  "lazy_static",
  "log",
  "num-traits",
+ "num_enum",
  "serde",
  "serde_json",
  "serde_tuple",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ multihash = { version = "0.18.1", default-features = false, features = [
 num-bigint = "0.4"
 num-derive = "0.3"
 num-traits = "0.2"
+num_enum = "0.7.2"
 paste = "1"
 pin-project = "1.1.2"
 prometheus = "0.13"

--- a/ipc/api/Cargo.toml
+++ b/ipc/api/Cargo.toml
@@ -20,6 +20,7 @@ lazy_static = { workspace = true }
 log = { workspace = true }
 cid = { workspace = true }
 num-traits = { workspace = true }
+num_enum = { workspace = true }
 serde = { workspace = true }
 serde_tuple = { workspace = true }
 strum = { workspace = true }

--- a/ipc/api/src/staking.rs
+++ b/ipc/api/src/staking.rs
@@ -12,21 +12,14 @@ use std::fmt::{Display, Formatter};
 
 pub type ConfigurationNumber = u64;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, num_enum::TryFromPrimitive)]
+#[non_exhaustive]
+#[repr(u8)]
 pub enum StakingOperation {
-    Deposit,
-    Withdraw,
-    SetMetadata,
-}
-
-impl From<u8> for StakingOperation {
-    fn from(value: u8) -> Self {
-        match value {
-            0 => Self::Deposit,
-            1 => Self::Withdraw,
-            _ => Self::SetMetadata,
-        }
-    }
+    Deposit = 0,
+    Withdraw = 1,
+    SetMetadata = 2,
+    SetFederatedPower = 3,
 }
 
 #[derive(Clone, Debug)]
@@ -52,7 +45,7 @@ impl TryFrom<lib_staking_change_log::NewStakingChangeRequestFilter> for StakingC
         Ok(Self {
             configuration_number: value.configuration_number,
             change: StakingChange {
-                op: StakingOperation::from(value.op),
+                op: StakingOperation::try_from(value.op)?,
                 payload: value.payload.to_vec(),
                 validator: ethers_address_to_fil_address(&value.validator)?,
             },


### PR DESCRIPTION
## Problem

The IPC API module was missing enum variant StakingOperation#SetFederatedPower. The fallback branch of the u8 to enum ended up representing unrecognized ABI values as SetMetadata operations. Consequently, SetFederatedPower commands were being wrongly translated and applied in the subnet gateway as SetMetadata commands.

## Solution

Add the missing enum variant and make the conversion typesafe by using try_from. To avoid being pedantic, use num_enum macros. This create was anyway part of the build graph already, so we might as well use it.

## Credits

Shoutout to @mikevoronov and @folex from Fluence Labs for finding and reporting this!