### PR TITLE
RPC fix: Explorers show premiums sent to miner

### DIFF
--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -444,6 +444,10 @@ where
             tx.transaction_index = Some(et::U64::from(res.index));
             tx.block_hash = Some(et::H256::from_slice(header.header.hash().as_bytes()));
             tx.block_number = Some(et::U64::from(res.height.value()));
+
+            // Fendermint does not actually send premiums to miners at this time
+            // The value of max_priority_fee_per_gas is set to zero to reflect that
+            tx.max_priority_fee_per_gas = 0;
             Ok(Some(tx))
         } else {
             error(ExitCode::USR_ILLEGAL_ARGUMENT, "incompatible transaction")


### PR DESCRIPTION
closes ENG-789

Explorers show premiums sent to miner because the RPC exposes the max_priority_fee which currently isn't used to fund miners. 

This provides a first pass at upgrading the system by modifying the output of the json rpc to overwrite max_priority_fee_per_gas to zero. Future PRs will enable miners to collect the premiums.

