### PR TITLE
feat(node): base fee rotation

### DIFF
--- a/fendermint/actors/gas_market/src/lib.rs
+++ b/fendermint/actors/gas_market/src/lib.rs
@@ -53,6 +53,11 @@ pub struct BlockGasUtilization {
     pub block_gas_used: Gas,
 }
 
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone)]
+pub struct BlockGasUtilizationRet {
+    pub base_fee: TokenAmount,
+}
+
 pub struct EIP1559GasMarketActor {}
 
 #[derive(FromPrimitive)]
@@ -108,12 +113,14 @@ impl EIP1559GasMarketActor {
     fn update_utilization(
         rt: &impl Runtime,
         utilization: BlockGasUtilization,
-    ) -> Result<(), ActorError> {
+    ) -> Result<BlockGasUtilizationRet, ActorError> {
         rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
 
         rt.transaction(|st: &mut EIP1559GasState, _rt| {
             st.base_fee = st.next_base_fee(utilization.block_gas_used);
-            Ok(())
+            Ok(BlockGasUtilizationRet {
+                base_fee: st.base_fee.clone(),
+            })
         })
     }
 }

--- a/fendermint/testing/contract-test/src/lib.rs
+++ b/fendermint/testing/contract-test/src/lib.rs
@@ -160,20 +160,19 @@ where
     }
 
     pub async fn execute_msgs(&self, msgs: Vec<FvmMessage>) -> Result<()> {
-        self
-            .modify_exec_state(|mut s| async {
-                for msg in msgs {
-                    let (a, out) = self.interpreter.deliver(s, msg).await?;
-                    if let Some(e) = out.apply_ret.failure_info {
-                        println!("failed: {}", e);
-                        return Err(anyhow!("err in msg deliver"));
-                    }
-                    s = a;
+        self.modify_exec_state(|mut s| async {
+            for msg in msgs {
+                let (a, out) = self.interpreter.deliver(s, msg).await?;
+                if let Some(e) = out.apply_ret.failure_info {
+                    println!("failed: {}", e);
+                    return Err(anyhow!("err in msg deliver"));
                 }
-                Ok((s, ()))
-            })
-            .await
-            .context("execute msgs failed")
+                s = a;
+            }
+            Ok((s, ()))
+        })
+        .await
+        .context("execute msgs failed")
     }
 
     pub async fn end_block(&self, _block_height: ChainEpoch) -> Result<()> {

--- a/fendermint/vm/interpreter/src/fvm/gas/mod.rs
+++ b/fendermint/vm/interpreter/src/fvm/gas/mod.rs
@@ -12,6 +12,10 @@ pub struct Available {
     pub block_gas: Gas,
 }
 
+pub struct CommitRet {
+    pub base_fee: TokenAmount,
+}
+
 pub struct GasUtilization {
     gas_used: Gas,
     gas_premium: TokenAmount,

--- a/fendermint/vm/interpreter/src/fvm/state/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/exec.rs
@@ -300,8 +300,11 @@ where
 
     pub fn update_gas_market(&mut self) -> anyhow::Result<()> {
         let height = self.block_height();
-        self.gas_market
-            .commit(&mut self.executor, height, self.validator_pubkey)
+        let ret = self
+            .gas_market
+            .commit(&mut self.executor, height, self.validator_pubkey)?;
+        self.params.base_fee = ret.base_fee;
+        Ok(())
     }
 
     /// Update the circulating supply, effective from the next block.


### PR DESCRIPTION
Adding the final step in base fee rotation: setting the base fee params and pass to fvm executor.

There are at least two ways to update base fee based on existing implementation:
1. In `FvmExecState` initialiser that constructs the `DefaultExecutor`, it first creates the `MachineContext` passing base fee into the context. However, the issue with this approach is the latest base fee is stored in an actor, so first must create the executor then load the base fee then reconstruct the Executor, which is kind of awkward.
2. In `EndBlock`, the gas market update is committed and we can return the updated base fee from the gas market update call. With this updated value, it's held in `App` and passed to the next `begin_block` call. Then `base_fee` is still part of the `StateParams` which we cannot remove if we want to survive crashes.

Currently the approach is `2`, perhaps `1` is preferred, we can discuss further.