### PR TITLE
Fixes E2E tests on Apple Silicon

### DIFF
--- a/fendermint/testing/graph-test/Makefile.toml
+++ b/fendermint/testing/graph-test/Makefile.toml
@@ -57,7 +57,7 @@ npm run graph-node
 
 echo "Waiting for Graph node to start..."
 # Notice that subgraph node does takes a while to spin up
-sleep 30s
+sleep 30
 
 npm run create-local
 npm run deploy-local

--- a/fendermint/testing/graph-test/subgraph/graph-node/docker-compose.yaml
+++ b/fendermint/testing/graph-test/subgraph/graph-node/docker-compose.yaml
@@ -2,6 +2,7 @@ version: '3'
 services:
   graph-node:
     image: graphprotocol/graph-node:v0.27.0
+    platform: linux/amd64
     ports:
       - '8000:8000'
       - '8001:8001'
@@ -24,6 +25,7 @@ services:
       GRAPH_ETHEREUM_GENESIS_BLOCK_NUMBER: 1
   ipfs:
     image: ipfs/go-ipfs:v0.10.0
+    platform: linux/amd64
     ports:
       - '5001:5001'
   postgres:


### PR DESCRIPTION
Fixes the issues that I've run into trying to run the e2e tests on my new Macbook. 
I was getting errors running `make e2e` under the `fendermint` directory. 

[] Specify `amd/64` platform to Docker when pulling the go-ipfs and graph-node images
[] Unix `sleep 30` instead of GNU `sleep 30s` (without specifying a unit, it will default to seconds anyways) 