### PR TITLE
ENG-842: Export topdown events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5060,7 +5060,6 @@ dependencies = [
  "ipc-types",
  "ipc-wallet",
  "ipc_actors_abis",
- "log",
  "num-derive 0.3.3",
  "num-traits",
  "reqwest",
@@ -5075,6 +5074,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.18.0",
  "toml 0.8.10",
+ "tracing",
  "url",
  "zeroize",
 ]

--- a/fendermint/app/options/src/debug.rs
+++ b/fendermint/app/options/src/debug.rs
@@ -1,0 +1,67 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::path::PathBuf;
+
+use crate::parse::parse_eth_address;
+use clap::{Args, Subcommand};
+use fvm_shared::address::Address;
+use ipc_api::subnet_id::SubnetID;
+
+#[derive(Args, Debug)]
+pub struct DebugArgs {
+    #[command(subcommand)]
+    pub command: DebugCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum DebugCommands {
+    /// IPC commands.
+    Ipc {
+        #[command(subcommand)]
+        command: DebugIpcCommands,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum DebugIpcCommands {
+    /// Fetch topdown events from the parent and export them to JSON.
+    ///
+    /// This can be used to construct an upgrade to impute missing events.
+    ExportTopDownEvents(Box<DebugExportTopDownEventsArgs>),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct DebugExportTopDownEventsArgs {
+    /// Child subnet for with the events will be fetched
+    #[arg(long, short)]
+    pub subnet_id: SubnetID,
+
+    /// Endpoint to the RPC of the child subnet's parent
+    #[arg(long, short)]
+    pub parent_endpoint: url::Url,
+
+    /// HTTP basic authentication token.
+    #[arg(long)]
+    pub parent_auth_token: Option<String>,
+
+    /// IPC gateway of the parent; 20 byte Ethereum address in 0x prefixed hex format
+    #[arg(long, value_parser = parse_eth_address, default_value = "0xff00000000000000000000000000000000000064")]
+    pub parent_gateway: Address,
+
+    /// IPC registry of the parent; 20 byte Ethereum address in 0x prefixed hex format
+    #[arg(long, value_parser = parse_eth_address, default_value = "0xff00000000000000000000000000000000000065")]
+    pub parent_registry: Address,
+
+    /// The first block to query for events.
+    #[arg(long)]
+    pub start_block_height: u64,
+
+    /// The last block to query for events.
+    #[arg(long)]
+    pub end_block_height: u64,
+
+    /// Location of the JSON file to write events to.
+    #[arg(long)]
+    pub events_file: PathBuf,
+}

--- a/fendermint/app/options/src/debug.rs
+++ b/fendermint/app/options/src/debug.rs
@@ -46,11 +46,11 @@ pub struct DebugExportTopDownEventsArgs {
     pub parent_auth_token: Option<String>,
 
     /// IPC gateway of the parent; 20 byte Ethereum address in 0x prefixed hex format
-    #[arg(long, value_parser = parse_eth_address, default_value = "0xff00000000000000000000000000000000000064")]
+    #[arg(long, value_parser = parse_eth_address)]
     pub parent_gateway: Address,
 
     /// IPC registry of the parent; 20 byte Ethereum address in 0x prefixed hex format
-    #[arg(long, value_parser = parse_eth_address, default_value = "0xff00000000000000000000000000000000000065")]
+    #[arg(long, value_parser = parse_eth_address)]
     pub parent_registry: Address,
 
     /// The first block to query for events.

--- a/fendermint/app/options/src/genesis.rs
+++ b/fendermint/app/options/src/genesis.rs
@@ -147,10 +147,6 @@ pub enum GenesisIpcCommands {
     Gateway(GenesisIpcGatewayArgs),
     /// Fetch the genesis parameters of a subnet from the parent.
     FromParent(Box<GenesisFromParentArgs>),
-    /// Fetch topdown events from the parent and export them to JSON.
-    ///
-    /// This can be used to construct an upgrade to impute missing events.
-    ExportTopDownEvents(Box<GenesisExportTopDownEventsArgs>),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -208,39 +204,4 @@ pub struct GenesisFromParentArgs {
     /// Number of decimals to use during converting FIL to Power.
     #[arg(long, default_value = "3")]
     pub power_scale: i8,
-}
-
-#[derive(Args, Debug, Clone)]
-pub struct GenesisExportTopDownEventsArgs {
-    /// Child subnet for with the events will be fetched
-    #[arg(long, short)]
-    pub subnet_id: SubnetID,
-
-    /// Endpoint to the RPC of the child subnet's parent
-    #[arg(long, short)]
-    pub parent_endpoint: url::Url,
-
-    /// HTTP basic authentication token.
-    #[arg(long)]
-    pub parent_auth_token: Option<String>,
-
-    /// IPC gateway of the parent; 20 byte Ethereum address in 0x prefixed hex format
-    #[arg(long, value_parser = parse_eth_address, default_value = "0xff00000000000000000000000000000000000064")]
-    pub parent_gateway: Address,
-
-    /// IPC registry of the parent; 20 byte Ethereum address in 0x prefixed hex format
-    #[arg(long, value_parser = parse_eth_address, default_value = "0xff00000000000000000000000000000000000065")]
-    pub parent_registry: Address,
-
-    /// The first block to query for events.
-    #[arg(long)]
-    pub start_block_height: u64,
-
-    /// The last block to query for events.
-    #[arg(long)]
-    pub end_block_height: u64,
-
-    /// Location of the JSON file to write events to.
-    #[arg(long)]
-    pub events_file: PathBuf,
 }

--- a/fendermint/app/options/src/genesis.rs
+++ b/fendermint/app/options/src/genesis.rs
@@ -145,7 +145,12 @@ pub struct GenesisIntoTendermintArgs {
 pub enum GenesisIpcCommands {
     /// Set all gateway parameters.
     Gateway(GenesisIpcGatewayArgs),
+    /// Fetch the genesis parameters of a subnet from the parent.
     FromParent(Box<GenesisFromParentArgs>),
+    /// Fetch topdown events from the parent and export them to JSON.
+    ///
+    /// This can be used to construct an upgrade to impute missing events.
+    ExportTopDownEvents(Box<GenesisExportTopDownEventsArgs>),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -180,11 +185,15 @@ pub struct GenesisFromParentArgs {
     #[arg(long, short)]
     pub parent_endpoint: url::Url,
 
+    /// HTTP basic authentication token.
+    #[arg(long)]
+    pub parent_auth_token: Option<String>,
+
     /// IPC gateway of the parent; 20 byte Ethereum address in 0x prefixed hex format
     #[arg(long, value_parser = parse_eth_address, default_value = "0xff00000000000000000000000000000000000064")]
     pub parent_gateway: Address,
 
-    /// IPC registry of the parent;  20 byte Ethereum address in 0x prefixed hex format
+    /// IPC registry of the parent; 20 byte Ethereum address in 0x prefixed hex format
     #[arg(long, value_parser = parse_eth_address, default_value = "0xff00000000000000000000000000000000000065")]
     pub parent_registry: Address,
 
@@ -199,4 +208,39 @@ pub struct GenesisFromParentArgs {
     /// Number of decimals to use during converting FIL to Power.
     #[arg(long, default_value = "3")]
     pub power_scale: i8,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct GenesisExportTopDownEventsArgs {
+    /// Child subnet for with the events will be fetched
+    #[arg(long, short)]
+    pub subnet_id: SubnetID,
+
+    /// Endpoint to the RPC of the child subnet's parent
+    #[arg(long, short)]
+    pub parent_endpoint: url::Url,
+
+    /// HTTP basic authentication token.
+    #[arg(long)]
+    pub parent_auth_token: Option<String>,
+
+    /// IPC gateway of the parent; 20 byte Ethereum address in 0x prefixed hex format
+    #[arg(long, value_parser = parse_eth_address, default_value = "0xff00000000000000000000000000000000000064")]
+    pub parent_gateway: Address,
+
+    /// IPC registry of the parent; 20 byte Ethereum address in 0x prefixed hex format
+    #[arg(long, value_parser = parse_eth_address, default_value = "0xff00000000000000000000000000000000000065")]
+    pub parent_registry: Address,
+
+    /// The first block to query for events.
+    #[arg(long)]
+    pub start_block_height: u64,
+
+    /// The last block to query for events.
+    #[arg(long)]
+    pub end_block_height: u64,
+
+    /// Location of the JSON file to write events to.
+    #[arg(long)]
+    pub events_file: PathBuf,
 }

--- a/fendermint/app/options/src/lib.rs
+++ b/fendermint/app/options/src/lib.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
 use config::ConfigArgs;
+use debug::DebugArgs;
 use fvm_shared::address::Network;
 use lazy_static::lazy_static;
 use tracing_subscriber::EnvFilter;
@@ -15,6 +16,7 @@ use self::{
 };
 
 pub mod config;
+pub mod debug;
 pub mod eth;
 pub mod genesis;
 pub mod key;
@@ -181,6 +183,8 @@ impl Options {
 pub enum Commands {
     /// Parse the configuration file and print it to the console.
     Config(ConfigArgs),
+    /// Arbitrary commands that aid in debugging.
+    Debug(DebugArgs),
     /// Run the `App`, listening to ABCI requests from Tendermint.
     Run(RunArgs),
     /// Subcommands related to the construction of signing keys.

--- a/fendermint/app/src/cmd/debug.rs
+++ b/fendermint/app/src/cmd/debug.rs
@@ -1,0 +1,68 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use anyhow::{anyhow, Context};
+use fendermint_app_options::debug::{
+    DebugArgs, DebugCommands, DebugExportTopDownEventsArgs, DebugIpcCommands,
+};
+use fendermint_vm_topdown::proxy::IPCProviderProxy;
+use ipc_provider::{
+    config::subnet::{EVMSubnet, SubnetConfig},
+    IpcProvider,
+};
+
+use crate::cmd;
+
+cmd! {
+  DebugArgs(self) {
+    match &self.command {
+        DebugCommands::Ipc { command } => command.exec(()).await,
+    }
+  }
+}
+
+cmd! {
+  DebugIpcCommands(self) {
+    match self {
+        DebugIpcCommands::ExportTopDownEvents(args) =>
+            export_topdown_events(args).await
+    }
+  }
+}
+
+async fn export_topdown_events(args: &DebugExportTopDownEventsArgs) -> anyhow::Result<()> {
+    // Configuration for the child subnet on the parent network,
+    // based on how it's done in `run.rs` and the `genesis ipc from-parent` command.
+    let parent_provider = IpcProvider::new_with_subnet(
+        None,
+        ipc_provider::config::Subnet {
+            id: args
+                .subnet_id
+                .parent()
+                .ok_or_else(|| anyhow!("subnet is not a child"))?,
+            config: SubnetConfig::Fevm(EVMSubnet {
+                provider_http: args.parent_endpoint.clone(),
+                provider_timeout: None,
+                auth_token: args.parent_auth_token.clone(),
+                registry_addr: args.parent_registry,
+                gateway_addr: args.parent_gateway,
+            }),
+        },
+    )?;
+
+    let parent_proxy = IPCProviderProxy::new(parent_provider, args.subnet_id.clone())
+        .context("failed to create provider proxy")?;
+
+    let events = fendermint_vm_topdown::sync::fetch_topdown_events(
+        &parent_proxy,
+        args.start_block_height,
+        args.end_block_height,
+    )
+    .await
+    .context("failed to fetch topdown events")?;
+
+    let json = serde_json::to_string_pretty(&events)?;
+    std::fs::write(&args.events_file, json)?;
+
+    Ok(())
+}

--- a/fendermint/app/src/cmd/genesis.rs
+++ b/fendermint/app/src/cmd/genesis.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{anyhow, Context};
 use fendermint_crypto::PublicKey;
-use fendermint_vm_topdown::proxy::IPCProviderProxy;
 use fvm_shared::address::Address;
 use ipc_provider::config::subnet::{EVMSubnet, SubnetConfig};
 use ipc_provider::IpcProvider;
@@ -94,8 +93,6 @@ cmd! {
             set_ipc_gateway(&genesis_file, args),
         GenesisIpcCommands::FromParent(args) =>
             new_genesis_from_parent(&genesis_file, args).await,
-        GenesisIpcCommands::ExportTopDownEvents(args) =>
-            export_topdown_events(args).await
     }
   }
 }
@@ -352,43 +349,6 @@ async fn new_genesis_from_parent(
 
     let json = serde_json::to_string_pretty(&genesis)?;
     std::fs::write(genesis_file, json)?;
-
-    Ok(())
-}
-
-async fn export_topdown_events(args: &GenesisExportTopDownEventsArgs) -> anyhow::Result<()> {
-    // Configuration for the child subnet on the parent network,
-    // based on how it's done in `run.rs` and above.
-    let parent_provider = IpcProvider::new_with_subnet(
-        None,
-        ipc_provider::config::Subnet {
-            id: args
-                .subnet_id
-                .parent()
-                .ok_or_else(|| anyhow!("subnet is not a child"))?,
-            config: SubnetConfig::Fevm(EVMSubnet {
-                provider_http: args.parent_endpoint.clone(),
-                provider_timeout: None,
-                auth_token: args.parent_auth_token.clone(),
-                registry_addr: args.parent_registry,
-                gateway_addr: args.parent_gateway,
-            }),
-        },
-    )?;
-
-    let parent_proxy = IPCProviderProxy::new(parent_provider, args.subnet_id.clone())
-        .context("failed to create provider proxy")?;
-
-    let events = fendermint_vm_topdown::sync::fetch_topdown_events(
-        &parent_proxy,
-        args.start_block_height,
-        args.end_block_height,
-    )
-    .await
-    .context("failed to fetch topdown events")?;
-
-    let json = serde_json::to_string_pretty(&events)?;
-    std::fs::write(&args.events_file, json)?;
 
     Ok(())
 }

--- a/fendermint/app/src/cmd/mod.rs
+++ b/fendermint/app/src/cmd/mod.rs
@@ -11,6 +11,7 @@ use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 
 pub mod config;
+pub mod debug;
 pub mod eth;
 pub mod genesis;
 pub mod key;
@@ -62,6 +63,7 @@ macro_rules! cmd {
 pub async fn exec(opts: &Options) -> anyhow::Result<()> {
     match &opts.command {
         Commands::Config(args) => args.exec(settings(opts)?).await,
+        Commands::Debug(args) => args.exec(()).await,
         Commands::Run(args) => args.exec(settings(opts)?).await,
         Commands::Key(args) => args.exec(()).await,
         Commands::Genesis(args) => args.exec(()).await,

--- a/fendermint/vm/topdown/src/sync/mod.rs
+++ b/fendermint/vm/topdown/src/sync/mod.rs
@@ -19,6 +19,8 @@ use std::time::Duration;
 
 use fendermint_vm_genesis::{Power, Validator};
 
+pub use syncer::fetch_topdown_events;
+
 /// Query the parent finality from the block chain state.
 ///
 /// It returns `None` from queries until the ledger has been initialized.

--- a/ipc/api/src/staking.rs
+++ b/ipc/api/src/staking.rs
@@ -8,11 +8,12 @@ use ethers::utils::hex;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use ipc_actors_abis::{lib_staking_change_log, subnet_actor_getter_facet};
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
 pub type ConfigurationNumber = u64;
 
-#[derive(Clone, Debug, num_enum::TryFromPrimitive)]
+#[derive(Clone, Debug, num_enum::TryFromPrimitive, Deserialize, Serialize)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum StakingOperation {
@@ -22,14 +23,14 @@ pub enum StakingOperation {
     SetFederatedPower = 3,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StakingChangeRequest {
     pub configuration_number: ConfigurationNumber,
     pub change: StakingChange,
 }
 
 /// The change request to validator staking
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StakingChange {
     pub op: StakingOperation,
     pub payload: Vec<u8>,

--- a/ipc/provider/Cargo.toml
+++ b/ipc/provider/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true }
 
-log = { workspace = true }
+tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 cid = { workspace = true }

--- a/ipc/provider/src/jsonrpc/mod.rs
+++ b/ipc/provider/src/jsonrpc/mod.rs
@@ -78,11 +78,11 @@ impl JsonRpcClient for JsonRpcClientImpl {
         let response = builder.send().await?;
 
         let response_body = response.text().await?;
-        log::debug!("received raw response body: {:?}", response_body);
+        tracing::debug!("received raw response body: {:?}", response_body);
 
         let value =
             serde_json::from_str::<JsonRpcResponse<T>>(response_body.as_ref()).map_err(|e| {
-                log::error!("cannot parse json rpc client response: {:?}", response_body);
+                tracing::error!("cannot parse json rpc client response: {:?}", response_body);
                 anyhow!(
                     "cannot parse json rpc response: {:} due to {:}",
                     response_body,
@@ -157,18 +157,18 @@ async fn handle_stream(
     loop {
         match ws_stream.next().await {
             None => {
-                log::trace!("No message in websocket stream. The stream was closed.");
+                tracing::trace!("No message in websocket stream. The stream was closed.");
                 break;
             }
             Some(result) => match result {
                 Ok(msg) => {
                     println!("{}", msg);
-                    log::trace!("Read message from websocket stream: {}", msg);
+                    tracing::trace!("Read message from websocket stream: {}", msg);
                     let value = serde_json::from_str(msg.to_text().unwrap()).unwrap();
                     chan.send(value).await.unwrap();
                 }
                 Err(err) => {
-                    log::error!("Error reading message from websocket stream: {:?}", err);
+                    tracing::error!("Error reading message from websocket stream: {:?}", err);
                     break;
                 }
             },

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -130,18 +130,12 @@ impl IpcProvider {
         match subnets.get(subnet) {
             Some(subnet) => match &subnet.config {
                 config::subnet::SubnetConfig::Fevm(_) => {
-                    let wallet = match self.evm_wallet() {
-                        Ok(w) => Some(w),
-                        Err(e) => {
-                            log::warn!("error initializing evm wallet: {e}");
-                            None
-                        }
-                    };
+                    let wallet = self.evm_keystore.as_ref().map(|ks| ks.clone());
                     let manager =
                         match EthSubnetManager::from_subnet_with_wallet_store(subnet, wallet) {
                             Ok(w) => Some(w),
                             Err(e) => {
-                                log::warn!("error initializing evm wallet: {e}");
+                                tracing::warn!("error initializing evm manager: {e}");
                                 return None;
                             }
                         };

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -130,7 +130,7 @@ impl IpcProvider {
         match subnets.get(subnet) {
             Some(subnet) => match &subnet.config {
                 config::subnet::SubnetConfig::Fevm(_) => {
-                    let wallet = self.evm_keystore.as_ref().map(|ks| ks.clone());
+                    let wallet = self.evm_keystore.clone();
                     let manager =
                         match EthSubnetManager::from_subnet_with_wallet_store(subnet, wallet) {
                             Ok(w) => Some(w),

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -126,6 +126,7 @@ impl IpcProvider {
     /// Get the connection instance for the subnet.
     pub fn connection(&self, subnet: &SubnetID) -> Option<Connection> {
         let subnets = &self.config.subnets;
+
         match subnets.get(subnet) {
             Some(subnet) => match &subnet.config {
                 config::subnet::SubnetConfig::Fevm(_) => {
@@ -151,6 +152,21 @@ impl IpcProvider {
                 }
             },
             None => None,
+        }
+    }
+
+    /// Get the connection of a subnet, or return an error.
+    fn get_connection(&self, subnet: &SubnetID) -> anyhow::Result<Connection> {
+        match self.connection(subnet) {
+            None => Err(anyhow!(
+                "subnet not found: {subnet}; known subnets: {:?}",
+                self.config
+                    .subnets
+                    .keys()
+                    .map(|id| id.to_string())
+                    .collect::<Vec<_>>()
+            )),
+            Some(conn) => Ok(conn),
         }
     }
 
@@ -243,10 +259,7 @@ impl IpcProvider {
         permission_mode: PermissionMode,
         supply_source: SupplySource,
     ) -> anyhow::Result<Address> {
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         let subnet_config = conn.subnet();
         let sender = self.check_sender(subnet_config, from)?;
@@ -277,10 +290,7 @@ impl IpcProvider {
         public_key: Vec<u8>,
     ) -> anyhow::Result<ChainEpoch> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         let subnet_config = conn.subnet();
         let sender = self.check_sender(subnet_config, from)?;
@@ -297,11 +307,7 @@ impl IpcProvider {
         balance: TokenAmount,
     ) -> anyhow::Result<()> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
-
+        let conn = self.get_connection(&parent)?;
         let subnet_config = conn.subnet();
         let sender = self.check_sender(subnet_config, from)?;
 
@@ -315,10 +321,7 @@ impl IpcProvider {
         amount: TokenAmount,
     ) -> anyhow::Result<()> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         let subnet_config = conn.subnet();
         let sender = self.check_sender(subnet_config, from)?;
@@ -333,10 +336,7 @@ impl IpcProvider {
         collateral: TokenAmount,
     ) -> anyhow::Result<()> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         let subnet_config = conn.subnet();
         let sender = self.check_sender(subnet_config, from)?;
@@ -351,10 +351,7 @@ impl IpcProvider {
         collateral: TokenAmount,
     ) -> anyhow::Result<()> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         let subnet_config = conn.subnet();
         let sender = self.check_sender(subnet_config, from)?;
@@ -368,10 +365,7 @@ impl IpcProvider {
         from: Option<Address>,
     ) -> anyhow::Result<()> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         let subnet_config = conn.subnet();
         let sender = self.check_sender(subnet_config, from)?;
@@ -385,10 +379,7 @@ impl IpcProvider {
         from: Option<Address>,
     ) -> anyhow::Result<()> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         let subnet_config = conn.subnet();
         let sender = self.check_sender(subnet_config, from)?;
@@ -402,10 +393,7 @@ impl IpcProvider {
         from: Option<Address>,
     ) -> anyhow::Result<()> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         let subnet_config = conn.subnet();
         let sender = self.check_sender(subnet_config, from)?;
@@ -418,10 +406,7 @@ impl IpcProvider {
         gateway_addr: Option<Address>,
         subnet: &SubnetID,
     ) -> anyhow::Result<HashMap<SubnetID, SubnetInfo>> {
-        let conn = match self.connection(subnet) {
-            None => return Err(anyhow!("target subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(subnet)?;
 
         let subnet_config = conn.subnet();
 
@@ -444,10 +429,7 @@ impl IpcProvider {
         amount: TokenAmount,
     ) -> anyhow::Result<ChainEpoch> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         let subnet_config = conn.subnet();
         let sender = self.check_sender(subnet_config, from)?;
@@ -473,10 +455,7 @@ impl IpcProvider {
         amount: TokenAmount,
     ) -> anyhow::Result<ChainEpoch> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         let subnet_config = conn.subnet();
         let sender = self.check_sender(subnet_config, from)?;
@@ -497,7 +476,7 @@ impl IpcProvider {
         amount: TokenAmount,
     ) -> anyhow::Result<ChainEpoch> {
         let conn = match self.connection(&subnet) {
-            None => return Err(anyhow!("target subnet not found")),
+            None => return Err(anyhow!("target subnet not found: {subnet}")),
             Some(conn) => conn,
         };
 
@@ -535,10 +514,7 @@ impl IpcProvider {
         to: Address,
         amount: TokenAmount,
     ) -> anyhow::Result<()> {
-        let conn = match self.connection(subnet) {
-            None => return Err(anyhow!("target subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(subnet)?;
 
         let subnet_config = conn.subnet();
         let sender = self.check_sender(subnet_config, from)?;
@@ -565,19 +541,13 @@ impl IpcProvider {
         subnet: &SubnetID,
         address: &Address,
     ) -> anyhow::Result<TokenAmount> {
-        let conn = match self.connection(subnet) {
-            None => return Err(anyhow!("target subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(subnet)?;
 
         conn.manager().wallet_balance(address).await
     }
 
     pub async fn chain_head(&self, subnet: &SubnetID) -> anyhow::Result<ChainEpoch> {
-        let conn = match self.connection(subnet) {
-            None => return Err(anyhow!("target subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(subnet)?;
 
         conn.manager().chain_head_height().await
     }
@@ -585,10 +555,7 @@ impl IpcProvider {
     /// Obtain the genesis epoch of the input subnet.
     pub async fn genesis_epoch(&self, subnet: &SubnetID) -> anyhow::Result<ChainEpoch> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("parent subnet config not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
         conn.manager().genesis_epoch(subnet).await
     }
 
@@ -599,10 +566,7 @@ impl IpcProvider {
         validator: &Address,
     ) -> anyhow::Result<ValidatorInfo> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target subnet parent not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         conn.manager().get_validator_info(subnet, validator).await
     }
@@ -614,10 +578,7 @@ impl IpcProvider {
         epoch: ChainEpoch,
     ) -> anyhow::Result<TopDownQueryPayload<Vec<StakingChangeRequest>>> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target subnet parent not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         conn.manager().get_validator_changeset(subnet, epoch).await
     }
@@ -626,10 +587,7 @@ impl IpcProvider {
     /// generate the genesis of the subnet
     pub async fn get_genesis_info(&self, subnet: &SubnetID) -> anyhow::Result<SubnetGenesisInfo> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("parent subnet config not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
         conn.manager().get_genesis_info(subnet).await
     }
 
@@ -639,10 +597,7 @@ impl IpcProvider {
         epoch: ChainEpoch,
     ) -> anyhow::Result<TopDownQueryPayload<Vec<IpcEnvelope>>> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         conn.manager().get_top_down_msgs(subnet, epoch).await
     }
@@ -652,37 +607,25 @@ impl IpcProvider {
         subnet: &SubnetID,
         height: ChainEpoch,
     ) -> anyhow::Result<GetBlockHashResult> {
-        let conn = match self.connection(subnet) {
-            None => return Err(anyhow!("target subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(subnet)?;
 
         conn.manager().get_block_hash(height).await
     }
 
     pub async fn get_chain_id(&self, subnet: &SubnetID) -> anyhow::Result<String> {
-        let conn = match self.connection(subnet) {
-            None => return Err(anyhow!("target subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(subnet)?;
 
         conn.manager().get_chain_id().await
     }
 
     pub async fn get_commit_sha(&self, subnet: &SubnetID) -> anyhow::Result<[u8; 32]> {
-        let conn = match self.connection(subnet) {
-            None => return Err(anyhow!("target subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(subnet)?;
 
         conn.manager().get_commit_sha().await
     }
 
     pub async fn get_chain_head_height(&self, subnet: &SubnetID) -> anyhow::Result<ChainEpoch> {
-        let conn = match self.connection(subnet) {
-            None => return Err(anyhow!("target subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(subnet)?;
 
         conn.manager().chain_head_height().await
     }
@@ -692,10 +635,7 @@ impl IpcProvider {
         subnet: &SubnetID,
         height: ChainEpoch,
     ) -> anyhow::Result<BottomUpCheckpointBundle> {
-        let conn = match self.connection(subnet) {
-            None => return Err(anyhow!("target subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(subnet)?;
 
         conn.manager().checkpoint_bundle_at(height).await
     }
@@ -705,10 +645,7 @@ impl IpcProvider {
         subnet: &SubnetID,
     ) -> anyhow::Result<ChainEpoch> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         conn.manager()
             .last_bottom_up_checkpoint_height(subnet)
@@ -720,10 +657,7 @@ impl IpcProvider {
         subnet: &SubnetID,
         height: ChainEpoch,
     ) -> anyhow::Result<Vec<QuorumReachedEvent>> {
-        let conn = match self.connection(subnet) {
-            None => return Err(anyhow!("target subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(subnet)?;
 
         conn.manager().quorum_reached_events(height).await
     }
@@ -736,10 +670,7 @@ impl IpcProvider {
         endpoint: String,
     ) -> anyhow::Result<()> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         let subnet_config = conn.subnet();
         let sender = self.check_sender(subnet_config, from)?;
@@ -752,20 +683,14 @@ impl IpcProvider {
     /// Lists the bootstrap nodes of a subnet
     pub async fn list_bootstrap_nodes(&self, subnet: &SubnetID) -> anyhow::Result<Vec<String>> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
 
         conn.manager().list_bootstrap_nodes(subnet).await
     }
 
     /// Returns the latest finality from the parent committed in a child subnet.
     pub async fn latest_parent_finality(&self, subnet: &SubnetID) -> anyhow::Result<ChainEpoch> {
-        let conn = match self.connection(subnet) {
-            None => return Err(anyhow!("target subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(subnet)?;
 
         conn.manager().latest_parent_finality().await
     }
@@ -779,10 +704,7 @@ impl IpcProvider {
         federated_power: &[u128],
     ) -> anyhow::Result<ChainEpoch> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
-        let conn = match self.connection(&parent) {
-            None => return Err(anyhow!("target parent subnet not found")),
-            Some(conn) => conn,
-        };
+        let conn = self.get_connection(&parent)?;
         conn.manager()
             .set_federated_power(from, subnet, validators, public_keys, federated_power)
             .await

--- a/ipc/provider/src/lotus/client.rs
+++ b/ipc/provider/src/lotus/client.rs
@@ -157,7 +157,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
             .client
             .request::<MpoolPushMessageResponse>(methods::MPOOL_PUSH_MESSAGE, params)
             .await?;
-        log::debug!("received mpool_push_message response: {r:?}");
+        tracing::debug!("received mpool_push_message response: {r:?}");
 
         Ok(r.message)
     }
@@ -165,7 +165,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
     async fn mpool_push(&self, mut msg: MpoolPushMessage) -> Result<Cid> {
         if msg.nonce.is_none() {
             let nonce = self.mpool_nonce(&msg.from).await?;
-            log::info!(
+            tracing::info!(
                 "sender: {:} with nonce: {nonce:} in subnet: {:}",
                 msg.from,
                 self.subnet
@@ -178,12 +178,12 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
         }
 
         self.estimate_message_gas(&mut msg).await?;
-        log::debug!("estimated gas for message: {msg:?}");
+        tracing::debug!("estimated gas for message: {msg:?}");
 
         let signature = self.sign_mpool_message(&msg)?;
 
         let params = create_signed_message_params(msg, signature);
-        log::debug!(
+        tracing::debug!(
             "message to push to mpool: {params:?} in subnet: {:?}",
             self.subnet
         );
@@ -192,7 +192,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
             .client
             .request::<CIDMap>(methods::MPOOL_PUSH, params)
             .await?;
-        log::debug!("received mpool_push_message response: {r:?}");
+        tracing::debug!("received mpool_push_message response: {r:?}");
 
         Cid::try_from(r)
     }
@@ -210,7 +210,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
             .client
             .request::<StateWaitMsgResponse>(methods::STATE_WAIT_MSG, params)
             .await?;
-        log::debug!("received state_wait_msg response: {r:?}");
+        tracing::debug!("received state_wait_msg response: {r:?}");
         Ok(r)
     }
 
@@ -220,7 +220,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
             .client
             .request::<String>(methods::STATE_NETWORK_NAME, serde_json::Value::Null)
             .await?;
-        log::debug!("received state_network_name response: {r:?}");
+        tracing::debug!("received state_network_name response: {r:?}");
         Ok(r)
     }
 
@@ -233,7 +233,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
             .request::<NetworkVersion>(methods::STATE_NETWORK_VERSION, params)
             .await?;
 
-        log::debug!("received state_network_version response: {r:?}");
+        tracing::debug!("received state_network_version response: {r:?}");
         Ok(r)
     }
 
@@ -254,7 +254,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
             cids.insert(key, Cid::try_from(cid_map)?);
         }
 
-        log::debug!("received state_actor_manifest_cid response: {cids:?}");
+        tracing::debug!("received state_actor_manifest_cid response: {cids:?}");
         Ok(cids)
     }
 
@@ -264,7 +264,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
             .client
             .request::<String>(methods::WALLET_DEFAULT_ADDRESS, json!({}))
             .await?;
-        log::debug!("received wallet_default response: {r:?}");
+        tracing::debug!("received wallet_default response: {r:?}");
 
         let addr = Address::from_str(&r)?;
         Ok(addr)
@@ -276,7 +276,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
             .client
             .request::<WalletListResponse>(methods::WALLET_LIST, json!({}))
             .await?;
-        log::debug!("received wallet_list response: {r:?}");
+        tracing::debug!("received wallet_list response: {r:?}");
         Ok(r)
     }
 
@@ -287,7 +287,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
             .client
             .request::<String>(methods::WALLET_NEW, json!([key_type_str]))
             .await?;
-        log::debug!("received wallet_new response: {r:?}");
+        tracing::debug!("received wallet_new response: {r:?}");
         Ok(r)
     }
 
@@ -297,7 +297,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
             .client
             .request::<String>(methods::WALLET_BALANCE, json!([address.to_string()]))
             .await?;
-        log::debug!("received wallet_balance response: {r:?}");
+        tracing::debug!("received wallet_balance response: {r:?}");
 
         let v = BigInt::from_str(&r)?;
         Ok(TokenAmount::from_atto(v))
@@ -316,7 +316,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
                 json!([address.to_string(), [CIDMap::from(tipset)]]),
             )
             .await?;
-        log::debug!("received read_state response: {r:?}");
+        tracing::debug!("received read_state response: {r:?}");
         Ok(r)
     }
 
@@ -325,7 +325,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
             .client
             .request::<ChainHeadResponse>(methods::CHAIN_HEAD, NO_PARAMS)
             .await?;
-        log::debug!("received chain_head response: {r:?}");
+        tracing::debug!("received chain_head response: {r:?}");
         Ok(r)
     }
 
@@ -345,7 +345,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
                 json!([epoch, [CIDMap::from(tip_set)]]),
             )
             .await?;
-        log::debug!("received get_tipset_by_height response: {r:?}");
+        tracing::debug!("received get_tipset_by_height response: {r:?}");
         Ok(r)
     }
 }

--- a/ipc/provider/src/lotus/message/state.rs
+++ b/ipc/provider/src/lotus/message/state.rs
@@ -52,7 +52,7 @@ impl Receipt {
         let r = base64::engine::general_purpose::STANDARD
             .decode(self.result.unwrap())
             .map_err(|e| {
-                log::error!("cannot base64 decode due to {e:?}");
+                tracing::error!("cannot base64 decode due to {e:?}");
                 anyhow!("cannot decode return string")
             })?;
 
@@ -61,7 +61,7 @@ impl Receipt {
             "deserialize create subnet return response",
         )
         .map_err(|e| {
-            log::error!("cannot decode bytes due to {e:?}");
+            tracing::error!("cannot decode bytes due to {e:?}");
             anyhow!("cannot cbor deserialize return data")
         })
     }

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -86,7 +86,7 @@ struct IPCContractInfo {
 impl TopDownFinalityQuery for EthSubnetManager {
     async fn genesis_epoch(&self, subnet_id: &SubnetID) -> Result<ChainEpoch> {
         let address = contract_address_from_subnet(subnet_id)?;
-        log::info!("querying genesis epoch in evm subnet contract: {address:}");
+        tracing::info!("querying genesis epoch in evm subnet contract: {address:}");
 
         let evm_subnet_id = gateway_getter_facet::SubnetID::try_from(subnet_id)?;
 
@@ -122,7 +122,7 @@ impl TopDownFinalityQuery for EthSubnetManager {
         );
 
         let topic1 = contract_address_from_subnet(subnet_id)?;
-        log::debug!(
+        tracing::debug!(
             "getting top down messages for subnet: {:?} with topic 1: {}",
             subnet_id,
             topic1,
@@ -184,7 +184,7 @@ impl TopDownFinalityQuery for EthSubnetManager {
         epoch: ChainEpoch,
     ) -> Result<TopDownQueryPayload<Vec<StakingChangeRequest>>> {
         let address = contract_address_from_subnet(subnet_id)?;
-        log::info!("querying validator changes in evm subnet contract: {address:}");
+        tracing::info!("querying validator changes in evm subnet contract: {address:}");
 
         let contract = subnet_actor_manager_facet::SubnetActorManagerFacet::new(
             address,
@@ -222,7 +222,7 @@ impl TopDownFinalityQuery for EthSubnetManager {
     }
 
     async fn latest_parent_finality(&self) -> Result<ChainEpoch> {
-        log::info!("querying latest parent finality ");
+        tracing::info!("querying latest parent finality ");
 
         let contract = gateway_getter_facet::GatewayGetterFacet::new(
             self.ipc_contract_info.gateway_addr,
@@ -244,10 +244,10 @@ impl SubnetManager for EthSubnetManager {
             .to_u128()
             .ok_or_else(|| anyhow!("invalid min validator stake"))?;
 
-        log::debug!("calling create subnet for EVM manager");
+        tracing::debug!("calling create subnet for EVM manager");
 
         let route = subnet_id_to_evm_addresses(&params.parent)?;
-        log::debug!("root SubnetID as Ethereum type: {route:?}");
+        tracing::debug!("root SubnetID as Ethereum type: {route:?}");
 
         let params = register_subnet_facet::ConstructorParams {
             parent_id: register_subnet_facet::SubnetID {
@@ -266,7 +266,7 @@ impl SubnetManager for EthSubnetManager {
             supply_source: register_subnet_facet::SupplySource::try_from(params.supply_source)?,
         };
 
-        log::info!("creating subnet on evm with params: {params:?}");
+        tracing::info!("creating subnet on evm with params: {params:?}");
 
         let signer = self.get_signer(&from)?;
         let signer = Arc::new(signer);
@@ -286,7 +286,7 @@ impl SubnetManager for EthSubnetManager {
         match receipt {
             Some(r) => {
                 for log in r.logs {
-                    log::debug!("log: {log:?}");
+                    tracing::debug!("log: {log:?}");
 
                     match ethers_contract::parse_log::<register_subnet_facet::SubnetDeployedFilter>(
                         log,
@@ -295,11 +295,11 @@ impl SubnetManager for EthSubnetManager {
                             let register_subnet_facet::SubnetDeployedFilter { subnet_addr } =
                                 subnet_deploy;
 
-                            log::debug!("subnet deployed at {subnet_addr:?}");
+                            tracing::debug!("subnet deployed at {subnet_addr:?}");
                             return ethers_address_to_fil_address(&subnet_addr);
                         }
                         Err(_) => {
-                            log::debug!("no event for subnet actor published yet, continue");
+                            tracing::debug!("no event for subnet actor published yet, continue");
                             continue;
                         }
                     }
@@ -323,7 +323,7 @@ impl SubnetManager for EthSubnetManager {
             .ok_or_else(|| anyhow!("invalid min validator stake"))?;
 
         let address = contract_address_from_subnet(&subnet)?;
-        log::info!(
+        tracing::info!(
             "interacting with evm subnet contract: {address:} with collateral: {collateral:}"
         );
 
@@ -350,7 +350,7 @@ impl SubnetManager for EthSubnetManager {
             .ok_or_else(|| anyhow!("invalid initial balance"))?;
 
         let address = contract_address_from_subnet(&subnet)?;
-        log::info!("interacting with evm subnet contract: {address:} with balance: {balance:}");
+        tracing::info!("interacting with evm subnet contract: {address:} with balance: {balance:}");
 
         let signer = Arc::new(self.get_signer(&from)?);
         let contract =
@@ -371,7 +371,7 @@ impl SubnetManager for EthSubnetManager {
         amount: TokenAmount,
     ) -> Result<()> {
         let address = contract_address_from_subnet(&subnet)?;
-        log::info!("pre-release funds from {subnet:} at contract: {address:}");
+        tracing::info!("pre-release funds from {subnet:} at contract: {address:}");
 
         let amount = amount
             .atto()
@@ -398,7 +398,7 @@ impl SubnetManager for EthSubnetManager {
             .ok_or_else(|| anyhow!("invalid collateral amount"))?;
 
         let address = contract_address_from_subnet(&subnet)?;
-        log::info!(
+        tracing::info!(
             "interacting with evm subnet contract: {address:} with collateral: {collateral:}"
         );
 
@@ -427,7 +427,7 @@ impl SubnetManager for EthSubnetManager {
             .ok_or_else(|| anyhow!("invalid collateral amount"))?;
 
         let address = contract_address_from_subnet(&subnet)?;
-        log::info!(
+        tracing::info!(
             "interacting with evm subnet contract: {address:} with collateral: {collateral:}"
         );
 
@@ -443,7 +443,7 @@ impl SubnetManager for EthSubnetManager {
 
     async fn leave_subnet(&self, subnet: SubnetID, from: Address) -> Result<()> {
         let address = contract_address_from_subnet(&subnet)?;
-        log::info!("leaving evm subnet: {subnet:} at contract: {address:}");
+        tracing::info!("leaving evm subnet: {subnet:} at contract: {address:}");
 
         let signer = Arc::new(self.get_signer(&from)?);
         let contract =
@@ -460,7 +460,7 @@ impl SubnetManager for EthSubnetManager {
 
     async fn kill_subnet(&self, subnet: SubnetID, from: Address) -> Result<()> {
         let address = contract_address_from_subnet(&subnet)?;
-        log::info!("kill evm subnet: {subnet:} at contract: {address:}");
+        tracing::info!("kill evm subnet: {subnet:} at contract: {address:}");
 
         let signer = Arc::new(self.get_signer(&from)?);
         let contract =
@@ -489,7 +489,7 @@ impl SubnetManager for EthSubnetManager {
         let mut s = HashMap::new();
 
         let evm_subnets = gateway_contract.list_subnets().call().await?;
-        log::debug!("raw subnet: {evm_subnets:?}");
+        tracing::debug!("raw subnet: {evm_subnets:?}");
 
         for subnet in evm_subnets {
             let info = SubnetInfo::try_from(subnet)?;
@@ -501,7 +501,7 @@ impl SubnetManager for EthSubnetManager {
 
     async fn claim_collateral(&self, subnet: SubnetID, from: Address) -> Result<()> {
         let address = contract_address_from_subnet(&subnet)?;
-        log::info!("claim collateral evm subnet: {subnet:} at contract: {address:}");
+        tracing::info!("claim collateral evm subnet: {subnet:} at contract: {address:}");
 
         let signer = Arc::new(self.get_signer(&from)?);
         let contract =
@@ -531,10 +531,10 @@ impl SubnetManager for EthSubnetManager {
             .to_u128()
             .ok_or_else(|| anyhow!("invalid value to fund"))?;
 
-        log::info!("fund with evm gateway contract: {gateway_addr:} with value: {value:}, original: {amount:?}");
+        tracing::info!("fund with evm gateway contract: {gateway_addr:} with value: {value:}, original: {amount:?}");
 
         let evm_subnet_id = gateway_manager_facet::SubnetID::try_from(&subnet)?;
-        log::debug!("evm subnet id to fund: {evm_subnet_id:?}");
+        tracing::debug!("evm subnet id to fund: {evm_subnet_id:?}");
 
         let signer = Arc::new(self.get_signer(&from)?);
         let gateway_contract = gateway_manager_facet::GatewayManagerFacet::new(
@@ -561,7 +561,9 @@ impl SubnetManager for EthSubnetManager {
         to: Address,
         amount: TokenAmount,
     ) -> Result<ChainEpoch> {
-        log::debug!("fund with token, subnet: {subnet}, amount: {amount}, from: {from}, to: {to}");
+        tracing::debug!(
+            "fund with token, subnet: {subnet}, amount: {amount}, from: {from}, to: {to}"
+        );
 
         let value = fil_amount_to_eth_amount(&amount)?;
         let evm_subnet_id = gateway_manager_facet::SubnetID::try_from(&subnet)?;
@@ -598,7 +600,7 @@ impl SubnetManager for EthSubnetManager {
             .to_u128()
             .ok_or_else(|| anyhow!("invalid value to fund"))?;
 
-        log::info!("release with evm gateway contract: {gateway_addr:} with value: {value:}");
+        tracing::info!("release with evm gateway contract: {gateway_addr:} with value: {value:}");
 
         let signer = Arc::new(self.get_signer(&from)?);
         let gateway_contract = gateway_manager_facet::GatewayManagerFacet::new(
@@ -631,7 +633,7 @@ impl SubnetManager for EthSubnetManager {
 
         self.ensure_same_gateway(&gateway_addr)?;
 
-        log::info!("propagate postbox evm gateway contract: {gateway_addr:} with message key: {postbox_msg_key:?}");
+        tracing::info!("propagate postbox evm gateway contract: {gateway_addr:} with message key: {postbox_msg_key:?}");
 
         let signer = Arc::new(self.get_signer(&from)?);
         let gateway_contract = gateway_messenger_facet::GatewayMessengerFacet::new(
@@ -662,7 +664,7 @@ impl SubnetManager for EthSubnetManager {
 
         let tx_pending = signer.send_transaction(tx, None).await?;
 
-        log::info!(
+        tracing::info!(
             "sending FIL from {from:} to {to:} in tx {:?}",
             tx_pending.tx_hash()
         );
@@ -694,11 +696,11 @@ impl SubnetManager for EthSubnetManager {
             self.ipc_contract_info.gateway_addr,
             Arc::new(self.ipc_contract_info.provider.clone()),
         );
-        log::debug!(
+        tracing::debug!(
             "gateway_contract address : {:?}",
             self.ipc_contract_info.gateway_addr
         );
-        log::debug!(
+        tracing::debug!(
             "gateway_contract_getter_facet address : {:?}",
             gateway_contract.address()
         );
@@ -811,7 +813,7 @@ impl SubnetManager for EthSubnetManager {
         federated_power: &[u128],
     ) -> Result<ChainEpoch> {
         let address = contract_address_from_subnet(subnet)?;
-        log::info!("interacting with evm subnet contract: {address:}");
+        tracing::info!("interacting with evm subnet contract: {address:}");
 
         let signer = Arc::new(self.get_signer(from)?);
         let contract =
@@ -821,21 +823,21 @@ impl SubnetManager for EthSubnetManager {
             .iter()
             .map(|validator_address| payload_to_evm_address(validator_address.payload()).unwrap())
             .collect();
-        log::debug!("converted addresses: {:?}", addresses);
+        tracing::debug!("converted addresses: {:?}", addresses);
 
         let pubkeys: Vec<ethers::core::types::Bytes> = public_keys
             .iter()
             .map(|key| ethers::core::types::Bytes::from(key.clone()))
             .collect();
-        log::debug!("converted pubkeys: {:?}", pubkeys);
+        tracing::debug!("converted pubkeys: {:?}", pubkeys);
 
         let power_u256: Vec<ethers::core::types::U256> = federated_power
             .iter()
             .map(|power| ethers::core::types::U256::from(*power))
             .collect();
-        log::debug!("converted power: {:?}", power_u256);
+        tracing::debug!("converted power: {:?}", power_u256);
 
-        log::debug!("from address: {:?}", from);
+        tracing::debug!("from address: {:?}", from);
 
         let call = contract.set_federated_power(addresses, pubkeys, power_u256);
         let txn = call_with_premium_estimation(signer, call).await?;
@@ -869,7 +871,7 @@ impl EthManager for EthSubnetManager {
             .bottom_up_checkpoint(ethers::types::U256::from(epoch as u64))
             .call()
             .await?;
-        log::debug!("raw bottom up checkpoint from gateway: {checkpoint:?}");
+        tracing::debug!("raw bottom up checkpoint from gateway: {checkpoint:?}");
         let token = checkpoint.into_token();
         let c = subnet_actor_checkpointing_facet::BottomUpCheckpoint::from_token(token)?;
         Ok(c)
@@ -877,7 +879,7 @@ impl EthManager for EthSubnetManager {
 
     async fn get_applied_top_down_nonce(&self, subnet_id: &SubnetID) -> Result<u64> {
         let route = subnet_id_to_evm_addresses(subnet_id)?;
-        log::debug!("getting applied top down nonce for route: {route:?}");
+        tracing::debug!("getting applied top down nonce for route: {route:?}");
 
         let evm_subnet_id = gateway_getter_facet::SubnetID {
             root: subnet_id.root_id(),
@@ -1058,7 +1060,7 @@ impl BottomUpCheckpointRelayer for EthSubnetManager {
         signatories: Vec<Address>,
     ) -> anyhow::Result<ChainEpoch> {
         let address = contract_address_from_subnet(&checkpoint.subnet_id)?;
-        log::debug!(
+        tracing::debug!(
             "submit bottom up checkpoint: {checkpoint:?} in evm subnet contract: {address:}"
         );
 


### PR DESCRIPTION
Adds a CLI command to fetch topdown events of a subnet and export them to JSON. These could be read into an upgrade and applied on the child subnet.

As an alternative, one can use the Filfox API: https://filfox.info/api/v1/address/f410fqpww4v74jydq25jncdbletyqd42oxyeoapzaz4a/events?page=0&pageSize=5

### Usage

```console
❯ cargo run -q -p fendermint_app -- debug ipc export-top-down-events --help
Fetch topdown events from the parent and export them to JSON.

This can be used to construct an upgrade to impute missing events.

Usage: fendermint debug ipc export-top-down-events [OPTIONS] --subnet-id <SUBNET_ID> --parent-endpoint <PARENT_ENDPOINT> --start-block-height <START_BLOCK_HEIGHT> --end-block-height <END_BLOCK_HEIGHT> --events-file <EVENTS_FILE>

Options:
  -s, --subnet-id <SUBNET_ID>
          Child subnet for with the events will be fetched

  -p, --parent-endpoint <PARENT_ENDPOINT>
          Endpoint to the RPC of the child subnet's parent

      --parent-auth-token <PARENT_AUTH_TOKEN>
          HTTP basic authentication token

      --parent-gateway <PARENT_GATEWAY>
          IPC gateway of the parent; 20 byte Ethereum address in 0x prefixed hex format
          
          [default: 0xff00000000000000000000000000000000000064]

      --parent-registry <PARENT_REGISTRY>
          IPC registry of the parent; 20 byte Ethereum address in 0x prefixed hex format
          
          [default: 0xff00000000000000000000000000000000000065]

      --start-block-height <START_BLOCK_HEIGHT>
          The first block to query for events

      --end-block-height <END_BLOCK_HEIGHT>
          The last block to query for events

      --events-file <EVENTS_FILE>
          Location of the JSON file to write events to

  -h, --help
          Print help (see a summary with '-h')

```

### Rationale

I added this under `debug ipc` because although it's very similar to `genesis ipc from-parent`, it doesn't have anything to do with the genesis per-se, and all `genesis` commands require a `--genesis-file` argument. The expectation is that we won't need this; the only reason for it to exist is to reduce the chance of manual errors in replaying events as part of an upgrade, but that's something that we ideally don't have to do. For this reason it's under a new `debug` command family, rather than an `ipc` one, to show that it's not a normal operation.

I didn't want to put it into the `ipc-cli` because I wanted to reuse the `fetch_data` in the `fendermint` project, and because the only reason for this to exist is to support a (one-off :crossed_fingers:) upgrade which happens in fendermint.


### Example

Trying to find events in the range of the following query:

```console
⟩ curl -X POST --location "https://gerovit.filmine.dev/rpc/v1" \
          -H "Content-Type: application/json" \
          -d '{"id": 1, "jsonrpc": "2.0", "method": "eth_getLogs", "params": [{"fromBlock": "0x39a454", "toBlock": "0x39a459"}]}'
{"jsonrpc":"2.0","result":[],"id":1}
```

```shell
cargo run  -p fendermint_app -- debug ipc export-top-down-events \
            --subnet-id /r314/f410fqpww4v74jydq25jncdbletyqd42oxyeoapzaz4a \
            --parent-endpoint <RPC_ENDPOINT> \
            --parent-auth-token <RPC_AUTH_TOKEN> \
            --parent-gateway 0x5cFA791d5c1b162216309fba6fc2A68758A3b233 \
            --parent-registry 0xe0B7D47e3f0443e8DC6cA6F84c75F65Cb3a29676 \
            --start-block-height 3777620 \
            --end-block-height 3777625 \
            --events-file topdown.json
```

See which configuration numbers were exported from https://node.glif.io/fvm-archive/lotus/rpc/v1:

```console
❯ cat topdown.json | jq -c ".[] | .[1][1][] | .configuration_number"
55
56
57
58
59
60
61
62
63
64
65
66

```