### PR TITLE
Adding quorum cert implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,7 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
+ "serde",
  "tap",
  "wyz",
 ]
@@ -3449,6 +3450,7 @@ dependencies = [
  "arbitrary",
  "async-stm",
  "async-trait",
+ "bitvec",
  "bytes",
  "cid",
  "clap 4.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,8 @@ tendermint-rpc = { version = "0.31", features = [
 ] }
 tendermint-proto = { version = "0.31" }
 
+bitvec = "1.0.1"
+
 [patch.crates-io]
 # Use stable-only features.
 gcra = { git = "https://github.com/consensus-shipyard/gcra-rs.git", branch = "main" }

--- a/fendermint/vm/topdown/Cargo.toml
+++ b/fendermint/vm/topdown/Cargo.toml
@@ -7,9 +7,11 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+
 anyhow = { workspace = true }
 async-stm = { workspace = true }
 async-trait = { workspace = true }
+bitvec = { workspace = true, features = ["serde"] }
 bytes = { workspace = true }
 cid = { workspace = true }
 ethers = { workspace = true }

--- a/fendermint/vm/topdown/src/voting.rs
+++ b/fendermint/vm/topdown/src/voting.rs
@@ -19,13 +19,14 @@ pub use ipc_ipld_resolver::ValidatorKey;
 use ipc_ipld_resolver::VoteRecord;
 
 pub type Weight = u64;
-pub type EcdsaSignature = Vec<u8>;
+pub type Signature = Bytes;
 
 /// A collection of validator public key that have signed the `content`. This includes their key
 /// and signatures. Mostly this comes from vote tally in the gossip channel.
-pub struct Quorum<K, V> {
+pub struct VoteSignatures<K, V> {
+    /// The content of the vote
     content: V,
-    validators: HashMap<K, EcdsaSignature>,
+    validators: HashMap<K, Signature>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -445,7 +446,7 @@ impl MultiSigCert {
     }
 }
 
-impl<K: Hash + Eq + Clone + Ord, V: PartialEq + AsRef<u8>> Quorum<K, V> {
+impl<K: Hash + Eq + Clone + Ord, V: PartialEq + AsRef<u8>> VoteSignatures<K, V> {
     pub fn new(content: V) -> Self {
         Self {
             content,
@@ -453,7 +454,7 @@ impl<K: Hash + Eq + Clone + Ord, V: PartialEq + AsRef<u8>> Quorum<K, V> {
         }
     }
 
-    pub fn add_vote(&mut self, k: K, content: V, sig: EcdsaSignature) -> anyhow::Result<()> {
+    pub fn add_vote(&mut self, k: K, content: V, sig: Signature) -> anyhow::Result<()> {
         if self.content != content {
             return Err(anyhow!("quorum content not match"));
         }

--- a/fendermint/vm/topdown/src/voting.rs
+++ b/fendermint/vm/topdown/src/voting.rs
@@ -607,7 +607,7 @@ mod tests {
         let signatures = key_pairs
             .iter()
             .map(|pair| {
-                if rand::random::<bool>() == true {
+                if rand::random::<bool>() {
                     Some(pair.sign(&message).unwrap())
                 } else {
                     None
@@ -622,12 +622,7 @@ mod tests {
         match cert.agg_signatures {
             AggregatedSignature::Ecdsa(ref v) => assert_eq!(
                 *v,
-                signatures
-                    .clone()
-                    .into_iter()
-                    .filter(|v| v.is_some())
-                    .map(|v| v.unwrap())
-                    .collect::<Vec<_>>()
+                signatures.clone().into_iter().flatten().collect::<Vec<_>>()
             ),
             AggregatedSignature::Schnorr(_) => unreachable!(),
         }
@@ -639,9 +634,8 @@ mod tests {
             "should validate cert"
         );
 
-        assert_eq!(
-            cert.is_valid(&vec![1, 2], &pub_keys).unwrap(),
-            false,
+        assert!(
+            !cert.is_valid(&[1, 2], &pub_keys).unwrap(),
             "should invalidate cert"
         );
     }


### PR DESCRIPTION
Following previous topdown commitment PR #1050. 

This PR adds Ecdsa signature aggregation scheme using bitmap to indicate signed valdators, with tests. Using a bitmap will have to ensure the validators are always in the same exact order otherwise the signature validation will fail. This is achieved by sorted the validators by weight then by their public key.

Following tasks includes: 
- [ ] integrate the `Quorum` into the topdown proposal, i.e. `prepare`.
- [ ] validate the new topdown proposal with the quorum signature in `process`.