### PR TITLE
Topdown consistency checks: Validate number of top down messages

### DIFF
--- a/fendermint/vm/topdown/src/error.rs
+++ b/fendermint/vm/topdown/src/error.rs
@@ -15,4 +15,8 @@ pub enum Error {
     ParentChainReorgDetected,
     #[error("Cannot query parent at height {1}: {0}")]
     CannotQueryParent(String, BlockHeight),
+    #[error("Cannot query parent with hash {1}: {0}")]
+    CannotQueryParentHash(String, String),
+    #[error("Number of topdown messages incorrect at height {0}, expected: {1}, found: {2}")]
+    TopDownMsgsLengthIncorrect(BlockHeight, u64, u64),
 }

--- a/fendermint/vm/topdown/src/finality/fetch.rs
+++ b/fendermint/vm/topdown/src/finality/fetch.rs
@@ -334,6 +334,13 @@ mod tests {
                 block_hash: r.0,
             })
         }
+
+        async fn get_top_down_nonce(
+            &self,
+            _block_hash: &[u8],
+        ) -> anyhow::Result<TopDownQueryPayload<u64>> {
+            todo!()
+        }
     }
 
     fn new_provider(

--- a/fendermint/vm/topdown/src/finality/mod.rs
+++ b/fendermint/vm/topdown/src/finality/mod.rs
@@ -88,6 +88,13 @@ mod tests {
                 block_hash: vec![],
             })
         }
+
+        async fn get_top_down_nonce(
+            &self,
+            _block_hash: &[u8],
+        ) -> anyhow::Result<TopDownQueryPayload<u64>> {
+            todo!()
+        }
     }
 
     fn mocked_agent_proxy() -> Arc<MockedParentQuery> {

--- a/fendermint/vm/topdown/src/proxy.rs
+++ b/fendermint/vm/topdown/src/proxy.rs
@@ -36,6 +36,12 @@ pub trait ParentQueryProxy {
         &self,
         height: BlockHeight,
     ) -> anyhow::Result<TopDownQueryPayload<Vec<StakingChangeRequest>>>;
+
+    /// Get the top down message nonce at the target block
+    async fn get_top_down_nonce(
+        &self,
+        block_hash: &[u8],
+    ) -> anyhow::Result<TopDownQueryPayload<u64>>;
 }
 
 /// The proxy to the subnet's parent
@@ -114,5 +120,14 @@ impl ParentQueryProxy for IPCProviderProxy {
                     .sort_by(|a, b| a.configuration_number.cmp(&b.configuration_number));
                 v
             })
+    }
+
+    async fn get_top_down_nonce(
+        &self,
+        block_hash: &[u8],
+    ) -> anyhow::Result<TopDownQueryPayload<u64>> {
+        self.ipc_provider
+            .get_top_down_nonce(&self.child_subnet, block_hash)
+            .await
     }
 }

--- a/ipc/cli/src/commands/crossmsg/mod.rs
+++ b/ipc/cli/src/commands/crossmsg/mod.rs
@@ -13,6 +13,7 @@ use fund::FundArgs;
 use propagate::PropagateArgs;
 use release::ReleaseArgs;
 
+use crate::commands::crossmsg::topdown_cross::{GetTopDownMsgNonce, GetTopDownMsgNonceArgs};
 use clap::{Args, Subcommand};
 
 pub mod fund;
@@ -38,6 +39,7 @@ impl CrossMsgsCommandsArgs {
             Commands::PreRelease(args) => PreRelease::handle(global, args).await,
             Commands::Propagate(args) => Propagate::handle(global, args).await,
             Commands::ListTopdownMsgs(args) => ListTopdownMsgs::handle(global, args).await,
+            Commands::ListTopdownNonce(args) => GetTopDownMsgNonce::handle(global, args).await,
             Commands::ParentFinality(args) => LatestParentFinality::handle(global, args).await,
         }
     }
@@ -52,5 +54,6 @@ pub(crate) enum Commands {
     PreRelease(PreReleaseArgs),
     Propagate(PropagateArgs),
     ListTopdownMsgs(ListTopdownMsgsArgs),
+    ListTopdownNonce(GetTopDownMsgNonceArgs),
     ParentFinality(LatestParentFinalityArgs),
 }

--- a/ipc/cli/src/commands/crossmsg/topdown_cross.rs
+++ b/ipc/cli/src/commands/crossmsg/topdown_cross.rs
@@ -83,3 +83,33 @@ pub(crate) struct LatestParentFinalityArgs {
     #[arg(long, help = "The subnet id to check parent finality")]
     pub subnet: String,
 }
+
+#[derive(Debug, Args)]
+#[command(about = "Get the top down message nonce at block")]
+pub(crate) struct GetTopDownMsgNonceArgs {
+    #[arg(long, help = "The subnet id to check")]
+    pub subnet: String,
+    #[arg(long, help = "The block hash")]
+    pub block_hash: String,
+}
+
+/// The command to get top down message nonce
+pub(crate) struct GetTopDownMsgNonce;
+
+#[async_trait]
+impl CommandLineHandler for GetTopDownMsgNonce {
+    type Arguments = GetTopDownMsgNonceArgs;
+
+    async fn handle(global: &GlobalArguments, arguments: &Self::Arguments) -> anyhow::Result<()> {
+        log::debug!("get top down message nonce: {:?}", arguments);
+
+        let provider = get_ipc_provider(global)?;
+        let subnet = SubnetID::from_str(&arguments.subnet)?;
+        let block_hash = hex::decode(&arguments.block_hash)?;
+
+        let nonce = provider.get_top_down_nonce(&subnet, &block_hash).await?;
+        println!("{}", nonce.value);
+
+        Ok(())
+    }
+}

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -50,6 +50,7 @@ use ipc_api::subnet_id::SubnetID;
 use ipc_wallet::{EthKeyAddress, EvmKeyStore, PersistentKeyStore};
 use num_traits::ToPrimitive;
 use std::result;
+use tracing::log;
 
 pub type DefaultSignerMiddleware = SignerMiddleware<Provider<Http>, Wallet<SigningKey>>;
 
@@ -863,9 +864,12 @@ impl SubnetManager for EthSubnetManager {
             .call()
             .await?;
 
-        if !exists {
-            return Err(anyhow!("subnet does not exists"));
-        }
+        let nonce = if !exists {
+            log::warn!("subnet does not exists at block hash, return 0 nonce");
+            0
+        } else {
+            nonce
+        };
 
         Ok(TopDownQueryPayload {
             value: nonce,

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -166,6 +166,12 @@ pub trait SubnetManager: Send + Sync + TopDownFinalityQuery + BottomUpCheckpoint
         public_keys: &[Vec<u8>],
         federated_power: &[u128],
     ) -> Result<ChainEpoch>;
+
+    async fn get_top_down_nonce(
+        &self,
+        subnet: &SubnetID,
+        block_hash: &[u8],
+    ) -> Result<TopDownQueryPayload<u64>>;
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This is the start of a series of updates to enhance topdown finality robustness and accuracy. 

This PR adds a simple check to ensure the number of top down messages received is actually correct. The purpose of this is that after running a few tests, some RPC nodes, especially when querying historical data, might not return events completely. Adding this check will alert this from happening and let throws an error/stops parent syncer for node operator to perform checks.

As the gateway already exposes the applied top down nonce by subnet, one just needs to query the consecutive historical state to deduce the number of top down messages.

Draft: updating unit tests.