### PR TITLE
feat(contracts): remove `crypto` feature from `fvm_shared` in binding

### DIFF
--- a/contracts/binding/Cargo.toml
+++ b/contracts/binding/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 ethers = { workspace = true, features = ["abigen", "ws"] }
-fvm_shared = { workspace = true, features = ["crypto"] }
+fvm_shared = { workspace = true }
 anyhow = { workspace = true }
 
 [build-dependencies]


### PR DESCRIPTION
## Summary

Removes `crypto` feature from `fvm_shared` in `contracts/binding`

## Details

The `contracts/binding` uses `fvm_shared` with the `crypto` flag enabled. However, this is unneeded as it's not directly used, and it also impacts downstream libraries when trying to compile to wasm. E.g., trying to build to wasm will fail due to a transitive dependency of `positioned-io`, stemming from the enabled `crypto` feature.