### PR TITLE
Launching abci server only when parent syncer has loaded enough blocks in cache

### DIFF
--- a/fendermint/vm/topdown/src/sync/tendermint.rs
+++ b/fendermint/vm/topdown/src/sync/tendermint.rs
@@ -5,6 +5,7 @@
 use crate::proxy::ParentQueryProxy;
 use crate::sync::syncer::LotusParentSyncer;
 use crate::sync::ParentFinalityStateQuery;
+use crate::BlockHeight;
 use anyhow::Context;
 
 /// Tendermint aware syncer
@@ -24,6 +25,10 @@ where
             inner,
             tendermint_client,
         }
+    }
+
+    pub async fn init(&mut self, cached_blocks: BlockHeight) -> anyhow::Result<()> {
+        self.inner.init(cached_blocks).await
     }
 
     /// Sync with the parent, unless CometBFT is still catching up with the network,


### PR DESCRIPTION
For some special cases, there might be a race condition for proposal processing and parent syncer data ingestion. 

One such scenario would be cometbft WAL replay. If somehow fendermint and cometbft crashes,  when restart, cometbft might replay the voting proposals with parent finality height. At this moment, fendermint has no time to sync with the parent node and proposals will be rejected. This PRs enforces that during initialization, only when the parent syncer has synced `max_proposal_range` number of blocks, should abci be available.

Closes ENG-841.