### PR TITLE
extras/axelar-token: improve error handling and add recovery paths.

### DIFF
--- a/extras/axelar-token/.env.example
+++ b/extras/axelar-token/.env.example
@@ -2,38 +2,53 @@
 ## To change the network to use as origin and destination, modify these following environment variables.
 ## Other environment variables are prefixed with the network name, followed by two underscores.
 ## For example, for the Polygon Mumbai network, the private key environment variable is POLYGON_MUMBAI__PRIVATE_KEY
-ORIGIN_NETWORK=POLYGON_MUMBAI  # Specifies the origin network as Polygon Mumbai
-DEST_NETWORK=FILECOIN_CALIBRATION  # Specifies the destination network as Filecoin Calibration
+# Specifies the origin network as Polygon Mumbai
+ORIGIN_NETWORK=POLYGON_MUMBAI
+# Specifies the destination network as Filecoin Calibration
+DEST_NETWORK=FILECOIN_CALIBRATION
 
 ###
 ### Polygon Mumbai
 #########################
 
-POLYGON_MUMBAI__PRIVATE_KEY=  # Private key for the Polygon Mumbai network
-POLYGON_MUMBAI__RPC_URL=https://polygon-mumbai.gateway.tenderly.co  # RPC URL for the Polygon Mumbai network
+# Private key for the Polygon Mumbai network
+POLYGON_MUMBAI__PRIVATE_KEY=
+# RPC URL for the Polygon Mumbai network
+POLYGON_MUMBAI__RPC_URL=https://polygon-mumbai.gateway.tenderly.co
 
 # Axelar config; see https://docs.axelar.dev/resources/contract-addresses/testnet
-POLYGON_MUMBAI__AXELAR_ITS_ADDRESS=0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C  # Axelar ITS address for the Polygon Mumbai network
-POLYGON_MUMBAI__AXELAR_CHAIN_NAME=Polygon  # Axelar chain name for the Polygon Mumbai network
+# Axelar ITS address for the Polygon Mumbai network
+POLYGON_MUMBAI__AXELAR_ITS_ADDRESS=0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C
+# Axelar chain name for the Polygon Mumbai network
+POLYGON_MUMBAI__AXELAR_CHAIN_NAME=Polygon
 
 ###
 ### Filecoin Calibration
 #########################
 
-FILECOIN_CALIBRATION__PRIVATE_KEY=  # Private key for the Filecoin Calibration network
-FILECOIN_CALIBRATION__RPC_URL=https://api.calibration.node.glif.io/rpc/v1  # RPC URL for the Filecoin Calibration network
+# Private key for the Filecoin Calibration network
+FILECOIN_CALIBRATION__PRIVATE_KEY=
+# RPC URL for the Filecoin Calibration network
+FILECOIN_CALIBRATION__RPC_URL=https://api.calibration.node.glif.io/rpc/v1
 
 # Axelar config; see https://docs.axelar.dev/resources/contract-addresses/testnet
-FILECOIN_CALIBRATION__AXELAR_ITS_ADDRESS=0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C  # Axelar ITS address for the Filecoin Calibration network
-FILECOIN_CALIBRATION__AXELAR_CHAIN_NAME=filecoin-2  # Axelar chain name for the Filecoin Calibration network
+# Axelar ITS address for the Filecoin Calibration network
+FILECOIN_CALIBRATION__AXELAR_ITS_ADDRESS=0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C
+# Axelar chain name for the Filecoin Calibration network
+FILECOIN_CALIBRATION__AXELAR_CHAIN_NAME=filecoin-2
 
 # IPC
-FILECOIN_CALIBRATION__IPC_GATEWAY_ADDRESS=0xdd0A8b2f247b8444AF716b14250939B57cdBe1E8  # IPC gateway address for the Filecoin Calibration network
+# IPC gateway address for the Filecoin Calibration network
+FILECOIN_CALIBRATION__IPC_GATEWAY_ADDRESS=0xdd0A8b2f247b8444AF716b14250939B57cdBe1E8
+# The admin address of the IpcTokenHandler, which is authorized to operate the treasury to recover funds.
+FILECOIN_CALIBRATION__HANDLER_ADMIN_ADDRESS=0x
 
 ###
 ### Axelar token addresses
 ################################
 
 # https://testnet.interchain.axelar.dev/polygon/0x0cc94E0b1056Ab7125DD820b406C0A4581CCec91
-POLYGON_MUMBAI__ORIGIN_TOKEN_ADDRESS=0x0cc94E0b1056Ab7125DD820b406C0A4581CCec91  # Origin token address for the Polygon Mumbai network
-FILECOIN_CALIBRATION__REMOTE_TOKEN_ADDRESS=0x0cc94E0b1056Ab7125DD820b406C0A4581CCec91  # Remote token address for the Filecoin Calibration network
+# Origin token address for the Polygon Mumbai network
+POLYGON_MUMBAI__ORIGIN_TOKEN_ADDRESS=0x0cc94E0b1056Ab7125DD820b406C0A4581CCec91
+# Remote token address for the Filecoin Calibration network
+FILECOIN_CALIBRATION__REMOTE_TOKEN_ADDRESS=0x0cc94E0b1056Ab7125DD820b406C0A4581CCec91

--- a/extras/axelar-token/script/Deploy.s.sol
+++ b/extras/axelar-token/script/Deploy.s.sol
@@ -17,7 +17,8 @@ contract Deploy is Script {
         vm.startBroadcast(privateKey);
         IpcTokenHandler handler = new IpcTokenHandler({
             axelarIts: vm.envAddress(string.concat(network, "__AXELAR_ITS_ADDRESS")),
-            ipcGateway: vm.envAddress(string.concat(network, "__IPC_GATEWAY_ADDRESS"))
+            ipcGateway: vm.envAddress(string.concat(network, "__IPC_GATEWAY_ADDRESS")),
+            admin: vm.envAddress(string.concat(network, "__HANDLER_ADMIN_ADDRESS"))
         });
         vm.stopBroadcast();
 

--- a/extras/axelar-token/src/IpcTokenHandler.sol
+++ b/extras/axelar-token/src/IpcTokenHandler.sol
@@ -73,9 +73,8 @@ contract IpcTokenHandler is InterchainTokenExecutable, IpcHandler, Ownable {
             // Increase the allowance of the admin address so they can retrieve these otherwise lost tokens.
             token.safeIncreaseAllowance(owner(), amount);
 
-            // Emit a FundingFailed event; we can't associate a specific subnet or recipient since parsing may have failed.
-            SubnetID memory nilSubnet;
-            emit FundingFailed(nilSubnet, address(0), amount);
+            // Emit a FundingFailed event.
+            emit FundingFailed(subnet, recipient, amount);
 
             return;
         }

--- a/extras/axelar-token/test/TestHandler.sol
+++ b/extras/axelar-token/test/TestHandler.sol
@@ -16,7 +16,8 @@ contract TestHandler is Test {
 
         IpcTokenHandler handler = new IpcTokenHandler({
             axelarIts: axelarIts,
-            ipcGateway: ipcGateway
+            ipcGateway: ipcGateway,
+            admin: address(0)
         });
 
         address[] memory route = new address[](1);

--- a/extras/axelar-token/test/TestHandler.sol
+++ b/extras/axelar-token/test/TestHandler.sol
@@ -67,12 +67,11 @@ contract TestHandler is Test {
         token.transfer(address(handler), 1);
         vm.startPrank(axelarIts);
 
-        SubnetID memory nilSubnet;
         vm.expectEmit();
         emit IERC20.Approval(address(handler), address(ipcGateway), 1);
         emit IERC20.Approval(address(handler), address(ipcGateway), 0);
         emit IERC20.Approval(address(handler), address(owner), 1);
-        emit IpcTokenHandler.FundingFailed(nilSubnet, address(0), 1);
+        emit IpcTokenHandler.FundingFailed(subnet, recipient, 1);
 
         vm.mockCallRevert(
             address(ipcGateway),
@@ -97,13 +96,7 @@ contract TestHandler is Test {
             ipcGateway: ipcGateway,
             admin: owner
         });
-
-        address[] memory route = new address[](1);
-        route[0] = 0x2a3eF0F414c626e51AFA2F29f3F7Be7a45C6DB09;
-        SubnetID memory subnet = SubnetID({ root: 314159, route: route });
-
-        address recipient = 0x6B505cdCCCA34aE8eea5D382aBaD40d2AfEa74ad;
-
+        
         // garbage
         bytes memory params = abi.encode(1);
 

--- a/extras/axelar-token/test/TestHandler.sol
+++ b/extras/axelar-token/test/TestHandler.sol
@@ -12,20 +12,21 @@ contract TestHandler is Test {
     function test_handler_Ok() public {
         address axelarIts = vm.addr(1);
         address ipcGateway = vm.addr(2);
+        address owner = vm.addr(3);
         DummyERC20 token = new DummyERC20("Test token", "TST", 10000);
 
         IpcTokenHandler handler = new IpcTokenHandler({
             axelarIts: axelarIts,
             ipcGateway: ipcGateway,
-            admin: address(0)
+            admin: owner
         });
 
         address[] memory route = new address[](1);
         route[0] = 0x2a3eF0F414c626e51AFA2F29f3F7Be7a45C6DB09;
+        SubnetID memory subnet = SubnetID({ root: 314159, route: route });
 
         address recipient = 0x6B505cdCCCA34aE8eea5D382aBaD40d2AfEa74ad;
 
-        SubnetID memory subnet = SubnetID({ root: 314159, route: route });
         bytes memory params = abi.encode(subnet, recipient);
 
         token.transfer(address(handler), 1);
@@ -37,9 +38,53 @@ contract TestHandler is Test {
             abi.encode("")
         );
         handler.executeWithInterchainToken(bytes32(""), "", "", params, bytes32(""), address(token), 1);
+
+        // the allowance of the gateway is still 1, because the call to fundWithToken was mocked and did not actually expend the allowance
+        // this is not what would happen in reality, but the assert gives us extra insight
+        require(token.allowance(address(handler), ipcGateway) == 1);
     }
 
-    // TODO test_handler_err_withdrawal (also test getClaims)
+    function test_handler_failGateway() public {
+        address axelarIts = vm.addr(1);
+        address ipcGateway = vm.addr(2);
+        address owner = vm.addr(3);
+        DummyERC20 token = new DummyERC20("Test token", "TST", 10000);
+
+        IpcTokenHandler handler = new IpcTokenHandler({
+            axelarIts: axelarIts,
+            ipcGateway: ipcGateway,
+            admin: owner
+        });
+
+        address[] memory route = new address[](1);
+        route[0] = 0x2a3eF0F414c626e51AFA2F29f3F7Be7a45C6DB09;
+        SubnetID memory subnet = SubnetID({ root: 314159, route: route });
+
+        address recipient = 0x6B505cdCCCA34aE8eea5D382aBaD40d2AfEa74ad;
+
+        bytes memory params = abi.encode(subnet, recipient);
+
+        token.transfer(address(handler), 1);
+        vm.startPrank(axelarIts);
+
+        SubnetID memory nilSubnet;
+        vm.expectEmit();
+        emit IERC20.Approval(address(handler), address(ipcGateway), 1);
+        emit IERC20.Approval(address(handler), address(ipcGateway), 0);
+        emit IERC20.Approval(address(handler), address(owner), 1);
+        emit IpcTokenHandler.FundingFailed(nilSubnet, address(0), 1);
+
+        vm.mockCallRevert(
+            address(ipcGateway),
+            abi.encodeWithSelector(TokenFundedGateway.fundWithToken.selector, subnet, recipient.from(), 1),
+            abi.encode("ERROR")
+        );
+        handler.executeWithInterchainToken(bytes32(""), "", "", params, bytes32(""), address(token), 1);
+
+        // the allowance was accrued to the owner
+        require(token.allowance(address(handler), ipcGateway) == 0);
+        require(token.allowance(address(handler), owner) == 1);
+    }
 
     // TODO test_handler_err_deposit (e.g. sending to a non-ERC20 subnet)
 


### PR DESCRIPTION
1. We introduce the notion of an "admin" address as the recovery operator.
2. We now handle failures when parsing semi-untrusted input, and when invoking the IPC gateway. If any of those fail, we increment the allowance of the admin so they can operate the otherwise locked tokens.
3. When the subnet reports a failure crediting the deposit (e.g. such as if the recipient was a smart contract / actor that reverted), we increment the allowance of the admin also. This is more failsafe and easier to operate than crediting the funds to the recipient on the L1 (who wouldn't be able to rescue them if it was a smart contract, unless it could manage to deploy itself onto the same address it had in the subnet, plausible if it used Deploy3).
4. As an ultimate backstop, we introduce a method so that the operator can increase its allowance on any token. This should only be used iff something unexpected failed, like the error handling paths themselves.