### PR TITLE
fix npm audit - upgrade dep

### DIFF
--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -10005,9 +10005,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "5.28.3",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-            "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+            "version": "5.28.4",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+            "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
             "dependencies": {
                 "@fastify/busboy": "^2.0.0"
             },


### PR DESCRIPTION
fixes ENG-861
running `check-audit --omit dev --audit-level critical fix` created the update