### PR TITLE
chore: update IntegrationTestBase.sol to delete unused variable

### DIFF
--- a/contracts/test/IntegrationTestBase.sol
+++ b/contracts/test/IntegrationTestBase.sol
@@ -152,7 +152,6 @@ contract TestSubnetActor is Test, TestParams {
     bytes4[] saOwnershipSelectors;
 
     SubnetActorDiamond saDiamond;
-    SubnetActorMock saMock;
 
     constructor() {
         saGetterSelectors = SelectorLibrary.resolveSelectors("SubnetActorGetterFacet");


### PR DESCRIPTION
Hi, I was going through this file and noticed that the subnet actor is initialized below, and this variable is not used.