### PR TITLE
FIX: Use f410 delegated address in EAM `can_deploy`

### DIFF
--- a/fendermint/actors/eam/src/lib.rs
+++ b/fendermint/actors/eam/src/lib.rs
@@ -236,14 +236,15 @@ mod tests {
 
     #[test]
     fn test_create_allowed() {
-        let deployers = vec![Address::new_id(1000), Address::new_id(2000)];
-        let rt = construct_and_verify(deployers);
-
         let id_addr = Address::new_id(1000);
         let eth_addr = EthAddress(hex_literal::hex!(
             "CAFEB0BA00000000000000000000000000000000"
         ));
         let f4_eth_addr = Address::new_delegated(10, &eth_addr.0).unwrap();
+
+        let deployers = vec![f4_eth_addr];
+
+        let rt = construct_and_verify(deployers);
         rt.set_delegated_address(id_addr.id().unwrap(), f4_eth_addr);
 
         rt.set_caller(*EVM_ACTOR_CODE_ID, id_addr);

--- a/fendermint/actors/eam/src/state.rs
+++ b/fendermint/actors/eam/src/state.rs
@@ -15,7 +15,10 @@ pub type DeployerMap<BS> = Map2<BS, Address, ()>;
 pub enum PermissionModeParams {
     /// No restriction, everyone can deploy
     Unrestricted,
-    /// Only whitelisted addresses can deploy
+    /// Only whitelisted addresses can deploy.
+    ///
+    /// Use FVM delegated addresses of Ethereum accounts,
+    /// because those are predictable in genesis.
     AllowList(Vec<Address>),
 }
 
@@ -51,6 +54,7 @@ impl State {
         Ok(State { permission_mode })
     }
 
+    /// Check if an actor can deploy a contract.
     pub fn can_deploy(
         &self,
         store: &impl Blockstore,


### PR DESCRIPTION
The `FvmRuntime` returns an `ActorID` wrapped as an `Address`, but this is almost impossible to tell up front.