### PR TITLE
ENG-731: Cache transactions in the ethapi

### DIFF
--- a/fendermint/eth/api/src/cache.rs
+++ b/fendermint/eth/api/src/cache.rs
@@ -3,27 +3,63 @@
 
 use std::sync::{Arc, Mutex};
 
-use crate::state::ActorType;
 use anyhow::Context;
 use cid::Cid;
-use fendermint_rpc::client::FendermintClient;
-use fendermint_rpc::query::QueryClient;
-use fendermint_vm_message::query::FvmQueryHeight;
+use lru_time_cache::LruCache;
+use tendermint_rpc::Client;
+
 use fvm_shared::{
     address::{Address, Payload},
     ActorID,
 };
-use lru_time_cache::LruCache;
-use tendermint_rpc::Client;
+
+use fendermint_rpc::client::FendermintClient;
+use fendermint_rpc::query::QueryClient;
+use fendermint_vm_message::query::FvmQueryHeight;
+
+use crate::state::ActorType;
+
+// The `LruCache` is wrapped in `Mutex` beause even reading requiers mutation.
+#[derive(Clone)]
+pub struct Cache<K, V> {
+    cache: Arc<Mutex<LruCache<K, V>>>,
+}
+
+impl<K, V> Cache<K, V>
+where
+    K: Ord + Clone,
+    V: Clone,
+{
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            cache: Arc::new(Mutex::new(LruCache::with_capacity(capacity))),
+        }
+    }
+
+    pub fn insert(&self, key: K, value: V) {
+        let mut guard = self.cache.lock().expect("cache poisoned");
+        guard.insert(key, value);
+    }
+
+    pub fn get(&self, key: &K) -> Option<V> {
+        let mut guard = self.cache.lock().expect("cache poisoned");
+        guard.get(key).cloned()
+    }
+
+    pub fn remove(&self, key: &K) {
+        let mut guard = self.cache.lock().expect("cache poisoned");
+        guard.remove(key);
+    }
+}
 
 /// Facilitate Ethereum address <-> Actor ID lookups.
 #[derive(Clone)]
 pub struct AddressCache<C> {
     client: FendermintClient<C>,
-    addr_to_id: Arc<Mutex<LruCache<Address, ActorID>>>,
-    id_to_addr: Arc<Mutex<LruCache<ActorID, Address>>>,
-    addr_to_actor_type: Arc<Mutex<LruCache<Address, ActorType>>>,
-    cid_to_actor_type: Arc<Mutex<LruCache<Cid, ActorType>>>,
+    addr_to_id: Cache<Address, ActorID>,
+    id_to_addr: Cache<ActorID, Address>,
+    addr_to_actor_type: Cache<Address, ActorType>,
+    cid_to_actor_type: Cache<Cid, ActorType>,
 }
 
 impl<C> AddressCache<C>
@@ -33,10 +69,10 @@ where
     pub fn new(client: FendermintClient<C>, capacity: usize) -> Self {
         Self {
             client,
-            addr_to_id: Arc::new(Mutex::new(LruCache::with_capacity(capacity))),
-            id_to_addr: Arc::new(Mutex::new(LruCache::with_capacity(capacity))),
-            addr_to_actor_type: Arc::new(Mutex::new(LruCache::with_capacity(capacity))),
-            cid_to_actor_type: Arc::new(Mutex::new(LruCache::with_capacity(capacity))),
+            addr_to_id: Cache::new(capacity),
+            id_to_addr: Cache::new(capacity),
+            addr_to_actor_type: Cache::new(capacity),
+            cid_to_actor_type: Cache::new(capacity),
         }
     }
 
@@ -95,43 +131,35 @@ where
     }
 
     fn get_id(&self, addr: &Address) -> Option<ActorID> {
-        let mut c = self.addr_to_id.lock().unwrap();
-        c.get(addr).cloned()
+        self.addr_to_id.get(addr)
     }
 
     fn set_id(&self, addr: Address, id: ActorID) {
-        let mut c = self.addr_to_id.lock().unwrap();
-        c.insert(addr, id);
+        self.addr_to_id.insert(addr, id)
     }
 
     fn get_addr(&self, id: &ActorID) -> Option<Address> {
-        let mut c = self.id_to_addr.lock().unwrap();
-        c.get(id).cloned()
+        self.id_to_addr.get(id)
     }
 
     fn set_addr(&self, id: ActorID, addr: Address) {
-        let mut c = self.id_to_addr.lock().unwrap();
-        c.insert(id, addr);
+        self.id_to_addr.insert(id, addr)
     }
 
     pub fn set_actor_type_for_addr(&self, addr: Address, actor_type: ActorType) {
-        let mut c = self.addr_to_actor_type.lock().unwrap();
-        c.insert(addr, actor_type);
+        self.addr_to_actor_type.insert(addr, actor_type)
     }
 
     pub fn get_actor_type_from_addr(&self, addr: &Address) -> Option<ActorType> {
-        let mut c = self.addr_to_actor_type.lock().unwrap();
-        c.get(addr).cloned()
+        self.addr_to_actor_type.get(addr)
     }
 
     pub fn set_actor_type_for_cid(&self, cid: Cid, actor_type: ActorType) {
-        let mut c = self.cid_to_actor_type.lock().unwrap();
-        c.insert(cid, actor_type);
+        self.cid_to_actor_type.insert(cid, actor_type);
     }
 
     pub fn get_actor_type_from_cid(&self, cid: &Cid) -> Option<ActorType> {
-        let mut c = self.cid_to_actor_type.lock().unwrap();
-        c.get(cid).cloned()
+        self.cid_to_actor_type.get(cid)
     }
 }
 

--- a/fendermint/eth/api/src/cache.rs
+++ b/fendermint/eth/api/src/cache.rs
@@ -50,6 +50,16 @@ where
         let mut guard = self.cache.lock().expect("cache poisoned");
         guard.remove(key);
     }
+
+    pub fn remove_many(&self, keys: &[K]) {
+        if keys.is_empty() {
+            return;
+        }
+        let mut guard = self.cache.lock().expect("cache poisoned");
+        for key in keys {
+            guard.remove(key);
+        }
+    }
 }
 
 /// Facilitate Ethereum address <-> Actor ID lookups.

--- a/fendermint/eth/api/src/cache.rs
+++ b/fendermint/eth/api/src/cache.rs
@@ -19,7 +19,7 @@ use fendermint_vm_message::query::FvmQueryHeight;
 
 use crate::state::ActorType;
 
-// The `LruCache` is wrapped in `Mutex` beause even reading requiers mutation.
+// The `LruCache` is wrapped in `Mutex` beause even reading requires mutation.
 #[derive(Clone)]
 pub struct Cache<K, V> {
     cache: Arc<Mutex<LruCache<K, V>>>,

--- a/fendermint/eth/api/src/conv/from_eth.rs
+++ b/fendermint/eth/api/src/conv/from_eth.rs
@@ -3,6 +3,7 @@
 
 //! Helper methods to convert between Ethereum and FVM data formats.
 
+use ethers_core::types as et;
 use ethers_core::types::transaction::eip2718::TypedTransaction;
 
 pub use fendermint_vm_message::conv::from_eth::*;
@@ -30,5 +31,40 @@ pub fn to_fvm_message(tx: TypedTransaction, accept_legacy: bool) -> JsonRpcResul
             ExitCode::USR_ILLEGAL_ARGUMENT,
             "unexpected transaction type",
         ),
+    }
+}
+
+/// Turn a request into the DTO returned by the API.
+pub fn to_eth_transaction(
+    tx: et::Eip1559TransactionRequest,
+    sig: et::Signature,
+    hash: et::TxHash,
+) -> et::Transaction {
+    et::Transaction {
+        hash,
+        nonce: tx.nonce.unwrap_or_default(),
+        block_hash: None,
+        block_number: None,
+        transaction_index: None,
+        from: tx.from.unwrap_or_default(),
+        to: tx.to.and_then(|to| to.as_address().cloned()),
+        value: tx.value.unwrap_or_default(),
+        gas: tx.gas.unwrap_or_default(),
+        max_fee_per_gas: tx.max_fee_per_gas,
+        max_priority_fee_per_gas: tx.max_priority_fee_per_gas,
+        // Strictly speaking a "Type 2" transaction should not need to set this, but we do because Blockscout
+        // has a database constraint that if a transaction is included in a block this can't be null.
+        gas_price: Some(
+            tx.max_fee_per_gas.unwrap_or_default()
+                + tx.max_priority_fee_per_gas.unwrap_or_default(),
+        ),
+        input: tx.data.unwrap_or_default(),
+        chain_id: tx.chain_id.map(|x| et::U256::from(x.as_u64())),
+        v: et::U64::from(sig.v),
+        r: sig.r,
+        s: sig.s,
+        transaction_type: Some(2u64.into()),
+        access_list: Some(tx.access_list),
+        other: Default::default(),
     }
 }

--- a/fendermint/eth/api/src/mpool.rs
+++ b/fendermint/eth/api/src/mpool.rs
@@ -1,0 +1,95 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+//! Utilities related to caching and buffering Ethereum transactions.
+use std::time::Duration;
+
+use ethers_core::types as et;
+use fendermint_rpc::{client::TendermintClient, FendermintClient, QueryClient};
+use fendermint_vm_message::{chain::ChainMessage, query::FvmQueryHeight, signed::DomainHash};
+use futures::StreamExt;
+use fvm_shared::chainid::ChainID;
+use tendermint::Block;
+use tendermint_rpc::{
+    event::EventData,
+    query::{EventType, Query},
+    SubscriptionClient,
+};
+
+use crate::{cache::Cache, HybridClient};
+
+const RETRY_SLEEP_SECS: u64 = 5;
+
+/// Cache submitted transactions by their Ethereum hash, because the CometBFT
+/// API would not be able to find them until they are delivered to the application
+/// and indexed by their domain hash, which some tools interpret as the transaction
+/// being dropped from the mempool.
+pub type TransactionCache = Cache<et::TxHash, et::Transaction>;
+
+pub fn start_tx_cache_clearing(client: FendermintClient<HybridClient>, cache: TransactionCache) {
+    tokio::task::spawn(async move {
+        let chain_id = get_chain_id(&client).await;
+        tx_cache_clearing_loop(client, cache, chain_id).await;
+    });
+}
+
+async fn tx_cache_clearing_loop(
+    client: FendermintClient<HybridClient>,
+    tx_cache: TransactionCache,
+    chain_id: ChainID,
+) {
+    loop {
+        let query = Query::from(EventType::NewBlock);
+
+        match client.underlying().subscribe(query).await {
+            Err(e) => {
+                tracing::warn!(error=?e, "failed to subscribe to NewBlocks; retrying later...");
+                tokio::time::sleep(Duration::from_secs(RETRY_SLEEP_SECS)).await;
+            }
+            Ok(mut subscription) => {
+                while let Some(result) = subscription.next().await {
+                    match result {
+                        Err(e) => {
+                            tracing::warn!(error=?e, "NewBlocks subscription failed; resubscribing...");
+                            break;
+                        }
+                        Ok(event) => {
+                            if let EventData::NewBlock {
+                                block: Some(block), ..
+                            } = event.data
+                            {
+                                let tx_hashes = collect_tx_hashes(&block, &chain_id);
+                                tx_cache.remove_many(&tx_hashes);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn collect_tx_hashes(block: &Block, chain_id: &ChainID) -> Vec<et::TxHash> {
+    let mut tx_hashes = Vec::new();
+    for tx in &block.data {
+        if let Ok(ChainMessage::Signed(msg)) = fvm_ipld_encoding::from_slice(tx) {
+            if let Ok(Some(DomainHash::Eth(h))) = msg.domain_hash(chain_id) {
+                tx_hashes.push(et::TxHash::from(h))
+            }
+        }
+    }
+    tx_hashes
+}
+
+async fn get_chain_id(client: &FendermintClient<HybridClient>) -> ChainID {
+    loop {
+        match client.state_params(FvmQueryHeight::default()).await {
+            Ok(sp) => {
+                return ChainID::from(sp.value.chain_id);
+            }
+            Err(e) => {
+                tracing::warn!(error=?e, "failed to get chain ID; retrying later...");
+                tokio::time::sleep(Duration::from_secs(RETRY_SLEEP_SECS)).await;
+            }
+        }
+    }
+}

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -37,6 +37,7 @@ use crate::filters::{
     FilterRecords,
 };
 use crate::handlers::ws::MethodNotification;
+use crate::mpool::TransactionCache;
 use crate::GasOpt;
 use crate::{
     conv::from_tm::{map_rpc_block_txs, to_chain_message, to_eth_block, to_eth_transaction},
@@ -53,7 +54,8 @@ pub type WebSocketSender = UnboundedSender<MethodNotification>;
 pub struct JsonRpcState<C> {
     pub client: FendermintClient<C>,
     pub addr_cache: AddressCache<C>,
-    pub tx_cache: Cache<et::TxHash, et::Transaction>,
+    /// Cache submitted transactions until they are added to a block.
+    pub tx_cache: TransactionCache,
     filter_timeout: Duration,
     filters: FilterMap,
     next_web_socket_id: AtomicUsize,

--- a/fendermint/eth/api/src/state.rs
+++ b/fendermint/eth/api/src/state.rs
@@ -30,7 +30,7 @@ use tendermint_rpc::{Order, Subscription, SubscriptionClient};
 use tokio::sync::mpsc::{Sender, UnboundedSender};
 use tokio::sync::RwLock;
 
-use crate::cache::AddressCache;
+use crate::cache::{AddressCache, Cache};
 use crate::conv::from_tm;
 use crate::filters::{
     run_subscription, BlockHash, FilterCommand, FilterDriver, FilterId, FilterKind, FilterMap,
@@ -53,6 +53,7 @@ pub type WebSocketSender = UnboundedSender<MethodNotification>;
 pub struct JsonRpcState<C> {
     pub client: FendermintClient<C>,
     pub addr_cache: AddressCache<C>,
+    pub tx_cache: Cache<et::TxHash, et::Transaction>,
     filter_timeout: Duration,
     filters: FilterMap,
     next_web_socket_id: AtomicUsize,
@@ -72,9 +73,11 @@ where
     ) -> Self {
         let client = FendermintClient::new(client);
         let addr_cache = AddressCache::new(client.clone(), cache_capacity);
+        let tx_cache = Cache::new(cache_capacity);
         Self {
             client,
             addr_cache,
+            tx_cache,
             filter_timeout,
             filters: Default::default(),
             next_web_socket_id: Default::default(),

--- a/fendermint/testing/materializer/src/materials/defaults.rs
+++ b/fendermint/testing/materializer/src/materials/defaults.rs
@@ -189,6 +189,10 @@ impl DefaultAccount {
     pub fn public_key(&self) -> &PublicKey {
         &self.public_key
     }
+
+    pub fn secret_key(&self) -> &SecretKey {
+        &self.secret_key
+    }
 }
 
 #[cfg(test)]

--- a/fendermint/testing/materializer/src/testnet.rs
+++ b/fendermint/testing/materializer/src/testnet.rs
@@ -133,9 +133,10 @@ where
     }
 
     /// Get an account by ID.
-    pub fn account(&self, id: &AccountId) -> anyhow::Result<&M::Account> {
+    pub fn account(&self, id: impl Into<AccountId>) -> anyhow::Result<&M::Account> {
+        let id: AccountId = id.into();
         self.accounts
-            .get(id)
+            .get(&id)
             .ok_or_else(|| anyhow!("account {id} does not exist"))
     }
 

--- a/fendermint/testing/materializer/tests/docker_tests/mod.rs
+++ b/fendermint/testing/materializer/tests/docker_tests/mod.rs
@@ -7,3 +7,4 @@
 // Tests using the manifest bearing their name.
 pub mod layer2;
 pub mod root_only;
+pub mod standalone;

--- a/fendermint/testing/materializer/tests/docker_tests/standalone.rs
+++ b/fendermint/testing/materializer/tests/docker_tests/standalone.rs
@@ -31,7 +31,7 @@ where
         .await
         .context("failed to get chain ID")?;
 
-    let wallet: Wallet<SigningKey> = Wallet::from_bytes(&sender.secret_key().serialize().as_ref())?
+    let wallet: Wallet<SigningKey> = Wallet::from_bytes(sender.secret_key().serialize().as_ref())?
         .with_chain_id(chain_id.as_u64());
 
     Ok(SignerMiddleware::new(provider, wallet))

--- a/fendermint/testing/materializer/tests/docker_tests/standalone.rs
+++ b/fendermint/testing/materializer/tests/docker_tests/standalone.rs
@@ -1,0 +1,94 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use anyhow::{bail, Context};
+use ethers::{
+    core::k256::ecdsa::SigningKey,
+    middleware::SignerMiddleware,
+    providers::{JsonRpcClient, Middleware, PendingTransaction, Provider},
+    signers::{Signer, Wallet},
+    types::{Eip1559TransactionRequest, H160},
+};
+use fendermint_materializer::{manifest::Rootnet, materials::DefaultAccount, HasEthApi};
+use futures::FutureExt;
+
+use crate::with_testnet;
+
+const MANIFEST: &str = "standalone.yaml";
+
+pub type TestMiddleware<C> = SignerMiddleware<Provider<C>, Wallet<SigningKey>>;
+
+/// Create a middleware that will assign nonces and sign the message.
+async fn make_middleware<C>(
+    provider: Provider<C>,
+    sender: &DefaultAccount,
+) -> anyhow::Result<TestMiddleware<C>>
+where
+    C: JsonRpcClient,
+{
+    let chain_id = provider
+        .get_chainid()
+        .await
+        .context("failed to get chain ID")?;
+
+    let wallet: Wallet<SigningKey> = Wallet::from_bytes(&sender.secret_key().serialize().as_ref())?
+        .with_chain_id(chain_id.as_u64());
+
+    Ok(SignerMiddleware::new(provider, wallet))
+}
+
+/// Test that top-down syncing and bottom-up checkpoint submission work.
+#[serial_test::serial]
+#[tokio::test]
+async fn test_sent_tx_found_in_mempool() {
+    with_testnet(
+        MANIFEST,
+        |manifest| {
+            // Slow down consensus to where we can see the effect of the transaction not being found by Ethereum hash.
+            if let Rootnet::New { ref mut env, .. } = manifest.rootnet {
+                env.insert("CMT_CONSENSUS_TIMEOUT_COMMIT".into(), "10s".into());
+            };
+        },
+        |_, _, testnet| {
+            let test = async {
+                let bob = testnet.account("bob")?;
+                let charlie = testnet.account("charlie")?;
+
+                let pangea = testnet.node(&testnet.root().node("pangea"))?;
+                let provider = pangea
+                    .ethapi_http_provider()?
+                    .expect("ethapi should be enabled");
+
+                let middleware = make_middleware(provider, bob)
+                    .await
+                    .context("failed to set up middleware")?;
+
+                // Create the simplest transaction possible: send tokens between accounts.
+                let to: H160 = charlie.eth_addr().into();
+                let transfer = Eip1559TransactionRequest::new().to(to).value(1);
+
+                let pending: PendingTransaction<_> = middleware
+                    .send_transaction(transfer, None)
+                    .await
+                    .context("failed to send txn")?;
+
+                let tx_hash = pending.tx_hash();
+
+                // We expect that the transaction is pending, however it should not return an error.
+                match middleware.get_transaction(tx_hash).await {
+                    Ok(Some(_)) => {}
+                    Ok(None) => bail!("pending transaction not found by eth hash"),
+                    Err(e) => {
+                        bail!("failed to get pending transaction: {e}")
+                    }
+                }
+
+                Ok(())
+            };
+
+            test.boxed_local()
+        },
+    )
+    .await
+    .unwrap()
+}

--- a/fendermint/testing/materializer/tests/manifests/standalone.yaml
+++ b/fendermint/testing/materializer/tests/manifests/standalone.yaml
@@ -1,0 +1,27 @@
+accounts:
+  alice: {}
+  bob: {}
+  charlie: {}
+
+rootnet:
+  type: New
+  # Balances and collateral are in atto
+  validators:
+    alice: '100'
+  balances:
+    # 100FIL is 100_000_000_000_000_000_000
+    alice: '100000000000000000000'
+    bob: '200000000000000000000'
+    charlie: '300000000000000000000'
+  env:
+    CMT_CONSENSUS_TIMEOUT_COMMIT: 1s
+    FM_LOG_LEVEL: info,fendermint=debug
+
+  nodes:
+    # A singleton node.
+    pangea:
+      mode:
+        type: Validator
+        validator: alice
+      seed_nodes: []
+      ethapi: true


### PR DESCRIPTION
The PR enhances the `ethapi` to be able to cache ~and buffer~ transactions until they are included in the blockchain, so that it can deal with ~out-of-order submissions and~ plug the gap in the API where an Ethereum transaction is submitted, but it's not found by its hash until it's executed and indexed by its _domain hash_ by CometBFT. 

- [x] Test to show that transaction isn't found by hash
- [x] Add pending transactions to a cache
- [x] Look up transactions in the cache in `eth_getTransactionByHash`
- [x] Subscribe to `NewBlock` events
- [x] Calculate the domain hash of transactions in the `NewBlock` and remove them from the cache

Deferred to future PRs:
- [ ] Look up the maximum nonce in the cache in `eth_getTransactionCount`
- [ ] Detect out-of-order submission error and put it in a buffer
- [ ] Detect transactions enabled in the buffer a newly created block
- [ ] Submit enabled transactions

### Testing

```bash
cargo test -p fendermint_materializer --test docker -- mempool --nocapture
```