### PR TITLE
Introduce New Observability - Configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2936,6 +2936,7 @@ dependencies = [
  "fvm_shared",
  "hex",
  "ipc-api",
+ "ipc-observability",
  "ipc-types",
  "lazy_static",
  "num-traits",

--- a/fendermint/app/options/Cargo.toml
+++ b/fendermint/app/options/Cargo.toml
@@ -26,6 +26,7 @@ fvm_shared = { workspace = true }
 ipc-api = { workspace = true }
 ipc-types = { workspace = true }
 url = { workspace = true }
+ipc-observability = { workspace = true }
 
 fendermint_vm_genesis = { path = "../../vm/genesis" }
 fendermint_vm_actor_interface = { path = "../../vm/actor_interface" }

--- a/fendermint/app/options/src/lib.rs
+++ b/fendermint/app/options/src/lib.rs
@@ -102,14 +102,6 @@ pub struct Options {
     #[arg(long, env = "FM_CONFIG_DIR")]
     config_dir: Option<PathBuf>,
 
-    /// Set a custom directory for ipc log files.
-    #[arg(long, env = "FM_LOG_DIR")]
-    pub log_dir: Option<PathBuf>,
-
-    /// Set a custom prefix for ipc log files.
-    #[arg(long, env = "FM_LOG_FILE_PREFIX")]
-    pub log_file_prefix: Option<String>,
-
     /// Optionally override the default configuration.
     #[arg(short, long, default_value = "dev")]
     pub mode: String,

--- a/fendermint/app/options/src/lib.rs
+++ b/fendermint/app/options/src/lib.rs
@@ -7,6 +7,7 @@ use clap::{Args, Parser, Subcommand};
 use config::ConfigArgs;
 use debug::DebugArgs;
 use fvm_shared::address::Network;
+use ipc_observability::traces::FileLayerConfig;
 use lazy_static::lazy_static;
 use tracing_subscriber::EnvFilter;
 
@@ -27,7 +28,7 @@ pub mod run;
 mod log;
 mod parse;
 
-use log::{parse_log_level, LogLevel};
+use log::{parse_log_level, parse_rotation_kind, LogLevel, RotationKind};
 use parse::parse_network;
 
 lazy_static! {
@@ -102,6 +103,46 @@ pub struct Options {
     #[arg(long, env = "FM_CONFIG_DIR")]
     config_dir: Option<PathBuf>,
 
+    // TODO Karel - move all FM_LOG_FILE* flags to a configuration file instead
+
+    // Enable logging to a file.
+    #[arg(long, env = "FM_LOG_FILE_ENABLED")]
+    pub log_file_enabled: Option<bool>,
+
+    /// Set a custom directory for ipc log files.
+    #[arg(long, env = "FM_LOG_FILE_DIR")]
+    pub log_dir: Option<PathBuf>,
+
+    #[arg(long, env = "FM_LOG_FILE_MAX_FILES")]
+    pub max_log_files: Option<usize>,
+
+    #[arg(
+        short = 'l',
+        long,
+        default_value = "daily",
+        value_enum,
+        env = "FM_LOG_FILE_ROTATION",
+        help = "The kind of rotation to use for log files. Options: minutely, hourly, daily, never.",
+        value_parser = parse_rotation_kind,
+    )]
+    pub log_files_rotation: Option<RotationKind>,
+
+    #[arg(
+        long,
+        env = "FM_LOG_FILE_DOMAINS_FILTER",
+        help = "Filter log events by domains. Only events from the specified domains will be logged. Comma separated.",
+        value_delimiter = ','
+    )]
+    pub domains_filter: Option<Vec<String>>,
+
+    #[arg(
+        long,
+        env = "FM_LOG_FILE_EVENTS_FILTER",
+        help = "Filter log events by name. Only events with the specified names will be logged. Comma separated.",
+        value_delimiter = ','
+    )]
+    pub events_filter: Option<Vec<String>>,
+
     /// Optionally override the default configuration.
     #[arg(short, long, default_value = "dev")]
     pub mode: String,
@@ -151,6 +192,17 @@ impl Options {
             level.to_filter()
         } else {
             self.log_console_filter()
+        }
+    }
+
+    pub fn log_file_config(&self) -> FileLayerConfig {
+        FileLayerConfig {
+            enabled: self.log_file_enabled.unwrap_or(false),
+            directory: self.log_dir.clone(),
+            max_log_files: self.max_log_files,
+            rotation: self.log_files_rotation.clone(),
+            domain_filter: self.domains_filter.clone(),
+            events_filter: self.events_filter.clone(),
         }
     }
 

--- a/fendermint/app/options/src/log.rs
+++ b/fendermint/app/options/src/log.rs
@@ -6,6 +6,8 @@ use clap::{builder::PossibleValue, ValueEnum};
 use lazy_static::lazy_static;
 use tracing_subscriber::EnvFilter;
 
+pub use ipc_observability::traces::RotationKind;
+
 /// Standard log levels, or something we can pass to <https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html>
 ///
 /// To be fair all of these could be handled by the `EnvFilter`, even `off`,
@@ -77,5 +79,15 @@ pub fn parse_log_level(s: &str) -> Result<LogLevel, String> {
         Err(e.to_string())
     } else {
         Ok(LogLevel::Filter(s.to_string()))
+    }
+}
+
+pub fn parse_rotation_kind(s: &str) -> Result<RotationKind, String> {
+    match s {
+        "minutely" => Ok(RotationKind::Minutely),
+        "hourly" => Ok(RotationKind::Hourly),
+        "daily" => Ok(RotationKind::Daily),
+        "never" => Ok(RotationKind::Never),
+        _ => Err(format!("invalid rotation kind: {}", s)),
     }
 }

--- a/fendermint/app/src/metrics/prometheus.rs
+++ b/fendermint/app/src/metrics/prometheus.rs
@@ -26,16 +26,6 @@ pub mod app {
     use prometheus::{IntCounter, IntGauge, Registry};
 
     metrics! {
-        TOPDOWN_VIEW_BLOCK_HEIGHT: IntGauge = "Highest parent subnet block observed";
-        TOPDOWN_VIEW_NUM_MSGS: IntCounter = "Number of top-down messages observed since start";
-        TOPDOWN_VIEW_NUM_VAL_CHNGS: IntCounter = "Number of top-down validator changes observed since start";
-        TOPDOWN_FINALIZED_BLOCK_HEIGHT: IntGauge = "Highest parent subnet block finalized";
-        TOPDOWN_FINALITY_VOTE_BLOCK_HEIGHT: IntGauge = "Block for which a finality vote has been received and added last";
-        TOPDOWN_FINALITY_VOTE_MAX_BLOCK_HEIGHT: IntGauge = "Highest block for which a finality vote has been received and added";
-        TOPDOWN_FINALITY_VOTE_ADDED: IntCounter = "Number of finality votes received and added since start";
-        TOPDOWN_FINALITY_VOTE_IGNORED: IntCounter = "Number of finality votes received and ignored since start";
-        TOPDOWN_FINALITY_MISSING_QUORUM: IntCounter = "Number of times we could have proposed but didn't because the quorum was missing";
-
         BOTTOMUP_CKPT_BLOCK_HEIGHT: IntGauge = "Highest bottom-up checkpoint created";
         BOTTOMUP_CKPT_CONFIG_NUM: IntGauge = "Highest configuration number checkpointed";
         BOTTOMUP_CKPT_NUM_MSGS: IntCounter = "Number of bottom-up messages observed since start";

--- a/fendermint/vm/topdown/src/observe.rs
+++ b/fendermint/vm/topdown/src/observe.rs
@@ -159,6 +159,59 @@ impl Recordable for ParentFinalityCommitted<'_> {
     }
 }
 
+pub fn emit_all() {
+    use ipc_observability::emit;
+
+    emit(ParentRpcCalled {
+        source: "source",
+        json_rpc: "json_rpc",
+        method: "method",
+        status: "status",
+        latency: 1.0,
+    });
+
+    let hash = vec![0u8; 32];
+
+    emit(ParentFinalityAcquired {
+        source: "parent-finality",
+        is_null: false,
+        block_height: 10,
+        block_hash: Some(HexEncodableBlockHash(hash.clone())),
+        commitment_hash: Some(HexEncodableBlockHash(hash.clone())),
+        num_msgs: 5,
+        num_validator_changes: 6,
+    });
+
+    emit(ParentFinalityPeerVoteReceived {
+        validator: "abcd",
+        block_height: 10,
+        block_hash: HexEncodableBlockHash(hash.clone()),
+        commitment_hash: HexEncodableBlockHash(hash.clone()),
+    });
+
+    emit(ParentFinalityPeerVoteSent {
+        block_height: 10,
+        block_hash: HexEncodableBlockHash(hash.clone()),
+        commitment_hash: HexEncodableBlockHash(hash.clone()),
+    });
+
+    emit(ParentFinalityPeerQuorumReached {
+        block_height: 10,
+        block_hash: HexEncodableBlockHash(hash.clone()),
+        commitment_hash: HexEncodableBlockHash(hash.clone()),
+        weight: 5,
+    });
+
+    emit(ParentFinalityCommitted {
+        parent_height: 10,
+        block_hash: HexEncodableBlockHash(hash.clone()),
+        local_height: Some(3),
+        proposer: Some("proposer-validator"),
+    });
+
+    println!("Emitted all events");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/fendermint/vm/topdown/src/observe.rs
+++ b/fendermint/vm/topdown/src/observe.rs
@@ -159,59 +159,6 @@ impl Recordable for ParentFinalityCommitted<'_> {
     }
 }
 
-pub fn emit_all() {
-    use ipc_observability::emit;
-
-    emit(ParentRpcCalled {
-        source: "source",
-        json_rpc: "json_rpc",
-        method: "method",
-        status: "status",
-        latency: 1.0,
-    });
-
-    let hash = vec![0u8; 32];
-
-    emit(ParentFinalityAcquired {
-        source: "parent-finality",
-        is_null: false,
-        block_height: 10,
-        block_hash: Some(HexEncodableBlockHash(hash.clone())),
-        commitment_hash: Some(HexEncodableBlockHash(hash.clone())),
-        num_msgs: 5,
-        num_validator_changes: 6,
-    });
-
-    emit(ParentFinalityPeerVoteReceived {
-        validator: "abcd",
-        block_height: 10,
-        block_hash: HexEncodableBlockHash(hash.clone()),
-        commitment_hash: HexEncodableBlockHash(hash.clone()),
-    });
-
-    emit(ParentFinalityPeerVoteSent {
-        block_height: 10,
-        block_hash: HexEncodableBlockHash(hash.clone()),
-        commitment_hash: HexEncodableBlockHash(hash.clone()),
-    });
-
-    emit(ParentFinalityPeerQuorumReached {
-        block_height: 10,
-        block_hash: HexEncodableBlockHash(hash.clone()),
-        commitment_hash: HexEncodableBlockHash(hash.clone()),
-        weight: 5,
-    });
-
-    emit(ParentFinalityCommitted {
-        parent_height: 10,
-        block_hash: HexEncodableBlockHash(hash.clone()),
-        local_height: Some(3),
-        proposer: Some("proposer-validator"),
-    });
-
-    println!("Emitted all events");
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ipc/observability/src/lib.rs
+++ b/ipc/observability/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod macros;
 pub mod traces;
+mod tracing_layers;
 pub use lazy_static::lazy_static;
 
 use std::fmt::Debug;

--- a/ipc/observability/src/traces.rs
+++ b/ipc/observability/src/traces.rs
@@ -5,54 +5,69 @@ use std::num::NonZeroUsize;
 pub use tracing_appender::non_blocking;
 pub use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
-use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Layer};
+use tracing_subscriber::filter::EnvFilter;
+use tracing_subscriber::{fmt, layer::SubscriberExt, Layer};
 
-#[derive(Default)]
-pub struct FileLayerOpts<'a> {
-    pub enabled: bool,
-    pub directory: Option<&'a str>,
-    pub max_log_files: Option<usize>,
-    pub rotation: Option<&'a str>,
-    pub filters: Option<Vec<&'a str>>,
+use crate::tracing_layers::DomainEventFilterLayer;
+
+#[derive(Debug)]
+pub enum RotationKind {
+    Minutely,
+    Hourly,
+    Daily,
+    Never,
+}
+
+impl RotationKind {
+    fn to_tracing_rotation(&self) -> Rotation {
+        match self {
+            RotationKind::Minutely => Rotation::DAILY,
+            RotationKind::Hourly => Rotation::HOURLY,
+            RotationKind::Daily => Rotation::DAILY,
+            RotationKind::Never => Rotation::NEVER,
+        }
+    }
+}
+
+impl From<&str> for RotationKind {
+    fn from(s: &str) -> Self {
+        match s {
+            "minutely" => RotationKind::Minutely,
+            "hourly" => RotationKind::Hourly,
+            "daily" => RotationKind::Daily,
+            "never" => RotationKind::Never,
+            _ => panic!("invalid rotation kind"),
+        }
+    }
 }
 
 #[derive(Default)]
-pub struct ConsoleLayerOpts {
+pub struct FileLayerConfig<'a> {
     pub enabled: bool,
-    pub filter: EnvFilter,
+    pub directory: Option<&'a str>,
+    pub max_log_files: Option<usize>,
+    pub rotation: Option<RotationKind>,
+    pub domain_filter: Option<Vec<&'a str>>,
+    pub events_filter: Option<Vec<&'a str>>,
 }
 
 // Register a tracing subscriber with the given options
 // Returns a guard that must be kept alive for the duration of the program (because it's non-blocking and needs to flush)
 pub fn register_tracing_subscriber(
-    console_opts: ConsoleLayerOpts,
-    file_opts: FileLayerOpts<'_>,
+    console_level_filter: EnvFilter,
+    file_level_filter: EnvFilter,
+    file_opts: FileLayerConfig<'_>,
 ) -> Option<WorkerGuard> {
     // log all traces to stderr (reserving stdout for any actual output such as from the CLI commands)
-    // TODO Karel - do we want to always allow it or should we make it configurable?
-
-    let console_layer = if console_opts.enabled {
-        let console_layer = fmt::layer()
-            .with_writer(std::io::stderr)
-            .with_target(false)
-            .with_file(true)
-            .with_line_number(true)
-            .with_filter(console_opts.filter);
-
-        Some(console_layer)
-    } else {
-        None
-    };
+    let console_layer = fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_target(false)
+        .with_file(true)
+        .with_line_number(true)
+        .with_filter(console_level_filter);
 
     let (file_layer, file_guard) = if file_opts.enabled {
         let (non_blocking, file_guard) = non_blocking(file_appender_from_opts(&file_opts));
-
-        let mut file_filter = EnvFilter::from_default_env();
-        if let Some(filters) = &file_opts.filters {
-            for domain in filters {
-                file_filter = file_filter.add_directive(domain.parse().unwrap());
-            }
-        }
 
         let file_layer = fmt::layer()
             .json()
@@ -61,7 +76,16 @@ pub fn register_tracing_subscriber(
             .with_target(false)
             .with_file(true)
             .with_line_number(true)
-            .with_filter(file_filter);
+            .with_filter(file_level_filter);
+
+        let domains = file_opts
+            .domain_filter
+            .map(|v| v.iter().map(|s| s.to_string()).collect());
+        let events = file_opts
+            .events_filter
+            .map(|v| v.iter().map(|s| s.to_string()).collect());
+
+        let file_layer = DomainEventFilterLayer::new(domains, events, file_layer);
 
         (Some(file_layer), Some(file_guard))
     } else {
@@ -78,11 +102,13 @@ pub fn register_tracing_subscriber(
     file_guard
 }
 
-fn file_appender_from_opts(opts: &FileLayerOpts<'_>) -> RollingFileAppender {
-    let directory = opts.directory.expect("journal directory must be set");
-    let mut appender = RollingFileAppender::builder().filename_suffix("journal");
+fn file_appender_from_opts(opts: &FileLayerConfig<'_>) -> RollingFileAppender {
+    let directory = opts.directory.expect("traces directory must be set");
+    let mut appender = RollingFileAppender::builder().filename_suffix("traces");
 
     if let Some(max_log_files) = opts.max_log_files {
+        println!("max log files: {}", max_log_files);
+
         appender = appender.max_log_files(
             NonZeroUsize::new(max_log_files)
                 .expect("max_log_files must be greater than 0")
@@ -90,19 +116,12 @@ fn file_appender_from_opts(opts: &FileLayerOpts<'_>) -> RollingFileAppender {
         );
     };
 
-    if let Some(rotation_str) = opts.rotation {
-        let rotation = match rotation_str {
-            "minutely" => Rotation::DAILY,
-            "hourly" => Rotation::HOURLY,
-            "daily" => Rotation::DAILY,
-            "never" => Rotation::NEVER,
-            _ => panic!("invalid rotation: {}", rotation_str),
-        };
-
-        appender = appender.rotation(rotation);
+    if let Some(rotation_kind) = &opts.rotation {
+        println!("rotation kind: {:?}", rotation_kind);
+        appender = appender.rotation(rotation_kind.to_tracing_rotation());
     };
 
     appender
         .build(directory)
-        .expect("failed to create journal appender")
+        .expect("failed to create traces appender")
 }

--- a/ipc/observability/src/traces.rs
+++ b/ipc/observability/src/traces.rs
@@ -3,6 +3,7 @@
 
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
+use std::str::FromStr;
 pub use tracing_appender::non_blocking;
 pub use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
@@ -30,14 +31,16 @@ impl RotationKind {
     }
 }
 
-impl From<&str> for RotationKind {
-    fn from(s: &str) -> Self {
+impl FromStr for RotationKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "minutely" => RotationKind::Minutely,
-            "hourly" => RotationKind::Hourly,
-            "daily" => RotationKind::Daily,
-            "never" => RotationKind::Never,
-            _ => panic!("invalid rotation kind"),
+            "minutely" => Ok(RotationKind::Minutely),
+            "hourly" => Ok(RotationKind::Hourly),
+            "daily" => Ok(RotationKind::Daily),
+            "never" => Ok(RotationKind::Never),
+            _ => Err(format!("invalid rotation kind: {}", s)),
         }
     }
 }

--- a/ipc/observability/src/tracing_layers.rs
+++ b/ipc/observability/src/tracing_layers.rs
@@ -1,9 +1,7 @@
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::ops::Deref;
 use tracing::{field::Visit, Event, Subscriber};
-use tracing_subscriber::Registry;
 use tracing_subscriber::{layer::Context, Layer};
 
 const DOMAIN_FIELD: &str = "domain";
@@ -13,14 +11,6 @@ pub struct DomainEventFilterLayer<L> {
     domains: Option<Vec<String>>,
     events: Option<Vec<String>>,
     inner: L,
-}
-
-impl Deref for DomainEventFilterLayer<Registry> {
-    type Target = Registry;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
 }
 
 impl<L> DomainEventFilterLayer<L> {

--- a/ipc/observability/src/tracing_layers.rs
+++ b/ipc/observability/src/tracing_layers.rs
@@ -1,0 +1,99 @@
+use std::sync::{Arc, RwLock};
+use tracing::{field::Visit, span::Record, Event, Id, Metadata, Subscriber};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::Registry;
+use tracing_subscriber::{layer::Context, Layer};
+
+const DOMAIN_FIELD: &str = "domain";
+const EVENT_FIELD: &str = "event";
+
+pub struct DomainEventFilterLayer<L> {
+    domains: Option<Vec<String>>,
+    events: Option<Vec<String>>,
+    inner: L,
+}
+
+impl<L> DomainEventFilterLayer<L> {
+    pub fn new(domains: Option<Vec<String>>, events: Option<Vec<String>>, inner: L) -> Self {
+        DomainEventFilterLayer {
+            domains,
+            events,
+            inner,
+        }
+    }
+}
+
+impl<S, L> Layer<S> for DomainEventFilterLayer<L>
+where
+    S: Subscriber,
+    L: Layer<S>,
+{
+    fn on_event(&self, event: &Event, ctx: Context<S>) {
+        if self.domains.is_none() && self.events.is_none() {
+            self.inner.on_event(event, ctx);
+            return;
+        }
+
+        let mut visitor = EventVisitor::new();
+        event.record(&mut visitor);
+
+        if self.domains.is_some()
+            && !visitor.domain.map_or(false, |d| {
+                self.domains
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .any(|dom| d.contains(dom))
+            })
+        {
+            return;
+        }
+
+        if self.events.is_some()
+            && !visitor.event.map_or(false, |e| {
+                self.events
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .any(|evt| e.contains(evt))
+            })
+        {
+            return;
+        }
+
+        self.inner.on_event(event, ctx);
+    }
+}
+
+#[derive(Debug)]
+struct EventVisitor {
+    domain: Option<String>,
+    event: Option<String>,
+}
+
+impl EventVisitor {
+    fn new() -> Self {
+        EventVisitor {
+            domain: None,
+            event: None,
+        }
+    }
+}
+
+impl Visit for EventVisitor {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() != DOMAIN_FIELD {
+            return;
+        }
+
+        self.domain = Some(value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() != EVENT_FIELD {
+            return;
+        }
+
+        self.event = Some(format!("{:?}", value));
+    }
+}

--- a/ipc/observability/src/tracing_layers.rs
+++ b/ipc/observability/src/tracing_layers.rs
@@ -1,6 +1,8 @@
-use std::sync::{Arc, RwLock};
-use tracing::{field::Visit, span::Record, Event, Id, Metadata, Subscriber};
-use tracing_subscriber::registry::LookupSpan;
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::ops::Deref;
+use tracing::{field::Visit, Event, Subscriber};
 use tracing_subscriber::Registry;
 use tracing_subscriber::{layer::Context, Layer};
 
@@ -11,6 +13,14 @@ pub struct DomainEventFilterLayer<L> {
     domains: Option<Vec<String>>,
     events: Option<Vec<String>>,
     inner: L,
+}
+
+impl Deref for DomainEventFilterLayer<Registry> {
+    type Target = Registry;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
 }
 
 impl<L> DomainEventFilterLayer<L> {


### PR DESCRIPTION
Close #1057 

There is a problem with using the configuration file because we want to set up tracing before the configuration is loaded. At least, this is how it currently works. Therefore, some kind of dynamic layer will need to be added to the subscriber layer when we want to use the configuration file. That is why I just used environment variables for now to cut corners and get this out as soon as possible. Once all metrics are implemented, I can fix the configuration reloading.