### PR TITLE
Including builtin and custom actor bundles in genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3263,6 +3263,7 @@ version = "0.1.0"
 dependencies = [
  "cid",
  "fvm_shared",
+ "hex",
  "ipc-api",
  "num-traits",
  "serde",

--- a/fendermint/app/options/src/genesis.rs
+++ b/fendermint/app/options/src/genesis.rs
@@ -204,4 +204,12 @@ pub struct GenesisFromParentArgs {
     /// Number of decimals to use during converting FIL to Power.
     #[arg(long, default_value = "3")]
     pub power_scale: i8,
+
+    /// The builtin actors bundle CAR file path.
+    #[arg(long)]
+    pub builtin_bundle_path: PathBuf,
+
+    /// The custom actors bundle CAR file path.
+    #[arg(long)]
+    pub custom_bundle_path: PathBuf,
 }

--- a/fendermint/app/src/app.rs
+++ b/fendermint/app/src/app.rs
@@ -461,7 +461,8 @@ where
                 self.multi_engine.clone(),
                 actor_bundle.builtin(),
                 actor_bundle.custom(),
-            ).await
+            )
+            .await
         } else {
             let bundle = &self.builtin_actors_bundle;
             let bundle = std::fs::read(bundle)
@@ -477,7 +478,8 @@ where
                 self.multi_engine.clone(),
                 &bundle,
                 &custom_actors_bundle,
-            ).await
+            )
+            .await
         }
         .context("failed to create genesis state")?;
 

--- a/fendermint/app/src/cmd/genesis.rs
+++ b/fendermint/app/src/cmd/genesis.rs
@@ -11,8 +11,8 @@ use std::path::PathBuf;
 use fendermint_vm_actor_interface::eam::EthAddress;
 use fendermint_vm_core::{chainid, Timestamp};
 use fendermint_vm_genesis::{
-    ipc, Account, Actor, ActorMeta, Collateral, Genesis, Multisig, PermissionMode, SignerAddr,
-    Validator, ValidatorKey,
+    ipc, Account, Actor, ActorMeta, Collateral, Genesis, GenesisActorBundles, Multisig,
+    PermissionMode, SignerAddr, Validator, ValidatorKey,
 };
 
 use crate::cmd;
@@ -46,6 +46,7 @@ cmd! {
       validators: Vec::new(),
       accounts: Vec::new(),
       eam_permission_mode: PermissionMode::Unrestricted,
+      actors: None,
       ipc: None,
     };
 
@@ -312,6 +313,12 @@ async fn new_genesis_from_parent(
             active_validators_limit: genesis_info.active_validators_limit,
         },
     };
+
+    let builtin_bundle = std::fs::read(&args.builtin_bundle_path)
+        .map_err(|e| anyhow!("failed to load builtin bundle CAR: {e}"))?;
+    let custom_actors_bundle = std::fs::read(&args.custom_bundle_path)
+        .map_err(|e| anyhow!("failed to load custom actor bundle CAR: {e}"))?;
+
     let mut genesis = Genesis {
         // We set the genesis epoch as the genesis timestamp so it can be
         // generated deterministically by all participants
@@ -325,6 +332,10 @@ async fn new_genesis_from_parent(
         validators: Vec::new(),
         accounts: Vec::new(),
         eam_permission_mode: PermissionMode::Unrestricted,
+        actors: Some(GenesisActorBundles::V1 {
+            builtin: builtin_bundle,
+            custom: custom_actors_bundle,
+        }),
         ipc: Some(ipc_params),
     };
 

--- a/fendermint/testing/contract-test/tests/run_upgrades.rs
+++ b/fendermint/testing/contract-test/tests/run_upgrades.rs
@@ -220,6 +220,7 @@ async fn test_applying_upgrades() {
             balance: TokenAmount::from_atto(0),
         }],
         eam_permission_mode: PermissionMode::Unrestricted,
+        actors: None,
         ipc: None,
     };
 

--- a/fendermint/testing/materializer/src/docker/mod.rs
+++ b/fendermint/testing/materializer/src/docker/mod.rs
@@ -687,6 +687,7 @@ impl Materializer<DockerMaterials> for DockerMaterializer {
                     })
                     .collect(),
                 eam_permission_mode: fendermint_vm_genesis::PermissionMode::Unrestricted,
+                actors: None,
                 ipc: Some(IpcParams {
                     gateway: GatewayParams {
                         subnet_id: SubnetID::new_root(chain_id.into()),

--- a/fendermint/vm/encoding/Cargo.toml
+++ b/fendermint/vm/encoding/Cargo.toml
@@ -15,3 +15,4 @@ num-traits = { workspace = true }
 cid = { workspace = true }
 fvm_shared = { workspace = true }
 ipc-api = { workspace = true }
+hex = { workspace = true }

--- a/fendermint/vm/genesis/src/lib.rs
+++ b/fendermint/vm/genesis/src/lib.rs
@@ -21,6 +21,19 @@ mod arb;
 
 /// Power conversion decimal points, e.g. 3 decimals means 1 power per milliFIL.
 pub type PowerScale = i8;
+pub type RawBytes = Vec<u8>;
+
+/// The genesis actor bundle enum
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum GenesisActorBundles {
+    V1 {
+        #[serde_as(as = "IsHumanReadable")]
+        builtin: RawBytes,
+        #[serde_as(as = "IsHumanReadable")]
+        custom: RawBytes,
+    },
+}
 
 /// The genesis data structure we serialize to JSON and start the chain with.
 #[serde_as]
@@ -44,6 +57,9 @@ pub struct Genesis {
     pub accounts: Vec<Actor>,
     /// The custom eam permission mode that controls who can deploy contracts
     pub eam_permission_mode: PermissionMode,
+    /// The genesis built-in and custom actor bundles to be injected into the fvm runtime
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actors: Option<GenesisActorBundles>,
     /// IPC related configuration, if enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ipc: Option<ipc::IpcParams>,
@@ -219,6 +235,20 @@ impl From<PermissionMode> for PermissionModeParams {
                 let addresses = addresses.into_iter().map(|v| v.0).collect::<Vec<_>>();
                 PermissionModeParams::AllowList(addresses)
             }
+        }
+    }
+}
+
+impl GenesisActorBundles {
+    pub fn builtin(&self) -> &[u8] {
+        match self {
+            GenesisActorBundles::V1 { builtin, .. } => builtin,
+        }
+    }
+
+    pub fn custom(&self) -> &[u8] {
+        match self {
+            GenesisActorBundles::V1 { custom, .. } => custom,
         }
     }
 }

--- a/fendermint/vm/interpreter/src/bytes.rs
+++ b/fendermint/vm/interpreter/src/bytes.rs
@@ -298,7 +298,7 @@ where
 }
 
 /// Parse the initial genesis either as JSON or CBOR.
-fn parse_genesis(bytes: &[u8]) -> anyhow::Result<Genesis> {
+pub fn parse_genesis(bytes: &[u8]) -> anyhow::Result<Genesis> {
     try_parse_genesis_json(bytes).or_else(|e1| {
         try_parse_genesis_cbor(bytes)
             .map_err(|e2| anyhow!("failed to deserialize genesis as JSON or CBOR: {e1}; {e2}"))


### PR DESCRIPTION
As part one of #1002, the builtin and custom actor bundles are added into the genesis as precompile actor code.

Updating unit tests, but implementation should be fixed.