### PR TITLE
Expose max_cache_block parameter for parent syncing

### DIFF
--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -130,6 +130,8 @@ pub struct TopDownSettings {
     pub proposal_delay: BlockHeight,
     /// The max number of blocks one should make the topdown proposal
     pub max_proposal_range: BlockHeight,
+    /// The max number of blocks to hold in memory for parent syncer
+    pub max_cache_blocks: Option<BlockHeight>,
     /// Parent syncing cron period, in seconds
     #[serde_as(as = "DurationSeconds<u64>")]
     pub polling_interval: Duration,

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -225,8 +225,8 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
             topdown_config.exponential_back_off,
             topdown_config.exponential_retry_limit,
         )
-            .with_proposal_delay(topdown_config.proposal_delay)
-            .with_max_proposal_range(topdown_config.max_proposal_range);
+        .with_proposal_delay(topdown_config.proposal_delay)
+        .with_max_proposal_range(topdown_config.max_proposal_range);
 
         if let Some(v) = topdown_config.max_cache_blocks {
             info!(value = v, "setting max cache blocks");

--- a/fendermint/vm/topdown/src/finality/null.rs
+++ b/fendermint/vm/topdown/src/finality/null.rs
@@ -334,13 +334,21 @@ impl FinalityWithNull {
 
         if let Some(latest_height) = self.latest_height_in_cache()? {
             let r = latest_height >= proposal.height;
-            tracing::debug!(is_true = r, "incoming proposal height seen?");
+            tracing::debug!(
+                is_true = r,
+                latest_height,
+                proposal = proposal.height.to_string(),
+                "incoming proposal height seen?"
+            );
             // requires the incoming height cannot be more advanced than our trusted parent node
             Ok(r)
         } else {
             // latest height is not found, meaning we dont have any prefetched cache, we just be
             // strict and vote no simply because we don't know.
-            tracing::debug!("reject proposal, no data in cache");
+            tracing::debug!(
+                proposal = proposal.height.to_string(),
+                "reject proposal, no data in cache"
+            );
             Ok(false)
         }
     }

--- a/fendermint/vm/topdown/src/lib.rs
+++ b/fendermint/vm/topdown/src/lib.rs
@@ -85,6 +85,11 @@ impl Config {
         self
     }
 
+    pub fn with_max_cache_blocks(mut self, max_cache_blocks: BlockHeight) -> Self {
+        self.max_cache_blocks = Some(max_cache_blocks);
+        self
+    }
+
     pub fn max_proposal_range(&self) -> BlockHeight {
         self.max_proposal_range
             .unwrap_or(DEFAULT_MAX_PROPOSAL_RANGE)


### PR DESCRIPTION
Expose max_cache_block in fendermint so that one can set this paremter. Also adding a few extra parameters in logging proposals.