### PR TITLE
ipc-cli subnet join to extract pubkey from the wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5060,6 +5060,7 @@ dependencies = [
  "ipc-types",
  "ipc-wallet",
  "ipc_actors_abis",
+ "libsecp256k1",
  "log",
  "num-derive 0.3.3",
  "num-traits",

--- a/docs/ipc/usage.md
+++ b/docs/ipc/usage.md
@@ -94,12 +94,11 @@ This command only shows subnets that have been registered to the gateway, i.e. t
 
 * To join a subnet with the `ipc-cli`
 ```bash
-./bin/ipc-cli subnet join --subnet <subnet-id> --collateral <collateral_amount> --public-key <public_key_validator_addr>
+./bin/ipc-cli subnet join --subnet <subnet-id> --collateral <collateral_amount>
 ```
 ```console
 # Example execution
-$ ./bin/ipc-cli subnet join --subnet=/r314159/t410fh4ywg4wvxcjzz4vsja3uh4f53johc2lf5bpjo6i --collateral=1 \
-    --public-key=043385c3b9ab8a697cd7bec6ca623cbdd0fea1293e8b464df825b104eb58a44cc8efacc6a3482b866b85ecdf734b5d4ef5495737deb348625ce6a35536142d2955
+$ ./bin/ipc-cli subnet join --subnet=/r314159/t410fh4ywg4wvxcjzz4vsja3uh4f53johc2lf5bpjo6i --collateral=1
 ```
 This command specifies the subnet to join, the amount of collateral to provide and the public key of the `--from` address that is joining as a validator.
 
@@ -276,23 +275,22 @@ You can find the checkpoint where your cross-message was included by listing the
 
 * To join a subnet with the `ipc-cli`
 ```bash
-./bin/ipc-cli subnet join --subnet <subnet-id> --collateral <collateral_amount> --public-key <public_key_validator_addr>
+./bin/ipc-cli subnet join --subnet <subnet-id> --collateral <collateral_amount>
 ```
 ```console
 # Example execution
-$ ./bin/ipc-cli subnet join --subnet=/r314159/t410fh4ywg4wvxcjzz4vsja3uh4f53johc2lf5bpjo6i --collateral=1 \
-    --public-key=043385c3b9ab8a697cd7bec6ca623cbdd0fea1293e8b464df825b104eb58a44cc8efacc6a3482b866b85ecdf734b5d4ef5495737deb348625ce6a35536142d2955
+$ ./bin/ipc-cli subnet join --subnet=/r314159/t410fh4ywg4wvxcjzz4vsja3uh4f53johc2lf5bpjo6i --collateral=1
 ```
 This command specifies the subnet to join, the amount of collateral to provide and the public key of the `--from` address that is joining as a validator.
 
 * To join a subnet and also include some initial balance for the validator in the subnet, you can add the `--initial-balance` flag with the balance to be included in genesis:
 ```bash
-./bin/ipc-cli subnet join --subnet <subnet-id> --collateral <collateral_amount> --public-key <public_key_validator_addr> --initial-balance <genesis-balance>
+./bin/ipc-cli subnet join --subnet <subnet-id> --collateral <collateral_amount> --initial-balance <genesis-balance>
 ```
 ```console
 # Example execution
 $ ./bin/ipc-cli subnet join --subnet=/r314159/t410fh4ywg4wvxcjzz4vsja3uh4f53johc2lf5bpjo6i --collateral=1 \
-    --public-key=043385c3b9ab8a697cd7bec6ca623cbdd0fea1293e8b464df825b104eb58a44cc8efacc6a3482b866b85ecdf734b5d4ef5495737deb348625ce6a35536142d2955 --initial-balance 0.5
+    --initial-balance 0.5
 ```
 
 * To leave a subnet, the following agent command can be used:

--- a/fendermint/testing/materializer/src/docker/mod.rs
+++ b/fendermint/testing/materializer/src/docker/mod.rs
@@ -906,7 +906,6 @@ impl Materializer<DockerMaterials> for DockerMaterializer {
             ",
             subnet.subnet_id,
             account.eth_addr(),
-            hex::encode(account.public_key().serialize()),
             collateral.0,
             balance.0
         );

--- a/fendermint/testing/materializer/src/docker/mod.rs
+++ b/fendermint/testing/materializer/src/docker/mod.rs
@@ -901,7 +901,6 @@ impl Materializer<DockerMaterials> for DockerMaterializer {
             "ipc-cli subnet join \
                 --subnet {} \
                 --from {:?} \
-                --public-key {} \
                 --collateral {} \
                 --initial-balance {} \
             ",

--- a/ipc/cli/src/commands/subnet/join.rs
+++ b/ipc/cli/src/commands/subnet/join.rs
@@ -2,16 +2,14 @@
 // SPDX-License-Identifier: MIT
 //! Join subnet cli command handler.
 
+use crate::commands::anyhow;
+use anyhow::Error;
 use async_trait::async_trait;
 use clap::Args;
 use ipc_api::subnet_id::SubnetID;
+use ipc_wallet::EvmKeyStore;
 use num_traits::Zero;
 use std::{fmt::Debug, str::FromStr};
-use ipc_wallet::EvmKeyStore;
-use anyhow::{Error};
-use crate::commands::anyhow;
-
-
 
 use crate::{
     f64_to_token_amount, get_ipc_provider, require_fil_addr_from_str, CommandLineHandler,
@@ -35,7 +33,8 @@ impl CommandLineHandler for JoinSubnet {
             None => None,
         };
         let keystore = provider.evm_wallet()?;
-        let address_str = arguments.from
+        let address_str = arguments
+            .from
             .as_deref()
             .ok_or_else(|| Error::msg("Address is required"))?;
         let address = ethers::types::Address::from_str(address_str)?;

--- a/ipc/cli/src/commands/subnet/join.rs
+++ b/ipc/cli/src/commands/subnet/join.rs
@@ -5,7 +5,6 @@
 use async_trait::async_trait;
 use clap::Args;
 use ipc_api::subnet_id::SubnetID;
-
 use num_traits::Zero;
 use std::{fmt::Debug, str::FromStr};
 

--- a/ipc/cli/src/commands/subnet/join.rs
+++ b/ipc/cli/src/commands/subnet/join.rs
@@ -45,7 +45,7 @@ impl CommandLineHandler for JoinSubnet {
             .get(&address.into())?
             .ok_or_else(|| anyhow!("key does not exists"))?;
         let sk = libsecp256k1::SecretKey::parse_slice(key_info.private_key())?;
-        let public_key = hex::encode(libsecp256k1::PublicKey::from_secret_key(&sk).serialize()).to_string();
+        let public_key = libsecp256k1::PublicKey::from_secret_key(&sk).serialize();
         if let Some(initial_balance) = arguments.initial_balance.filter(|x| !x.is_zero()) {
             log::info!("pre-funding address with {initial_balance}");
             provider
@@ -78,8 +78,6 @@ pub struct JoinSubnetArgs {
         help = "The collateral to stake in the subnet (in whole FIL units)"
     )]
     pub collateral: f64,
-    #[arg(long, help = "The validator's metadata, hex encoded")]
-    pub public_key: String,
     #[arg(
         long,
         help = "Optionally add an initial balance to the validator in genesis in the subnet"

--- a/ipc/provider/Cargo.toml
+++ b/ipc/provider/Cargo.toml
@@ -14,6 +14,7 @@ async-trait = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true }
 
+libsecp256k1 = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -295,7 +295,7 @@ impl IpcProvider {
         let public_key = libsecp256k1::PublicKey::from_secret_key(&sk).serialize();
 
         conn.manager()
-            .join_subnet(subnet, sender, collateral, public_key.to_vec())
+            .join_subnet(subnet, sender, collateral, public_key.into())
             .await
     }
 

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -10,6 +10,7 @@ use fvm_shared::{
     address::Address, clock::ChainEpoch, crypto::signature::SignatureType, econ::TokenAmount,
 };
 use ipc_api::checkpoint::{BottomUpCheckpointBundle, QuorumReachedEvent};
+use ipc_api::evm::payload_to_evm_address;
 use ipc_api::staking::{StakingChangeRequest, ValidatorInfo};
 use ipc_api::subnet::{PermissionMode, SupplySource};
 use ipc_api::{
@@ -274,7 +275,6 @@ impl IpcProvider {
         subnet: SubnetID,
         from: Option<Address>,
         collateral: TokenAmount,
-        public_key: Vec<u8>,
     ) -> anyhow::Result<ChainEpoch> {
         let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
         let conn = match self.connection(&parent) {
@@ -284,9 +284,18 @@ impl IpcProvider {
 
         let subnet_config = conn.subnet();
         let sender = self.check_sender(subnet_config, from)?;
+        let addr = payload_to_evm_address(sender.payload())?;
+        let keystore = self.evm_wallet()?;
+        let key_info = keystore
+            .read()
+            .unwrap()
+            .get(&addr.into())?
+            .ok_or_else(|| anyhow!("key does not exists"))?;
+        let sk = libsecp256k1::SecretKey::parse_slice(key_info.private_key())?;
+        let public_key = libsecp256k1::PublicKey::from_secret_key(&sk).serialize();
 
         conn.manager()
-            .join_subnet(subnet, sender, collateral, public_key)
+            .join_subnet(subnet, sender, collateral, public_key.to_vec())
             .await
     }
 

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -297,6 +297,10 @@ impl IpcProvider {
             .ok_or_else(|| anyhow!("key does not exists"))?;
         let sk = libsecp256k1::SecretKey::parse_slice(key_info.private_key())?;
         let public_key = libsecp256k1::PublicKey::from_secret_key(&sk).serialize();
+        let hex_public_key = hex::encode(public_key);
+        log::info!(
+            "joining subnet with public key: {hex_public_key:?}"
+        );
 
         conn.manager()
             .join_subnet(subnet, sender, collateral, public_key.into())

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -298,9 +298,7 @@ impl IpcProvider {
         let sk = libsecp256k1::SecretKey::parse_slice(key_info.private_key())?;
         let public_key = libsecp256k1::PublicKey::from_secret_key(&sk).serialize();
         let hex_public_key = hex::encode(public_key);
-        log::info!(
-            "joining subnet with public key: {hex_public_key:?}"
-        );
+        log::info!("joining subnet with public key: {hex_public_key:?}");
 
         conn.manager()
             .join_subnet(subnet, sender, collateral, public_key.into())

--- a/scripts/deploy_subnet_under_calibration_net/deploy.sh
+++ b/scripts/deploy_subnet_under_calibration_net/deploy.sh
@@ -16,7 +16,6 @@ IPC_CLI=${IPC_FOLDER}/target/release/ipc-cli
 IPC_CONFIG_FOLDER=${HOME}/.ipc
 
 wallet_addresses=()
-address_pubkeys=()
 CMT_P2P_HOST_PORTS=(26656 26756 26856)
 CMT_RPC_HOST_PORTS=(26657 26757 26857)
 ETHAPI_HOST_PORTS=(8545 8645 8745)
@@ -178,25 +177,16 @@ echo "Created new subnet id: $subnet_id"
 #subnet_id=/r314159/t410flp4jf7keqcf5bqogrkx4wpkygiskykcvpaigicq
 #echo "Use existing subnet id: $subnet_id"
 
-# Step 5.1: Use the new subnet ID to update IPC config file
+# Step 6: Use the new subnet ID to update IPC config file
 toml set ${IPC_CONFIG_FOLDER}/config.toml subnets[1].id $subnet_id > /tmp/config.toml.3
 cp /tmp/config.toml.3 ${IPC_CONFIG_FOLDER}/config.toml
-
-# Step 6: Generate pubkeys from addresses
-echo "$DASHES Generating pubkey for wallet addresses... $default_wallet_address"
-for i in {0..2}
-do
-  pubkey=$($IPC_CLI wallet pub-key --wallet-type evm --address ${wallet_addresses[i]})
-  echo "Wallet $i address's pubkey: $pubkey"
-  address_pubkeys+=($pubkey)
-done
 
 # Step 7: Join subnet for addresses in wallet
 echo "$DASHES Join subnet for addresses in wallet..."
 for i in {0..2}
 do
   echo "Joining subnet ${subnet_id} for address ${wallet_addresses[i]}"
-  $IPC_CLI subnet join --from ${wallet_addresses[i]} --subnet $subnet_id --public-key ${address_pubkeys[i]} --initial-balance 1 --collateral 10
+  $IPC_CLI subnet join --from ${wallet_addresses[i]} --subnet $subnet_id --initial-balance 1 --collateral 10
 done
 
 # Step 8: Start validators


### PR DESCRIPTION
This closes ENG-612. I am still gaining Rust experience, but this did seem straight forward enough. I copied the code from 
cli/src/commands/wallet/export.rs:125 into JoinSubnet to calculate the public key.


working:
```
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/ipc$ ipc-cli subnet create --parent /r314159 --min-validator-stake 1 --min-validators 1 --bottomup-check-period 5 --supply-source-kind native  --
from 0x1c6c6494ee7c390c81352f218ba698a065ba4feb --permission-mode collateral
[2024-04-09T23:55:05Z INFO  ipc_provider::manager::evm::manager] creating subnet on evm with params: ConstructorParams { min_activation_collateral: 1000000000000000000, min_validators: 1, bottom_up_check_
period: 5, ipc_gateway_addr: 0xb4271dc950665e8598cef7d0c7eb3efc44e064f2, active_validators_limit: 100, majority_percentage: 67, consensus: 0, power_scale: 3, permission_mode: 0, supply_source: SupplySourc
e { kind: 0, token_address: 0x0000000000000000000000000000000000000000 }, parent_id: SubnetID { root: 314159, route: [] } }
[2024-04-09T23:56:00Z INFO  ipc_cli::commands::subnet::create] created subnet actor with id: /r314159/t410f3sol4itcks7m7sbusuriows7zq2eshnzk6fmjnq
mikers@mikers-B560-DS3H-AC-Y1:~/dev/consensus-shipyard/ipc/ipc$ ipc-cli subnet join --from 0x1c6c6494ee7c390c81352f218ba698a065ba4feb --subnet /r314159/t410f3sol4itcks7m7sbusuriows7zq2eshnzk6fmjnq --colla
teral 1
[2024-04-09T23:56:41Z INFO  ipc_provider::manager::evm::manager] interacting with evm subnet contract: 0xdc9c…1db9 with collateral: 1000000000000000000
joined at epoch: 1512688

```