### PR TITLE
React to Ctrl-C when running ipc-cli using a docker image

### DIFF
--- a/fendermint/docker/docker-entry.sh
+++ b/fendermint/docker/docker-entry.sh
@@ -5,7 +5,7 @@
 CMD=$1
 
 if [[ $CMD == 'ipc-cli' ]]; then
-  exec ipc-cli "${@:2}"
+  exec -t ipc-cli "${@:2}"
 else
   if (( $# == 0)); then
     exec fendermint

--- a/fendermint/docker/docker-entry.sh
+++ b/fendermint/docker/docker-entry.sh
@@ -8,8 +8,8 @@ if [[ $CMD == 'ipc-cli' ]]; then
   ipc-cli "${@:2}"
 else
   if (( $# == 0)); then
-    fendermint
+    exec fendermint
   else
-    fendermint "$@"
+    exec fendermint "$@"
   fi
 fi

--- a/fendermint/docker/docker-entry.sh
+++ b/fendermint/docker/docker-entry.sh
@@ -5,11 +5,11 @@
 CMD=$1
 
 if [[ $CMD == 'ipc-cli' ]]; then
-  exec -t ipc-cli "${@:2}"
+  ipc-cli "${@:2}"
 else
   if (( $# == 0)); then
-    exec fendermint
+    fendermint
   else
-    exec fendermint "$@"
+    fendermint "$@"
   fi
 fi


### PR DESCRIPTION
Previously when we run `ipc-cli` with a docker image, the terminal won't react to Ctrl-C. This PR fixes it.

Closes ENG-778

Local test result

```bash
$ docker run -it -v ~/.ipc:/fendermint/.ipc fendermint:latest ipc-cli checkpoint relayer --subnet /r314159/t410fw3df6gtwycgozfolgfqrwagd3p5yn53uf34ptgi --submitter 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
[2024-03-24T20:24:13Z INFO  ipc_provider::checkpoint] launching bottom-up relayer, parent: /r314159, child: /r314159/t410fw3df6gtwycgozfolgfqrwagd3p5yn53uf34ptgi for t410f6op5nzi2vwepn5gonk4ie4tzz773sitggxp4hiy
[2024-03-24T20:24:13Z INFO  ipc_provider::checkpoint] last submission height: 1440
(...push ctrl-c)
^C[1]    57887 exit 130   docker run -it -v ~/.ipc:/fendermint/.ipc fendermint:latest ipc-cli checkpoin
```