### PR TITLE
ENG-854: Limit consensus concurrency to 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,6 +2913,7 @@ dependencies = [
  "tendermint-proto 0.31.1",
  "tendermint-rpc",
  "tokio",
+ "tower",
  "tower-abci",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,6 +214,7 @@ frc42_dispatch = "6.0.0"
 
 # Using the same tendermint-rs dependency as tower-abci. From both we are interested in v037 modules.
 tower-abci = { version = "0.7" }
+tower = { version = "0.4" }
 tendermint = { version = "0.31", features = ["secp256k1"] }
 tendermint-config = "0.33.0"
 tendermint-rpc = { version = "0.31", features = [

--- a/fendermint/abci/examples/kvstore.rs
+++ b/fendermint/abci/examples/kvstore.rs
@@ -4,12 +4,17 @@
 
 use async_stm::{atomically, TVar};
 use async_trait::async_trait;
-use fendermint_abci::{AbciResult as Result, Application, ApplicationService};
+use fendermint_abci::{
+    util::take_until_max_size, AbciResult as Result, Application, ApplicationService,
+};
 use structopt::StructOpt;
 use tendermint::abci::{request, response, Event, EventAttributeIndexExt};
 use tower::ServiceBuilder;
 use tower_abci::{split, v037::Server};
 use tracing::{info, Level};
+
+// For the sake of example, sho the relationship between buffering, concurrency and block size.
+const MAX_TXNS: usize = 100;
 
 /// In-memory, hashmap-backed key-value store ABCI application.
 ///
@@ -64,6 +69,29 @@ impl Application for KVStore {
             value: value.into_bytes().into(),
             ..Default::default()
         })
+    }
+
+    async fn prepare_proposal(
+        &self,
+        request: request::PrepareProposal,
+    ) -> Result<response::PrepareProposal> {
+        let mut txs = take_until_max_size(request.txs, request.max_tx_bytes.try_into().unwrap());
+
+        // Enfore transaciton limit so that we don't have a problem with buffering.
+        txs.truncate(MAX_TXNS);
+
+        Ok(response::PrepareProposal { txs })
+    }
+
+    async fn process_proposal(
+        &self,
+        request: request::ProcessProposal,
+    ) -> Result<response::ProcessProposal> {
+        if request.txs.len() > MAX_TXNS {
+            Ok(response::ProcessProposal::Reject)
+        } else {
+            Ok(response::ProcessProposal::Accept)
+        }
     }
 
     async fn deliver_tx(&self, request: request::DeliverTx) -> Result<response::DeliverTx> {
@@ -158,9 +186,12 @@ async fn main() {
     let server = Server::builder()
         .consensus(
             // Because message handling is asynchronous, we must limit the concurrency of `consensus` to 1,
-            // otherwise transactions can be executed in an arbitrary order.
+            // otherwise transactions can be executed in an arbitrary order. `buffer` is required to avoid
+            // deadlocks in the connection handler; in ABCI++ (pre 2.0) we need to allow for all potential
+            // messages in the block, plus the surrounding begin/end/commit methods to be pipelined. The
+            // message limit is enforced in proposal preparation and processing.
             ServiceBuilder::new()
-                .buffer(100)
+                .buffer(MAX_TXNS + 3)
                 .concurrency_limit(1)
                 .service(consensus),
         )

--- a/fendermint/abci/src/application.rs
+++ b/fendermint/abci/src/application.rs
@@ -160,6 +160,7 @@ where
         // See https://github.com/tower-rs/tower/issues/547
         let app: A = std::mem::replace(&mut self.0, app);
 
+        // Because this is async, make sure the `Consensus` service is wrapped in a concurrency limiting Tower layer.
         let res = async move {
             let res = match req {
                 Request::Echo(r) => Response::Echo(log_error(app.echo(r).await)?),

--- a/fendermint/app/Cargo.toml
+++ b/fendermint/app/Cargo.toml
@@ -34,6 +34,7 @@ tendermint-config = { workspace = true }
 tendermint-rpc = { workspace = true }
 tendermint-proto = { workspace = true }
 tokio = { workspace = true }
+tower = { workspace = true }
 tower-abci = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }

--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -31,10 +31,15 @@ halt_height = 0
 # kind =
 
 [abci]
-# Number of concurrent requests allowed to reach the application.
+# Number of concurrent requests allowed to be _submitted_ to the application.
+# Because message handling is asynhronous, this doesn't make any difference
+# in practice, because they will be executed concurrently, unless affected
+# by Tower layers applied in the application root.
 bound = 1
-# Buffer size for consensus messages.
-consensus_buffer = 1000
+# Maximum number of messages allowed in a block, which also affects the
+# buffer size applied on the consensus service. It is important to keep
+# those in-sync to avoid potential deadlocks with message handling in Tower.
+block_max_msgs = 1000
 
 [abci.listen]
 # Only accept connections from Tendermint, assumed to be running locally.

--- a/fendermint/app/config/default.toml
+++ b/fendermint/app/config/default.toml
@@ -33,6 +33,8 @@ halt_height = 0
 [abci]
 # Number of concurrent requests allowed to reach the application.
 bound = 1
+# Buffer size for consensus messages.
+consensus_buffer = 1000
 
 [abci.listen]
 # Only accept connections from Tendermint, assumed to be running locally.

--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -91,6 +91,8 @@ pub struct AbciSettings {
     pub listen: SocketAddress,
     /// Queue size for each ABCI component.
     pub bound: usize,
+    /// Buffer size for consensus messages.
+    pub consensus_buffer: usize,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -91,8 +91,8 @@ pub struct AbciSettings {
     pub listen: SocketAddress,
     /// Queue size for each ABCI component.
     pub bound: usize,
-    /// Buffer size for consensus messages.
-    pub consensus_buffer: usize,
+    /// Maximum number of messages allowed in a block.
+    pub block_max_msgs: usize,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -336,6 +336,7 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
             // Not limiting the concurrency to 1 can lead to transactions being applied
             // in different order across nodes.
             ServiceBuilder::new()
+                .buffer(settings.abci.consensus_buffer)
                 .concurrency_limit(1)
                 .service(consensus),
         )


### PR DESCRIPTION
Adds a `tower` service layer that limits the concurrent requests going to the `consensus` connection to 1, which should hopefully solve the issue of transactions being applied in a different order than they appear in the block. This is the actual fix for a [problem we had with end_block](https://github.com/consensus-shipyard/ipc/commit/4b2c90b2cf053c85d6ff684e4ae7d6b228c31eb9). 


### Buffering

A buffer is added so that the other channels aren't blocked while `consensus` isn't ready. See [here](https://docs.rs/tower/latest/tower/struct.ServiceBuilder.html#order) for example. 

To be honest I don't understand this - this limit only affects the `Connection`, but a single `Connection` instance effectively only serves one kind of request, because CometBFT opens 4 different sockets to the service. By the looks of it it should wait, and buffering should not be required, yet the end-to-end tests failed when there wasn't a buffer :eyes: 

Ah, one reason for this is is that if there is no `buffer`, then while `Connection` is waiting to submit the next request [here](https://github.com/penumbra-zone/tower-abci/blob/dc2d5efee8cd748b4d816563002c3f569d12b55a/src/v037/server.rs#L240), it cannot process the asynchronously executing responses [here](https://github.com/penumbra-zone/tower-abci/blob/dc2d5efee8cd748b4d816563002c3f569d12b55a/src/v037/server.rs#L274). So the reason the tests might fail is that if CometBFT sends multiple requests in a row (which it does, pipelined) such as `[begin, deliver_tx, end, commit]` for the deployment that failed, then this happens:
1. Receive `deliver_tx`, take a permit, [put it in the response](https://github.com/tower-rs/tower/blob/39adf5c509a1b2141f679654d8317524ca96b58b/tower/src/limit/concurrency/service.rs#L92)
2. Receive `end`, wait for the permit
3. Now, even though `deliver_tx` is ready, it cannot be processed by `Connection::run` because it's blocked waiting for the permit, therefore it won't free the permit inside the `Response`, and we have a deadlock. 

By adding a buffer, we unblock 2, which unblocks 3, and replenishes the permit. 

Thus it is important that the buffer size is at least as much as the maximum number of messages in a block, so the settings have been extended with a default limit of 1000, which is enforced in `prepare_proposal` and `process_proposal`.