### PR TITLE
fix(federated validation): make subnet gateway use federated power to calculate power table

### DIFF
--- a/contracts/src/gateway/router/TopDownFinalityFacet.sol
+++ b/contracts/src/gateway/router/TopDownFinalityFacet.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.23;
 
 import {GatewayActorModifiers} from "../../lib/LibGatewayActorStorage.sol";
 import {ParentFinality} from "../../structs/CrossNet.sol";
-import {Validator, ValidatorInfo, StakingChangeRequest, Membership} from "../../structs/Subnet.sol";
+import {PermissionMode, Validator, ValidatorInfo, StakingChangeRequest, Membership} from "../../structs/Subnet.sol";
 import {LibGateway} from "../../lib/LibGateway.sol";
 
 import {FilAddress} from "fevmate/utils/FilAddress.sol";
@@ -51,20 +51,28 @@ contract TopDownFinalityFacet is GatewayActorModifiers {
         // confirm the change
         s.validatorsTracker.confirmChange(configurationNumber);
 
-        // get the active validators
+        // Get active validators and populate the new power table.
         address[] memory validators = s.validatorsTracker.validators.listActiveValidators();
         uint256 vLength = validators.length;
         Validator[] memory vs = new Validator[](vLength);
         for (uint256 i; i < vLength; ) {
             address addr = validators[i];
             ValidatorInfo storage info = s.validatorsTracker.validators.validators[addr];
-            vs[i] = Validator({weight: info.confirmedCollateral, addr: addr, metadata: info.metadata});
+
+            // Extract the consensus weight for validator.
+            uint256 weight = info.confirmedCollateral;
+            if (s.validatorsTracker.validators.permissionMode == PermissionMode.Federated) {
+                // Use the explicit federated power for power accounting if in Federated permissioning mode.
+                weight = info.federatedPower;
+            }
+
+            vs[i] = Validator({weight: weight, addr: addr, metadata: info.metadata});
             unchecked {
                 ++i;
             }
         }
 
-        // update membership with the applied changes
+        // update membership with the resulting power table.
         LibGateway.updateMembership(Membership({configurationNumber: configurationNumber, validators: vs}));
         return configurationNumber;
     }

--- a/contracts/src/gateway/router/TopDownFinalityFacet.sol
+++ b/contracts/src/gateway/router/TopDownFinalityFacet.sol
@@ -63,7 +63,8 @@ contract TopDownFinalityFacet is GatewayActorModifiers {
             uint256 weight = info.confirmedCollateral;
             if (s.validatorsTracker.validators.permissionMode == PermissionMode.Federated) {
                 // Use the explicit federated power for power accounting if in Federated permissioning mode.
-                weight = info.federatedPower;
+                // Sum it to the confirmedCollateral (which was locked pre-bootstrap and can no longer be adjusted after genesis)
+                weight += info.federatedPower;
             }
 
             vs[i] = Validator({weight: weight, addr: addr, metadata: info.metadata});


### PR DESCRIPTION
Federated validation is a bit messy right now. There are two phases:

1. Pre-bootstrap and pre-genesis: the sum of collateral and explicit power determine the weight of a validator.
2. Post-bootstrap and post-genesis: only setFederatedPower calls are allowed. Collateral-based [changes are disallowed](https://github.com/consensus-shipyard/ipc/blob/0855f0fd0b267942e3e2e4b3bf5ff8d5fbe0596d/contracts/src/subnet/SubnetActorManagerFacet.sol#L161).

This fixes the weight calculation in the child within phase 2, summing the explicit power to the collateral-based power (fixed at genesis).

Note: This calculation should not happen inside the subnet. See design discussion at https://github.com/consensus-shipyard/ipc/pull/784.