### PR TITLE
fix(ci): docker-compose is deprecated; switch to docker compose.

### DIFF
--- a/fendermint/testing/graph-test/Makefile.toml
+++ b/fendermint/testing/graph-test/Makefile.toml
@@ -95,7 +95,7 @@ script = """
 set -x
 cd ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/fendermint/testing/graph-test/test-data/subgraph/graph-node
 echo "Tearing down subgraph..."
-docker-compose down -v
+docker compose down -v
 cd ..
 rm -rf node_modules
 rm -rf config abis generated

--- a/fendermint/testing/graph-test/subgraph/package.json
+++ b/fendermint/testing/graph-test/subgraph/package.json
@@ -9,8 +9,8 @@
     "remove-local": "npx @graphprotocol/graph-cli remove --node http://localhost:8020/ Greeter",
     "deploy-local": "npx @graphprotocol/graph-cli deploy --node http://localhost:8020/ -l v0.0.1 --ipfs http://localhost:5001 Greeter",
     "test": "npx @graphprotocol/graph-cli test",
-    "graph-node": "docker-compose --file ./graph-node/docker-compose.yaml up -d",
-    "graph-local-clean": "docker-compose down -v && docker-compose rm -v && rm -rf data/ipfs data/postgres"
+    "graph-node": "docker compose --file ./graph-node/docker-compose.yaml up -d",
+    "graph-local-clean": "docker compose down -v && docker-compose rm -v && rm -rf data/ipfs data/postgres"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.45.2",


### PR DESCRIPTION
Our build has started failing due to this deprecated use of `docker-compose`. Probably some builder image changed to exclude `docker-compose`.