### PR TITLE
CONFIG: Add setting for external addresses for the resolver

### DIFF
--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -183,6 +183,11 @@ max_provider_age = 300
 # Leaving it empty disables the IPLD Resolver.
 listen_addr = ""
 
+# A list of known external addresses this node is reachable on.
+# If left empty we rely on the `libp2p::Swarm` and the `Identity` protocol to discover it
+# automatically as it's reported back to us from peers, although this might not work sufficiently.
+external_addresses = []
+
 # Maximum number of incoming connections.
 max_incoming = 30
 

--- a/fendermint/app/config/test.toml
+++ b/fendermint/app/config/test.toml
@@ -22,3 +22,7 @@ static_addresses = [
 
 [resolver.connection]
 listen_addr = "/ip4/198.51.100.2/tcp/1234"
+external_addresses = [
+  "/ip4/198.51.100.2/tcp/1234",
+  "/dns4/my.node.com/tcp/1234",
+]

--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -285,6 +285,7 @@ impl Settings {
                     .ignore_empty(true) // otherwise "" will be parsed as a list item
                     .try_parsing(true) // required for list separator
                     .list_separator(",") // need to list keys explicitly below otherwise it can't pase simple `String` type
+                    .with_list_parse_key("resolver.connection.external_addresses")
                     .with_list_parse_key("resolver.discovery.static_addresses")
                     .with_list_parse_key("resolver.membership.static_subnets"),
             ))
@@ -374,12 +375,14 @@ mod tests {
         #[test]
         fn parse_comma_separated() {
             let settings = with_env_vars(vec![
-            ("FM_RESOLVER__DISCOVERY__STATIC_ADDRESSES", "/ip4/198.51.100.0/tcp/4242/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N,/ip6/2604:1380:2000:7a00::1/udp/4001/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb"),
-            // Set a normal string key as well to make sure we have configured the library correctly and it doesn't try to parse everything as a list.
-            ("FM_RESOLVER__NETWORK__NETWORK_NAME", "test"),
-        ], || try_parse_config("")).unwrap();
+                ("FM_RESOLVER__CONNECTION__EXTERNAL_ADDRESSES", "/ip4/198.51.100.0/tcp/4242/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N,/ip6/2604:1380:2000:7a00::1/udp/4001/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb"),
+                ("FM_RESOLVER__DISCOVERY__STATIC_ADDRESSES", "/ip4/198.51.100.1/tcp/4242/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N,/ip6/2604:1380:2000:7a00::2/udp/4001/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb"),
+                // Set a normal string key as well to make sure we have configured the library correctly and it doesn't try to parse everything as a list.
+                ("FM_RESOLVER__NETWORK__NETWORK_NAME", "test"),
+            ], || try_parse_config("")).unwrap();
 
             assert_eq!(settings.resolver.discovery.static_addresses.len(), 2);
+            assert_eq!(settings.resolver.connection.external_addresses.len(), 2);
         }
 
         #[test]
@@ -387,12 +390,14 @@ mod tests {
             let settings = with_env_vars(
                 vec![
                     ("FM_RESOLVER__DISCOVERY__STATIC_ADDRESSES", ""),
+                    ("FM_RESOLVER__CONNECTION__EXTERNAL_ADDRESSES", ""),
                     ("FM_RESOLVER__MEMBERSHIP__STATIC_SUBNETS", ""),
                 ],
                 || try_parse_config(""),
             )
             .unwrap();
 
+            assert_eq!(settings.resolver.connection.external_addresses.len(), 0);
             assert_eq!(settings.resolver.discovery.static_addresses.len(), 0);
             assert_eq!(settings.resolver.membership.static_subnets.len(), 0);
         }

--- a/fendermint/app/settings/src/resolver.rs
+++ b/fendermint/app/settings/src/resolver.rs
@@ -24,6 +24,9 @@ pub struct ResolverSettings {
     pub content: ContentSettings,
 }
 
+/// Settings describing the subnet hierarchy, not the physical network.
+///
+/// For physical network settings see [ConnectionSettings].
 #[derive(Clone, Debug, Deserialize)]
 pub struct NetworkSettings {
     /// Cryptographic key used to sign messages.
@@ -78,6 +81,8 @@ pub struct MembershipSettings {
 pub struct ConnectionSettings {
     /// The address where we will listen to incoming connections.
     pub listen_addr: Multiaddr,
+    /// A list of known external addresses this node is reachable on.
+    pub external_addresses: Vec<Multiaddr>,
     /// Maximum number of incoming connections.
     pub max_incoming: u32,
     /// Expected number of peers, for sizing the Bloom filter.

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -419,6 +419,7 @@ fn to_resolver_config(settings: &Settings) -> anyhow::Result<ipc_ipld_resolver::
     let config = Config {
         connection: ConnectionConfig {
             listen_addr: r.connection.listen_addr.clone(),
+            external_addresses: r.connection.external_addresses.clone(),
             expected_peer_count: r.connection.expected_peer_count,
             max_incoming: r.connection.max_incoming,
             max_peers_per_query: r.connection.max_peers_per_query,

--- a/ipld/resolver/src/service.rs
+++ b/ipld/resolver/src/service.rs
@@ -64,6 +64,8 @@ pub struct NoKnownPeers(SubnetID);
 pub struct ConnectionConfig {
     /// The address where we will listen to incoming connections.
     pub listen_addr: Multiaddr,
+    /// A list of known external addresses this node is reachable on.
+    pub external_addresses: Vec<Multiaddr>,
     /// Maximum number of incoming connections.
     pub max_incoming: u32,
     /// Expected number of peers, for sizing the Bloom filter.
@@ -181,12 +183,16 @@ where
         //.connection_event_buffer_size(64)
         //.build();
 
-        let swarm = Swarm::new(
+        let mut swarm = Swarm::new(
             transport,
             behaviour,
             peer_id,
             libp2p::swarm::Config::with_tokio_executor(),
         );
+
+        for addr in config.connection.external_addresses {
+            swarm.add_external_address(addr)
+        }
 
         let (request_tx, request_rx) = mpsc::unbounded_channel();
         let (event_tx, _) = broadcast::channel(config.connection.event_buffer_capacity as usize);

--- a/ipld/resolver/tests/smoke.rs
+++ b/ipld/resolver/tests/smoke.rs
@@ -318,6 +318,7 @@ fn make_config(rng: &mut StdRng, cluster_size: u32, bootstrap_addr: Option<Multi
     let config = Config {
         connection: ConnectionConfig {
             listen_addr: Multiaddr::from(Protocol::Memory(rng.gen::<u64>())),
+            external_addresses: vec![],
             expected_peer_count: cluster_size,
             max_incoming: cluster_size,
             max_peers_per_query: cluster_size,


### PR DESCRIPTION
I was under the impression that the `libp2p::Swarm` somehow gets the external [address reported](https://github.com/libp2p/rust-libp2p/blob/1a9cf4f7760724032b729c43165716c7ecd842ad/swarm/src/lib.rs#L1193) to it and it passes it on [to Kademlia](https://github.com/libp2p/rust-libp2p/blob/695404d56bf51cd86d983e3c699d71bdbd9e87d1/protocols/kad/src/behaviour.rs#L2621) but it doesn't seem to work with more involved network setups. 

This PR adds a `FM_RESOLVER__CONNECTION__EXTERNAL_ADDRESSES` setting which accepts a list of `Multiaddr` types.