### PR TITLE
fix(contracts/sdk): `IpcUpgradableOwnable`: pass `msg.sender` to `Ownable` `init` for compatibility with OZ v5

### DIFF
--- a/.github/workflows/contracts-prettier.yaml
+++ b/.github/workflows/contracts-prettier.yaml
@@ -15,11 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.ref }}
       - name: Set up node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '21'
+          node-version: "21"
       - name: Run formatter
         run: cd contracts && make fmt
       - name: Check diff clean

--- a/.github/workflows/contracts-test.yaml
+++ b/.github/workflows/contracts-test.yaml
@@ -12,19 +12,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.ref }}
           submodules: recursive
 
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install abi
         run: pip install eth_abi
 
       - name: Install lcov and genhtml
-        run:  sudo apt-get update && sudo apt-get -y install lcov
+        run: sudo apt-get update && sudo apt-get -y install lcov
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/contracts/sdk/IpcContractUpgradeable.sol
+++ b/contracts/sdk/IpcContractUpgradeable.sol
@@ -29,7 +29,7 @@ abstract contract IpcExchangeUpgradeable is Initializable, IIpcHandler, OwnableU
 
     function __IpcExchangeUpgradeable_init(address gatewayAddr_) public onlyInitializing {
         gatewayAddr = gatewayAddr_;
-        __Ownable_init();
+        __Ownable_init(msg.sender);
         __ReentrancyGuard_init();
     }
 


### PR DESCRIPTION
[__Ownable_init()](https://github.com/consensus-shipyard/ipc/blob/b6d472d41601af6327df9c98dd0c486f57c77eaf/contracts/sdk/IpcContractUpgradeable.sol#L32) function requires `msg.sender` param in [@openzeppelin/contracts-upgradeable v5](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/f960f47267044822613be18e149c2e0ee1a3bf6e/contracts/access/OwnableUpgradeable.sol#L51)