### PR TITLE
fundToken Inflation / Deflation / Tax on transfer Fix

### DIFF
--- a/contracts/src/gateway/GatewayManagerFacet.sol
+++ b/contracts/src/gateway/GatewayManagerFacet.sol
@@ -170,8 +170,9 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
         SupplySource memory supplySource = SubnetActorGetterFacet(subnetId.getActor()).supplySource();
         supplySource.expect(SupplyKind.ERC20);
 
-        // Lock the specified amount into custody.
-        // Account for tokens with Transfer Fees
+        // Locks a specified amount into custody, adjusting for tokens with transfer fees. This operation
+        // accommodates inflationary tokens, potentially reflecting a higher effective locked amount.
+        // Operation reverts if the effective transferred amount is zero.
         uint256 transferAmount = supplySource.lock({value: amount});
 
         // Create the top-down message to mint the supply in the subnet.

--- a/contracts/src/gateway/GatewayManagerFacet.sol
+++ b/contracts/src/gateway/GatewayManagerFacet.sol
@@ -171,14 +171,15 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
         supplySource.expect(SupplyKind.ERC20);
 
         // Lock the specified amount into custody.
-        supplySource.lock({value: amount});
+        // Account for tokens with Transfer Fees
+        uint256 transferAmount = supplySource.lock({value: amount});
 
         // Create the top-down message to mint the supply in the subnet.
         IpcEnvelope memory crossMsg = CrossMsgHelper.createFundMsg({
             subnet: subnetId,
             signer: msg.sender,
             to: to,
-            value: amount
+            value: transferAmount
         });
 
         // Commit top-down message.

--- a/contracts/src/lib/SupplySourceHelper.sol
+++ b/contracts/src/lib/SupplySourceHelper.sol
@@ -46,7 +46,9 @@ library SupplySourceHelper {
         }
     }
 
-    /// @notice Locks the specified amount sent by the msg.sender into custody.
+    /// @notice Locks the specified amount from msg.sender into custody.
+    ///         Reverts with NoBalanceIncrease if the token balance does not increase.
+    ///         May return more than requested for inflationary tokens due to balance rise.
     function lock(SupplySource memory supplySource, uint256 value) internal returns (uint256) {
         if (supplySource.kind == SupplyKind.ERC20) {
             IERC20 token = IERC20(supplySource.tokenAddress);

--- a/contracts/src/lib/SupplySourceHelper.sol
+++ b/contracts/src/lib/SupplySourceHelper.sol
@@ -56,6 +56,7 @@ library SupplySourceHelper {
             if (finalBalance <= initialBalance) {
                 revert NoBalanceIncrease();
             }
+            // Safe arithmetic is not necessary because underflow is not possible due to the check above
             return finalBalance - initialBalance;
         }
         // Do nothing for native.

--- a/contracts/src/lib/SupplySourceHelper.sol
+++ b/contracts/src/lib/SupplySourceHelper.sol
@@ -53,7 +53,7 @@ library SupplySourceHelper {
             uint256 initialBalance = token.balanceOf(address(this));
             token.safeTransferFrom({from: msg.sender, to: address(this), value: value});
             uint256 finalBalance = token.balanceOf(address(this));
-            if (!(finalBalance > initialBalance)) {
+            if (finalBalance <= initialBalance) {
                 revert NoBalanceIncrease();
             }
             return finalBalance - initialBalance;

--- a/contracts/test/IntegrationTestBase.sol
+++ b/contracts/test/IntegrationTestBase.sol
@@ -901,6 +901,12 @@ contract IntegrationTestBase is Test, TestParams, TestRegistry, TestSubnetActor,
         registerSubnetGW(collateral, subnetAddress, gatewayDiamond);
     }
 
+    function getSubnetCircSupplyGW(SubnetID memory subnetId, GatewayDiamond gw) public view returns (uint256) {
+        GatewayGetterFacet getter = gw.getter();
+        Subnet memory subnet = getter.subnets(subnetId.toHash());
+        return subnet.circSupply;
+    }
+
     function getSubnetGW(
         address subnetAddress,
         GatewayDiamond gw

--- a/contracts/test/helpers/ERC20Deflationary.sol
+++ b/contracts/test/helpers/ERC20Deflationary.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract ERC20Deflationary is ERC20, Ownable {
+    uint256 public deflationRatePercentage;
+
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint256 initialSupply,
+        address owner,
+        uint256 deflationRate_
+    ) ERC20(name_, symbol_) Ownable(owner) {
+        require(deflationRate_ <= 100, "Deflation rate must be between 0 and 100.");
+        deflationRatePercentage = deflationRate_;
+        _mint(owner, initialSupply);
+    }
+
+    function setDeflationRate(uint256 newRate) public onlyOwner {
+        require(newRate <= 100, "Deflation rate must be between 0 and 100.");
+        deflationRatePercentage = newRate;
+    }
+
+    function _update(address from, address to, uint256 value) internal virtual override {
+        if (from != address(0) && to != address(0)) {
+            uint256 burnAmount = (value * deflationRatePercentage) / 100;
+            uint256 transferAmount = value - burnAmount;
+
+            super._update(from, to, transferAmount); // Perform the standard transfer with the reduced amount.
+
+            if (burnAmount > 0) {
+                _burn(from, burnAmount); // Burn the deflation amount from the sender.
+            }
+        } else {
+            super._update(from, to, value);
+        }
+    }
+}

--- a/contracts/test/helpers/ERC20Inflationary.sol
+++ b/contracts/test/helpers/ERC20Inflationary.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract ERC20Inflationary is ERC20, Ownable {
+    uint256 public inflationRatePercentage;
+
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint256 initialSupply,
+        address owner,
+        uint256 inflationRate_
+    ) ERC20(name_, symbol_) Ownable(owner) {
+        require(inflationRate_ <= 100, "Inflation rate must be between 0 and 100.");
+        inflationRatePercentage = inflationRate_;
+        _mint(owner, initialSupply);
+    }
+
+    function setInflationRate(uint256 newRate) public onlyOwner {
+        require(newRate <= 100, "Inflation rate must be between 0 and 100.");
+        inflationRatePercentage = newRate;
+    }
+
+    function _update(address from, address to, uint256 value) internal virtual override {
+        if (from != address(0) && to != address(0)) {
+            super._update(from, to, value); // Perform the standard transfer first.
+
+            uint256 inflationAmount = (value * inflationRatePercentage) / 100;
+            _mint(to, inflationAmount); // Mint the inflation to the recipient.
+        } else {
+            super._update(from, to, value);
+        }
+    }
+}

--- a/contracts/test/helpers/ERC20Nil.sol
+++ b/contracts/test/helpers/ERC20Nil.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract ERC20Nil is ERC20, Ownable {
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint256 initialSupply,
+        address owner
+    ) ERC20(name_, symbol_) Ownable(owner) {
+        _mint(owner, initialSupply);
+    }
+
+    function _update(address from, address to, uint256 value) internal virtual override {
+        if (from != address(0) && to != address(0)) {
+            //do nothing "NIL"
+        } else {
+            super._update(from, to, value);
+        }
+    }
+}

--- a/contracts/test/integration/MultiSubnet.t.sol
+++ b/contracts/test/integration/MultiSubnet.t.sol
@@ -337,9 +337,11 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
     function testMultiSubnet_DeflationaryErc20_ReleaseFromChildToParent() public {
         address caller = address(new MockIpcContract());
         address recipient = address(new MockIpcContractPayable());
-        uint256 amount = 4098;
+        uint256 amount = 4096;
 
         deflationaryToken.transfer(caller, amount);
+        assertEq(deflationaryToken.balanceOf(caller), amount / 2);
+
         vm.prank(caller);
         deflationaryToken.approve(rootSubnet.gatewayAddr, amount);
 
@@ -364,6 +366,10 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
             amount / 2
         );
 
+        assertEq(deflationaryToken.balanceOf(caller), 0);
+        assertEq(deflationaryToken.balanceOf(rootSubnet.gatewayAddr), amount / 4);
+        assertEq(getSubnetCircSupplyGW(deflationaryTokenSubnet.id, rootSubnet.gateway), amount / 4);
+
         GatewayManagerFacet manager = deflationaryTokenSubnet.gateway.manager();
         uint256 releaseAmount = amount / 2 / 2;
 
@@ -378,12 +384,14 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
         submitBottomUpCheckpoint(checkpoint, deflationaryTokenSubnet.subnetActor);
 
         assertEq(deflationaryToken.balanceOf(recipient), releaseAmount / 2);
+        assertEq(deflationaryToken.balanceOf(rootSubnet.gatewayAddr), 0);
+        assertEq(getSubnetCircSupplyGW(deflationaryTokenSubnet.id, rootSubnet.gateway), 0);
     }
 
     function testMultiSubnet_InflationaryErc20_ReleaseFromChildToParent() public {
         address caller = address(new MockIpcContract());
         address recipient = address(new MockIpcContractPayable());
-        uint256 amount = 4098;
+        uint256 amount = 4096;
 
         inflationaryToken.transfer(caller, amount);
         vm.prank(caller);
@@ -402,6 +410,10 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
             amount * 2
         );
 
+        assertEq(inflationaryToken.balanceOf(caller), 0);
+        assertEq(inflationaryToken.balanceOf(rootSubnet.gatewayAddr), amount * 4);
+        assertEq(getSubnetCircSupplyGW(inflationaryTokenSubnet.id, rootSubnet.gateway), amount * 4);
+
         GatewayManagerFacet manager = inflationaryTokenSubnet.gateway.manager();
         uint256 releaseAmount = amount * 2 * 2;
 
@@ -416,12 +428,14 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
         submitBottomUpCheckpoint(checkpoint, inflationaryTokenSubnet.subnetActor);
 
         assertEq(inflationaryToken.balanceOf(recipient), releaseAmount * 2);
+        assertEq(inflationaryToken.balanceOf(rootSubnet.gatewayAddr), 0);
+        assertEq(getSubnetCircSupplyGW(inflationaryTokenSubnet.id, rootSubnet.gateway), 0);
     }
 
     function testMultiSubnet_NilErc20_ReleaseFromChildToParent() public {
         address caller = address(new MockIpcContract());
         address recipient = address(new MockIpcContractPayable());
-        uint256 amount = 4098;
+        uint256 amount = 4096;
 
         nilToken.transfer(caller, amount);
         vm.prank(caller);

--- a/contracts/test/integration/MultiSubnet.t.sol
+++ b/contracts/test/integration/MultiSubnet.t.sol
@@ -450,6 +450,7 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
         vm.prank(caller);
         vm.expectRevert(SupplySourceHelper.NoBalanceIncrease.selector);
         rootSubnet.gateway.manager().fundWithToken(nilTokenSubnet.id, FvmAddressHelper.from(address(caller)), amount);
+        assertEq(getSubnetCircSupplyGW(nilTokenSubnet.id, rootSubnet.gateway), 0);
     }
 
     function testMultiSubnet_Erc20_ReleaseResultOkFromParentToChild() public {


### PR DESCRIPTION
closes ENG-713

- [x] In `SupplySourceHelper#lock`, take a reading of our token balance before calling safeTransferFrom. Take another reading after. 
- [x] Calculate the difference between before and after, and return it.
- [x] Use that in GatewayManagerFacet#fundWithToken as the value to mint in the subnet.
- [x] In the gateway, make sure to run a 0 check, as the effectively transferred amount may be 0. In this case, ~skip sending the top down message.~ revert 

NOTE the suggested behavior on the previous item was to skip the top down message, but instead this PR executes a revert. This seemed to be the more appropriate behavior from my perspective on best practices. LMK if i am missing something and will remove the revert and skip the top down message in the gateway

- [x] IMPORTANT: Make sure to use safe arithmetic operations, as an underflow here would be fatal!

See [this thread](https://filecoinproject.slack.com/archives/C065VJDDSJH/p1711370060434969) for a doubt I am checking with Zokyo.

Add tests for these scenarios:

- [x] transfer is inflationary
- [x] transfer is deflationary
- [x] transfer has nil effect (effectively transferred value is 0)