### PR TITLE
Fix diamond upgrade failing to find typescript bindings

### DIFF
--- a/contracts/scripts/util.ts
+++ b/contracts/scripts/util.ts
@@ -159,9 +159,15 @@ export async function getRuntimeBytecode(bytecode) {
 export async function getBytecodeFromFacet(facet) {
     const facetName = facet.name
     const libs = facet.libs
-    const bytecodeNeedsLink = getBytecodeFromFacetTypeChainFilename(
-        findFileInDir(`${facetName}__factory.ts`, `./typechain/factories/`),
+    const factoryFileName = findFileInDir(
+        `${facetName}__factory.ts`,
+        `./typechain/factories/`,
     )
+    if (factoryFileName === null) {
+        throw new Error('Typescript bindings for Facet not found')
+    }
+    const bytecodeNeedsLink =
+        getBytecodeFromFacetTypeChainFilename(factoryFileName)
     let libs2 = {}
     // Loop through each key in the libs
     for (let key in libs) {

--- a/contracts/scripts/util.ts
+++ b/contracts/scripts/util.ts
@@ -6,6 +6,31 @@ import * as linker from 'solc/linker'
 
 const { getSelectors, FacetCutAction } = require('./js/diamond.js')
 const fs = require('fs')
+const path = require('path')
+
+function findFileInDir(filename, folder) {
+    // This function checks each entry in the directory: if it's a file matching the filename, it returns its path.
+    // If it's a directory, the function recurses into it.
+    function searchDirectory(currentPath) {
+        const entries = fs.readdirSync(currentPath, { withFileTypes: true })
+
+        for (let entry of entries) {
+            const entryPath = path.join(currentPath, entry.name)
+
+            if (entry.isDirectory()) {
+                const result = searchDirectory(entryPath)
+                if (result) return result
+            } else if (entry.isFile() && entry.name === filename) {
+                return entryPath
+            }
+        }
+
+        // If no file is found, return null.
+        return null
+    }
+
+    return searchDirectory(folder)
+}
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
@@ -135,7 +160,7 @@ export async function getBytecodeFromFacet(facet) {
     const facetName = facet.name
     const libs = facet.libs
     const bytecodeNeedsLink = getBytecodeFromFacetTypeChainFilename(
-        `./typechain/factories/${facetName}__factory.ts`,
+        findFileInDir(`${facetName}__factory.ts`, `./typechain/factories/`),
     )
     let libs2 = {}
     // Loop through each key in the libs


### PR DESCRIPTION
 more flexible search for filename in case the typescript files are not generated flatly in the typechain/factories folder
 
 working on https://linear.app/interplanetary-consensus/issue/ENG-801/test-upgradability-of-subnet-actor-and-subnet-registry
 
 I discovered that without any clear indication of what's changed locally on my linux development machine I was failing to find local bytecode.

This PR includes a recursive search through the directory and throws an error if it is not found. 

I can confirm that with this PR, the gateway and subnet registry diamond upgrade scripts are working