### PR TITLE
fix: fix dircpy crate bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "dircpy"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "015cf520d424257fb8fbeccda4ee8d921b02907ae612484f036fa1a432b9036e"
+checksum = "a88521b0517f5f9d51d11925d8ab4523497dcf947073fa3231a311b63941131c"
 dependencies = [
  "jwalk",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ clap = { version = "4.1", features = ["derive", "env", "string"] }
 byteorder = "1.5.0"
 config = "0.13"
 dirs = "5.0"
-dircpy = "0.3"
+dircpy = "0.3.19"
 either = "1.10"
 env_logger = "0.10"
 erased-serde = "0.3"


### PR DESCRIPTION
The dircpy has a bug which was fixed in a higher version, but the cargo update ran previously used the buggy version. This pr fixes it and fix the crate version.