### PR TITLE
EAM: Allow deployments by contracts

### DIFF
--- a/fendermint/actors/eam/src/lib.rs
+++ b/fendermint/actors/eam/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fil_actor_eam::{EamActor, Method};
+use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::ActorError;
 use fil_actors_runtime::EAM_ACTOR_ID;
@@ -39,6 +40,16 @@ impl IPCEamActor {
         // The caller is guaranteed to be an ID address.
         let caller_id = rt.message().caller().id().unwrap();
 
+        // Check if the caller is a contract. If it is, and we're in permissioned mode,
+        // then the contract was either there in genesis or has been deployed by a whitelisted
+        // account; in both cases it's been known up front whether it creates other contracts,
+        // and if that was undesireable it would not have been deployed as it is.
+        let code_cid = rt.get_actor_code_cid(&caller_id).expect("caller has code");
+        if rt.resolve_builtin_actor_type(&code_cid) == Some(Type::EVM) {
+            return Ok(());
+        }
+
+        // Check if the caller is whitelisted.
         let state: State = rt.state()?;
         if !state.can_deploy(rt, caller_id)? {
             return Err(ActorError::forbidden(String::from(
@@ -84,11 +95,12 @@ pub struct ConstructorParams {
 mod tests {
     use fil_actor_eam::ext::evm::ConstructorParams;
     use fil_actor_eam::ext::init::{Exec4Params, Exec4Return, EXEC4_METHOD};
-    use fil_actor_eam::{compute_address_create, CreateParams, Return};
+    use fil_actor_eam::{compute_address_create, CreateExternalParams, CreateParams, Return};
     use fil_actors_evm_shared::address::EthAddress;
     use fil_actors_runtime::runtime::builtins::Type;
     use fil_actors_runtime::test_utils::{
-        expect_empty, MockRuntime, EVM_ACTOR_CODE_ID, SYSTEM_ACTOR_CODE_ID,
+        expect_empty, MockRuntime, ETHACCOUNT_ACTOR_CODE_ID, EVM_ACTOR_CODE_ID,
+        SYSTEM_ACTOR_CODE_ID,
     };
     use fil_actors_runtime::INIT_ACTOR_ADDR;
     use fil_actors_runtime::SYSTEM_ACTOR_ADDR;
@@ -143,20 +155,18 @@ mod tests {
         let f4_eth_addr = Address::new_delegated(10, &eth_addr.0).unwrap();
 
         rt.set_delegated_address(id_addr.id().unwrap(), f4_eth_addr);
-        rt.set_caller(*EVM_ACTOR_CODE_ID, id_addr);
+        rt.set_caller(*ETHACCOUNT_ACTOR_CODE_ID, id_addr);
 
-        let create_params = CreateParams {
-            initcode: vec![0xff],
-            nonce: 0,
-        };
+        let create_params = CreateExternalParams(vec![0xff]);
 
         let exit_code = rt
             .call::<IPCEamActor>(
-                Method::Create as u64,
+                Method::CreateExternal as u64,
                 IpldBlock::serialize_cbor(&create_params).unwrap(),
             )
             .unwrap_err()
             .exit_code();
+
         assert_eq!(exit_code, ExitCode::USR_FORBIDDEN)
     }
 
@@ -172,15 +182,13 @@ mod tests {
         let f4_eth_addr = Address::new_delegated(10, &eth_addr.0).unwrap();
 
         rt.set_delegated_address(id_addr.id().unwrap(), f4_eth_addr);
-        rt.set_caller(*EVM_ACTOR_CODE_ID, id_addr);
-        rt.expect_validate_caller_type(vec![Type::EVM]);
+        rt.set_caller(*ETHACCOUNT_ACTOR_CODE_ID, id_addr);
+        rt.set_origin(id_addr);
+        rt.expect_validate_caller_addr(vec![id_addr]);
 
         let initcode = vec![0xff];
 
-        let create_params = CreateParams {
-            initcode: initcode.clone(),
-            nonce: 0,
-        };
+        let create_params = CreateExternalParams(initcode.clone());
 
         let evm_params = ConstructorParams {
             creator: eth_addr,
@@ -211,7 +219,7 @@ mod tests {
 
         let result = rt
             .call::<IPCEamActor>(
-                Method::Create as u64,
+                Method::CreateExternal as u64,
                 IpldBlock::serialize_cbor(&create_params).unwrap(),
             )
             .unwrap()
@@ -230,7 +238,74 @@ mod tests {
     }
 
     #[test]
-    fn test_create_allowed() {
+    fn test_create_by_whitelisted_allowed() {
+        let eth_addr = EthAddress(hex_literal::hex!(
+            "CAFEB0BA00000000000000000000000000000000"
+        ));
+        let f4_eth_addr = Address::new_delegated(10, &eth_addr.0).unwrap();
+
+        let deployers = vec![Address::new_id(2000), f4_eth_addr];
+        let rt = construct_and_verify(deployers);
+
+        let id_addr = Address::new_id(1000);
+        rt.set_delegated_address(id_addr.id().unwrap(), f4_eth_addr);
+        rt.set_caller(*ETHACCOUNT_ACTOR_CODE_ID, id_addr);
+        rt.set_origin(id_addr);
+        rt.expect_validate_caller_addr(vec![id_addr]);
+
+        let initcode = vec![0xff];
+
+        let create_params = CreateExternalParams(initcode.clone());
+
+        let evm_params = ConstructorParams {
+            creator: eth_addr,
+            initcode: initcode.into(),
+        };
+
+        let new_eth_addr = compute_address_create(&rt, &eth_addr, 0);
+        let params = Exec4Params {
+            code_cid: *EVM_ACTOR_CODE_ID,
+            constructor_params: RawBytes::serialize(evm_params).unwrap(),
+            subaddress: new_eth_addr.0[..].to_owned().into(),
+        };
+
+        let send_return = IpldBlock::serialize_cbor(&Exec4Return {
+            id_address: Address::new_id(111),
+            robust_address: Address::new_id(0), // not a robust address but im hacking here and nobody checks
+        })
+        .unwrap();
+
+        rt.expect_send_simple(
+            INIT_ACTOR_ADDR,
+            EXEC4_METHOD,
+            IpldBlock::serialize_cbor(&params).unwrap(),
+            TokenAmount::from_atto(0),
+            send_return,
+            ExitCode::OK,
+        );
+
+        let result = rt
+            .call::<IPCEamActor>(
+                Method::CreateExternal as u64,
+                IpldBlock::serialize_cbor(&create_params).unwrap(),
+            )
+            .unwrap()
+            .unwrap()
+            .deserialize::<Return>()
+            .unwrap();
+
+        let expected_return = Return {
+            actor_id: 111,
+            robust_address: Some(Address::new_id(0)),
+            eth_address: new_eth_addr,
+        };
+
+        assert_eq!(result, expected_return);
+        rt.verify();
+    }
+
+    #[test]
+    fn test_create_by_contract_allowed() {
         let eth_addr = EthAddress(hex_literal::hex!(
             "CAFEB0BA00000000000000000000000000000000"
         ));
@@ -242,7 +317,6 @@ mod tests {
         let id_addr = Address::new_id(1000);
         rt.set_delegated_address(id_addr.id().unwrap(), f4_eth_addr);
         rt.set_caller(*EVM_ACTOR_CODE_ID, id_addr);
-
         rt.expect_validate_caller_type(vec![Type::EVM]);
 
         let initcode = vec![0xff];


### PR DESCRIPTION
It is okay to allow contracts to deploy other contracts, they don't need to be whitelisted.