### PR TITLE
Debug genesis validator

### DIFF
--- a/contracts/src/gateway/router/TopDownFinalityFacet.sol
+++ b/contracts/src/gateway/router/TopDownFinalityFacet.sol
@@ -60,12 +60,7 @@ contract TopDownFinalityFacet is GatewayActorModifiers {
             ValidatorInfo storage info = s.validatorsTracker.validators.validators[addr];
 
             // Extract the consensus weight for validator.
-            uint256 weight = info.confirmedCollateral;
-            if (s.validatorsTracker.validators.permissionMode == PermissionMode.Federated) {
-                // Use the explicit federated power for power accounting if in Federated permissioning mode.
-                // Sum it to the confirmedCollateral (which was locked pre-bootstrap and can no longer be adjusted after genesis)
-                weight += info.federatedPower;
-            }
+            uint256 weight = info.confirmedCollateral + info.federatedPower;
 
             vs[i] = Validator({weight: weight, addr: addr, metadata: info.metadata});
             unchecked {

--- a/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -386,8 +386,12 @@ where
 /// * include any new validator, or validators whose power has been updated
 /// * include validators to be removed with a power of 0, as [expected](https://github.com/informalsystems/tendermint-rs/blob/bcc0b377812b8e53a02dff156988569c5b3c81a2/rpc/src/dialect/end_block.rs#L12-L14) by CometBFT
 fn power_diff(current: PowerTable, next: PowerTable) -> PowerUpdates {
+    tracing::debug!(?current, ?next, "power diff of tables");
+
     let current = into_power_map(current);
     let next = into_power_map(next);
+
+    tracing::debug!(?current, ?next, "power maps");
 
     let mut diff = Vec::new();
 

--- a/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -103,6 +103,8 @@ where
         msgs,
     };
 
+    tracing::debug!(?checkpoint, "checkpoint to create");
+
     // Save the checkpoint in the ledger.
     // Pass in the current power table, because these are the validators who can sign this checkpoint.
     gateway
@@ -120,6 +122,8 @@ where
 
         power_diff(curr_power_table, next_power_table)
     };
+
+    tracing::debug!(?power_updates, "power updates");
 
     emit!(NewBottomUpCheckpoint {
         block_height: height.value(),

--- a/fendermint/vm/interpreter/src/fvm/state/ipc.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/ipc.rs
@@ -174,8 +174,10 @@ impl<DB: Blockstore + Clone> GatewayCaller<DB> {
         let membership = self
             .current_membership(state)
             .context("failed to get current membership")?;
+        tracing::debug!(?membership, "current membership");
 
         let power_table = membership_to_power_table(&membership, state.power_scale());
+        tracing::debug!(?power_table, "power table");
 
         Ok((membership.configuration_number, power_table))
     }

--- a/fendermint/vm/interpreter/src/fvm/state/ipc.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/ipc.rs
@@ -135,6 +135,11 @@ impl<DB: Blockstore + Clone> GatewayCaller<DB> {
             p.saturating_add(et::U256::from(v.power.0))
         });
 
+        tracing::debug!(
+            root_hash = hex::encode(tree.root_hash().0),
+            total_power = total_power.to_string(),
+            "parameters to create checkpoint"
+        );
         self.checkpointing.call(state, |c| {
             c.create_bottom_up_checkpoint(checkpoint, tree.root_hash().0, total_power)
         })


### PR DESCRIPTION
Currently with federatedPower permission mode, the validator changes are not reflected correctly to the child subnet with
![image](https://github.com/consensus-shipyard/ipc/assets/108330426/b6da00f5-3c27-4c5e-8a7a-86c4ab316580)

This happens because in the child, the permission mode is not initialised correctly.

This PR introduces a quick and dirty fix to the above error. Also this PR adds a couple of debug logs for future debugging.