### PR TITLE
ipc-cli subnet join to extract pubkey from the wallet -- From argument fixes 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5060,6 +5060,7 @@ dependencies = [
  "ipc-types",
  "ipc-wallet",
  "ipc_actors_abis",
+ "libsecp256k1",
  "log",
  "num-derive 0.3.3",
  "num-traits",

--- a/ipc/provider/Cargo.toml
+++ b/ipc/provider/Cargo.toml
@@ -14,6 +14,7 @@ async-trait = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true }
 
+libsecp256k1 = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
fixes issue brought up by @fridrik01 regarding the "from" argument being optional. 

code was moved from ipc/cli/src/commands/subnet/join.rs to ipc/provider/src/lib.rs and looks cleaner