### PR TITLE
fix(ci): aderyn target.

### DIFF
--- a/.github/workflows/contracts-sast.yaml
+++ b/.github/workflows/contracts-sast.yaml
@@ -41,8 +41,19 @@ jobs:
       - name: Install aderyn
         run: cargo install aderyn
 
+      - name: Make deps
+        run: cd contracts && make deps
+
+      # We need a normal npm install because pnpm hoists node_modules and creates symlinks.
+      # Aderyn performs local compilation calling solc directly. Solc requires the target of symlinks to be whitelisted
+      # in allowed-paths. Unfortunately, Aderyn doesn't support passing in allowed-paths, nor does it pick them up from
+      # Foundry config. I also wasn't able to mimic a standard node_modules layout with pnpm, after trying various
+      # hoisting and linking settings. So we bite the bullet and perform an ordinary npm install to make Aderyn happy.
+      - name: Force an ordinary npm install
+        run: cd contracts && rm -rf node_modules && npm install
+
       - name: Run aderyn
-        run: cd contracts && make deps && aderyn ./ -o report.json
+        run: aderyn ./ -o report.json
 
       - name: Check results
         run: cd contracts && ./tools/check_aderyn.sh

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -15,6 +15,7 @@ memory_limit =  2147483648 # 2GB
 remappings = [
     "murky/=lib/murky/src/",
 ]
+allow_paths = ["../node_modules"]
 
 [fuzz]
 runs = 512


### PR DESCRIPTION
Root cause:
1. pnpm hoists dependencies to the workspace root and uses symlinks to link them under `node_modules`.
2. Aderyn performs local compilation calling solc directly.
3. Solc requires the target of symlinks to be whitelisted in `--allow-paths`.

Unfortunately:
1. Aderyn doesn't support passing in allowed paths, nor does it pick them up from Foundry config.
2. I wasn't able to mimic a standard `node_modules` layout with pnpm, after trying various hoisting and linking settings.

So we bite the bullet and perform an ordinary npm install to make Aderyn happy.

Also rewrote the `check_aderyn.sh` script to make it POSIX compliant, so I could run it on macOS to verify the fix.