### PR TITLE
Fix add_licence script on mac

### DIFF
--- a/scripts/add_license.sh
+++ b/scripts/add_license.sh
@@ -5,7 +5,7 @@
 COPYRIGHT_TXT=$(dirname $0)/copyright.txt
 
 # Any year is fine. We can update the year as a single PR in all files that have it up to last year.
-PAT_PL=".*// Copyright 202(1|2)-202\d Protocol Labs.*"
+PAT_PL=".*// Copyright 202(1|2)-202[0-9] Protocol Labs.*"
 PAT_SPDX="/*// SPDX-License-Identifier: .*"
 
 # Look at enough lines so that we can include multiple copyright holders.
@@ -40,7 +40,7 @@ for file in $(git grep --cached -Il '' -- '*.rs'); do
 		continue
 	fi
   header=$(head -$LINES "$file")
-	if ! echo "$header" | grep -q -P "$PAT_SPDX"; then
+	if ! echo "$header" | grep -q -E "$PAT_SPDX"; then
 		echo "$file was missing header"
 		cat $COPYRIGHT_TXT "$file" > temp
 		mv temp "$file"
@@ -56,7 +56,7 @@ for file in $(git diff --diff-filter=d --name-only origin/main -- '*.rs'); do
 		continue
 	fi
   header=$(head -$LINES "$file")
-	if ! echo "$header" | grep -q -P "$PAT_PL"; then
+	if ! echo "$header" | grep -q -E "$PAT_PL"; then
 		echo "$file was missing Protocol Labs"
 		head -1 $COPYRIGHT_TXT > temp
 		cat "$file" >> temp


### PR DESCRIPTION
Recently Macos switched to BSD grep which does not have the -P option.

Running for example `make lint` on Macos resulted in making changes to all source files since it thought they had missing header which can take a while to fix when you have other local changes.

Example:

```
10:53@Fridriks-MBP ~/workspace/ipc-monorepo$ make lint
./scripts/add_license.sh
grep: invalid option -- P
usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]
fendermint/abci/examples/kvstore.rs was missing header
grep: invalid option -- P
usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]
fendermint/abci/src/application.rs was missing header
grep: invalid option -- P
...
```

Afterwards, it had changed all source files in the repo:

```
10:54@Fridriks-MBP ~/workspace/ipc-monorepo$ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   fendermint/abci/examples/kvstore.rs
	modified:   fendermint/abci/src/application.rs
	modified:   fendermint/abci/src/lib.rs
	modified:   fendermint/abci/src/util.rs
	modified:   fendermint/actors/build.rs
	modified:   fendermint/actors/chainmetadata/src/actor.rs
	modified:   fendermint/actors/chainmetadata/src/lib.rs
	modified:   fendermint/actors/chainmetadata/src/shared.rs
	modified:   fendermint/actors/eam/src/lib.rs
  ...
```