### PR TITLE
STORAGE: KVRead::iterate

### DIFF
--- a/fendermint/rocksdb/src/kvstore.rs
+++ b/fendermint/rocksdb/src/kvstore.rs
@@ -138,6 +138,28 @@ where
             }
         })
     }
+
+    fn iter<K, V>(&self, ns: &S::Namespace) -> impl Iterator<Item = KVResult<(K, V)>>
+    where
+        S: Decode<K> + Decode<V>,
+        <S as KVStore>::Repr: Ord + 'static,
+    {
+        self.cache
+            .with_cf_handle(ns.as_ref(), |cf| {
+                let it = self.snapshot.iterator_cf(cf, rocksdb::IteratorMode::Start);
+
+                let it = it.map(|res| res.map_err(to_kv_error)).map(|res| {
+                    res.and_then(|(k, v)| {
+                        let k: K = S::from_repr(&k.to_vec())?;
+                        let v: V = S::from_repr(&v.to_vec())?;
+                        Ok((k, v))
+                    })
+                });
+
+                Ok(it)
+            })
+            .expect("just wrapped into ok")
+    }
 }
 
 impl<'a, S> KVRead<S> for RocksDbWriteTx<'a>
@@ -159,6 +181,28 @@ where
                 None => Ok(None),
             }
         })
+    }
+
+    fn iter<K, V>(&self, ns: &S::Namespace) -> impl Iterator<Item = KVResult<(K, V)>>
+    where
+        S: Decode<K> + Decode<V>,
+        <S as KVStore>::Repr: Ord + 'static,
+    {
+        self.cache
+            .with_cf_handle(ns.as_ref(), |cf| {
+                let it = self.tx.iterator_cf(cf, rocksdb::IteratorMode::Start);
+
+                let it = it.map(|res| res.map_err(to_kv_error)).map(|res| {
+                    res.and_then(|(k, v)| {
+                        let k: K = S::from_repr(&k.to_vec())?;
+                        let v: V = S::from_repr(&v.to_vec())?;
+                        Ok((k, v))
+                    })
+                });
+
+                Ok(it)
+            })
+            .expect("just wrapped into ok")
     }
 }
 

--- a/fendermint/rocksdb/src/kvstore.rs
+++ b/fendermint/rocksdb/src/kvstore.rs
@@ -139,7 +139,7 @@ where
         })
     }
 
-    fn iter<K, V>(&self, ns: &S::Namespace) -> impl Iterator<Item = KVResult<(K, V)>>
+    fn iterate<K, V>(&self, ns: &S::Namespace) -> impl Iterator<Item = KVResult<(K, V)>>
     where
         S: Decode<K> + Decode<V>,
         <S as KVStore>::Repr: Ord + 'static,
@@ -183,7 +183,7 @@ where
         })
     }
 
-    fn iter<K, V>(&self, ns: &S::Namespace) -> impl Iterator<Item = KVResult<(K, V)>>
+    fn iterate<K, V>(&self, ns: &S::Namespace) -> impl Iterator<Item = KVResult<(K, V)>>
     where
         S: Decode<K> + Decode<V>,
         <S as KVStore>::Repr: Ord + 'static,

--- a/fendermint/storage/src/im.rs
+++ b/fendermint/storage/src/im.rs
@@ -160,6 +160,8 @@ where
     where
         S: Decode<K> + Decode<V>,
         <S as KVStore>::Repr: Ord + 'static,
+        K: 'static,
+        V: 'static,
     {
         if let Some(m) = self.data.get(ns) {
             let mut items = m.iter().map(|(k, v)| (k, v.as_ref())).collect::<Vec<_>>();

--- a/fendermint/storage/src/im.rs
+++ b/fendermint/storage/src/im.rs
@@ -156,7 +156,7 @@ where
         Ok(None)
     }
 
-    fn iter<K, V>(&self, ns: &S::Namespace) -> impl Iterator<Item = KVResult<(K, V)>>
+    fn iterate<K, V>(&self, ns: &S::Namespace) -> impl Iterator<Item = KVResult<(K, V)>>
     where
         S: Decode<K> + Decode<V>,
         <S as KVStore>::Repr: Ord + 'static,

--- a/fendermint/storage/src/im.rs
+++ b/fendermint/storage/src/im.rs
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use std::{
     hash::Hash,
+    marker::PhantomData,
     mem,
     sync::{Arc, Mutex, MutexGuard},
     thread,
 };
 
 use crate::{
-    Decode, Encode, KVRead, KVReadable, KVResult, KVStore, KVTransaction, KVWritable, KVWrite,
+    Decode, Encode, KVError, KVRead, KVReadable, KVResult, KVStore, KVTransaction, KVWritable,
+    KVWrite,
 };
 
 /// Read-only mode.
@@ -16,6 +18,7 @@ pub struct Read;
 /// Read-write mode.
 pub struct Write;
 
+/// Immutable data multimap.
 type IDataMap<S> = im::HashMap<
     <S as KVStore>::Namespace,
     im::HashMap<<S as KVStore>::Repr, Arc<<S as KVStore>::Repr>>,
@@ -152,6 +155,21 @@ where
         }
         Ok(None)
     }
+
+    fn iter<K, V>(&self, ns: &S::Namespace) -> impl Iterator<Item = KVResult<(K, V)>>
+    where
+        S: Decode<K> + Decode<V>,
+        <S as KVStore>::Repr: Ord + 'static,
+    {
+        if let Some(m) = self.data.get(ns) {
+            let mut items = m.iter().map(|(k, v)| (k, v.as_ref())).collect::<Vec<_>>();
+            items.sort_by(|a, b| a.0.cmp(b.0));
+
+            KVIter::<S, K, V>::new(items)
+        } else {
+            KVIter::empty()
+        }
+    }
 }
 
 impl<'a, S: KVStore> KVWrite<S> for Transaction<'a, S, Write>
@@ -180,6 +198,48 @@ where
             self.data.insert(ns.clone(), m);
         }
         Ok(())
+    }
+}
+
+struct KVIter<'a, S: KVStore, K, V> {
+    items: Vec<(&'a S::Repr, &'a S::Repr)>,
+    next: usize,
+    phantom_v: PhantomData<V>,
+    phantom_k: PhantomData<K>,
+}
+
+impl<'a, S, K, V> KVIter<'a, S, K, V>
+where
+    S: KVStore,
+{
+    pub fn new(items: Vec<(&'a S::Repr, &'a S::Repr)>) -> Self {
+        KVIter {
+            items,
+            next: 0,
+            phantom_v: PhantomData,
+            phantom_k: PhantomData,
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self::new(vec![])
+    }
+}
+
+impl<'a, S, K, V> Iterator for KVIter<'a, S, K, V>
+where
+    S: KVStore + Decode<K> + Decode<V>,
+{
+    type Item = Result<(K, V), KVError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((k, v)) = self.items.get(self.next) {
+            self.next += 1;
+            let kv = S::from_repr(k).and_then(|k| S::from_repr(v).map(|v| (k, v)));
+            Some(kv)
+        } else {
+            None
+        }
     }
 }
 

--- a/fendermint/storage/src/lib.rs
+++ b/fendermint/storage/src/lib.rs
@@ -66,6 +66,12 @@ pub trait KVRead<S: KVStore> {
     fn get<K, V>(&self, ns: &S::Namespace, k: &K) -> KVResult<Option<V>>
     where
         S: Encode<K> + Decode<V>;
+
+    fn iter<K, V>(&self, ns: &S::Namespace) -> impl Iterator<Item = KVResult<(K, V)>>
+    where
+        S: Decode<K> + Decode<V>,
+        S::Repr: Ord,
+        <S as KVStore>::Repr: 'static;
 }
 
 /// Operations available on a write transaction.

--- a/fendermint/storage/src/lib.rs
+++ b/fendermint/storage/src/lib.rs
@@ -67,7 +67,10 @@ pub trait KVRead<S: KVStore> {
     where
         S: Encode<K> + Decode<V>;
 
-    fn iter<K, V>(&self, ns: &S::Namespace) -> impl Iterator<Item = KVResult<(K, V)>>
+    /// Iterate items in the namespace ordered by their representation.
+    ///
+    /// TODO: Add parameters for iteration direction and bounds.
+    fn iterate<K, V>(&self, ns: &S::Namespace) -> impl Iterator<Item = KVResult<(K, V)>>
     where
         K: 'static,
         V: 'static,
@@ -164,7 +167,7 @@ where
         kv.delete(&self.ns, k)
     }
 
-    pub fn iter<'a, 'b>(
+    pub fn iterate<'a, 'b>(
         &'a self,
         kv: &'b impl KVRead<S>,
     ) -> impl Iterator<Item = KVResult<(K, V)>> + 'b
@@ -175,6 +178,6 @@ where
         V: 'static,
         'a: 'b,
     {
-        kv.iter::<K, V>(&self.ns)
+        kv.iterate::<K, V>(&self.ns)
     }
 }


### PR DESCRIPTION
Adds an `iterate` method to the `KVRead` abstraction if the `KVStore::Repr` type implements `Ord`. 

It could be extended to take a parameter like the RocksDB implementation to say whether we want to iterate from the start, the end, from a specific key, or in between two keys; perhaps `iterate` could take parameters and a `KVCollection::iter` could just do the default in-order one. Here I just wanted to see how it can be implemented and where to add it.

This is a support PR for https://github.com/consensus-shipyard/ipc/pull/914 to implement initialisation from the storage.