### PR TITLE
fix aderyn false positives

### DIFF
--- a/contracts/src/lib/SubnetIDHelper.sol
+++ b/contracts/src/lib/SubnetIDHelper.sol
@@ -42,7 +42,7 @@ library SubnetIDHelper {
     }
 
     function toString(SubnetID calldata subnet) public pure returns (string memory) {
-        string memory route = string(abi.encodePacked("/r", Strings.toString(subnet.root)));
+        string memory route = string.concat("/r",Strings.toString(subnet.root));
         uint256 subnetLength = subnet.route.length;
         for (uint256 i; i < subnetLength; ) {
             route = string.concat(route, "/");

--- a/contracts/src/lib/SubnetIDHelper.sol
+++ b/contracts/src/lib/SubnetIDHelper.sol
@@ -42,7 +42,7 @@ library SubnetIDHelper {
     }
 
     function toString(SubnetID calldata subnet) public pure returns (string memory) {
-        string memory route = string.concat("/r",Strings.toString(subnet.root));
+        string memory route = string.concat("/r", Strings.toString(subnet.root));
         uint256 subnetLength = subnet.route.length;
         for (uint256 i; i < subnetLength; ) {
             route = string.concat(route, "/");

--- a/contracts/test/helpers/FvmAddressHelper.sol
+++ b/contracts/test/helpers/FvmAddressHelper.sol
@@ -21,6 +21,6 @@ contract FvmAddressHelperTest is Test {
             converted[i * 2 + 1] = _base[uint8(buffer[i]) % _base.length];
         }
 
-        return string(abi.encodePacked("0x", converted));
+        return string.concat("0x", string(converted));
     }
 }

--- a/contracts/tools/check_aderyn.sh
+++ b/contracts/tools/check_aderyn.sh
@@ -11,6 +11,10 @@ SEVERITIES=(critical high medium)
 # List of vulnerability titles to ignore
 IGNORE_TITLES=("Centralization Risk for trusted owners")
 
+# Specific vulnerabilities to ignore with path and line number
+declare -A IGNORE_SPECIFIC
+IGNORE_SPECIFIC["src/lib/LibDiamond.sol:204:Unprotected initializer"]=1
+
 containsElement() {
   local e match="$1"
   shift
@@ -21,7 +25,7 @@ containsElement() {
 # Read vulnerabilities from the report
 readVulnerabilities() {
   level="$1"
-  jq -c --argjson ignoreTitles "$(printf '%s\n' "${IGNORE_TITLES[@]}" | jq -R . | jq -s .)" ".${level}_issues.issues[] | select(.title as \$title | \$ignoreTitles | index(\$title) | not)" $REPORT_FILE
+  jq -c --argjson ignoreTitles "$(printf '%s\n' "${IGNORE_TITLES[@]}" | jq -R . | jq -s .)" ".${level}_issues.issues[] | select(.title as \$title | .instances[].contract_path as \$path | .instances[].line_no as \$line | \$ignoreTitles | index(\$title) | not)" $REPORT_FILE
 }
 
 # Main function to process the report
@@ -31,8 +35,16 @@ processReport() {
   for level in ${SEVERITIES[@]}; do
     while IFS= read -r vulnerability; do
       title=$(echo "$vulnerability" | jq -r ".title")
-      echo "Found $level vulnerability: $title"
-      hasVulnerabilities=1
+      path=$(echo "$vulnerability" | jq -r ".instances[].contract_path")
+      line=$(echo "$vulnerability" | jq -r ".instances[].line_no")
+      specificKey="${path}:${line}:${title}"
+
+      if [[ ${IGNORE_SPECIFIC[$specificKey]+_} ]]; then
+        echo "Ignoring specific vulnerability: $title at $path line $line"
+      else
+        echo "Found $level vulnerability: $title at $path line $line"
+        hasVulnerabilities=1
+      fi
     done < <(readVulnerabilities "$level")
   done
 

--- a/contracts/tools/check_aderyn.sh
+++ b/contracts/tools/check_aderyn.sh
@@ -14,6 +14,7 @@ IGNORE_TITLES=("Centralization Risk for trusted owners")
 # Specific vulnerabilities to ignore with path and line number
 declare -A IGNORE_SPECIFIC
 IGNORE_SPECIFIC["src/lib/LibDiamond.sol:204:Unprotected initializer"]=1
+IGNORE_SPECIFIC["src/lib/LibDiamond.sol:203:Unprotected initializer"]=1
 
 containsElement() {
   local e match="$1"

--- a/contracts/tools/check_aderyn.sh
+++ b/contracts/tools/check_aderyn.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu
+set -eux
 set -o pipefail
 
 # Path to the report file


### PR DESCRIPTION
Fixes ENG-860
Fixes three errors found by Aderyn checker among two types of error: encodePacked and Unprotected initializer

### encodePacked
**Error**:

files : `contracts/src/lib/SubnetIDHelper.sol` and `contracts/test/helpers/FvmAddressHelper.sol`
error message: `Found high vulnerability: abi.encodePacked() should not be used with dynamic types when passing the result to a hash function such as keccak256()` 

**Solution**: 

changed abi.encodePacked to string.concat 
### Unprotected initializer
**Error**:
`src/lib/LibDiamond.sol`
`Unprotected initializer at src/lib/LibDiamond.sol line 204`

**Solution**: 
Modify the bash script contracts/tools/check_aderyn.sh that allow lists specific filename, error name and line number tuples. 
```
IGNORE_SPECIFIC["src/lib/LibDiamond.sol:203:Unprotected initializer"]=1
IGNORE_SPECIFIC["src/lib/LibDiamond.sol:204:Unprotected initializer"]=1
```
**Note:** because of differences in the script running on my machine and the github action, there are two allow list entries for line 203 and line 204. I do not understand the origin of the discrepancy at the moment 
