### PR TITLE
feat(node): skip power scale if not collateral based

### DIFF
--- a/fendermint/app/options/src/genesis.rs
+++ b/fendermint/app/options/src/genesis.rs
@@ -226,7 +226,8 @@ pub struct GenesisFromParentArgs {
     #[arg(long, short = 'f', value_parser = parse_token_amount, default_value = "1000")]
     pub base_fee: TokenAmount,
 
-    /// Number of decimals to use during converting FIL to Power.
-    #[arg(long, default_value = "3")]
-    pub power_scale: i8,
+    /// Number of decimals to use during converting FIL to Power. Only configurable if the subnet
+    /// is collateral based.
+    #[arg(long, default_value = "Some(3)")]
+    pub power_scale: Option<i8>,
 }

--- a/fendermint/vm/genesis/src/lib.rs
+++ b/fendermint/vm/genesis/src/lib.rs
@@ -252,7 +252,7 @@ mod tests {
     use num_traits::Num;
     use quickcheck_macros::quickcheck;
 
-    use crate::{Collateral, Genesis};
+    use crate::{Collateral, Genesis, PowerScale};
 
     #[quickcheck]
     fn genesis_json(value0: Genesis) {
@@ -297,6 +297,13 @@ mod tests {
             let power = collateral.into_power(3).0;
             assert_eq!(power, expected, "{atto:?} atto => {power} power");
         }
+    }
+
+    #[test]
+    fn power_scale_18_decimals() {
+        let c = Collateral(TokenAmount::from_atto(1000));
+        let p = c.into_power(TokenAmount::DECIMALS as PowerScale);
+        assert_eq!(p.0, 1000);
     }
 
     #[test]

--- a/fendermint/vm/interpreter/src/fvm/state/ipc.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/ipc.rs
@@ -179,7 +179,7 @@ impl<DB: Blockstore + Clone> GatewayCaller<DB> {
             .current_membership(state)
             .context("failed to get current membership")?;
 
-        let power_table = membership_to_power_table(&membership, state.power_scale());
+        let power_table = membership_to_power_table(&membership, state.power_scale())?;
 
         Ok((membership.configuration_number, power_table))
     }
@@ -351,19 +351,57 @@ pub fn tokens_to_burn(msgs: &[checkpointing_facet::IpcEnvelope]) -> TokenAmount 
 fn membership_to_power_table(
     m: &gateway_getter_facet::Membership,
     power_scale: PowerScale,
-) -> Vec<Validator<Power>> {
+) -> anyhow::Result<Vec<Validator<Power>>> {
     let mut pt = Vec::new();
 
     for v in m.validators.iter() {
         // Ignoring any metadata that isn't a public key.
-        if let Ok(pk) = PublicKey::parse_slice(&v.metadata, None) {
-            let c = from_eth::to_fvm_tokens(&v.weight);
-            pt.push(Validator {
-                public_key: ValidatorKey(pk),
-                power: Collateral(c).into_power(power_scale),
-            })
-        }
+        let Ok(pk) = PublicKey::parse_slice(&v.metadata, None) else {
+            return Err(anyhow!(
+                "metadata not correct public key: {}",
+                hex::encode(&v.metadata)
+            ));
+        };
+
+        let c = from_eth::to_fvm_tokens(&v.weight);
+        pt.push(Validator {
+            public_key: ValidatorKey(pk),
+            power: Collateral(c).into_power(power_scale),
+        })
     }
 
-    pt
+    Ok(pt)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::fvm::state::ipc::membership_to_power_table;
+    use fendermint_vm_genesis::PowerScale;
+    use fvm_shared::econ::TokenAmount;
+    use ipc_actors_abis::gateway_getter_facet::gateway_getter_facet;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_membership_to_power_table() {
+        let m = gateway_getter_facet::Membership {
+            configuration_number: 4,
+            validators: vec![
+                gateway_getter_facet::Validator {
+                    weight: ethers::types::U256::from(1),
+                    addr: ethers::types::Address::from_str("0x489Ee71B9E8eDEabB30eBA1b09De783Ee9B85F6B").unwrap(),
+                    metadata: ethers::types::Bytes::from_str("0x0485ff6016b937c0cec4f77cc452d250901aa8ff601faba7f4153a34c94ef9cdd8305e9432be8f94036d243dc1d8d5d0526d656ad179d252cf4dfdb49c78c47c65").unwrap(),
+                },
+                gateway_getter_facet::Validator {
+                    weight: ethers::types::U256::from(1000),
+                    addr: ethers::types::Address::from_str("0x0b18D28e32B2A24e003769960e4F3E262b176399").unwrap(),
+                    metadata: ethers::types::Bytes::from_str("0x0485ff6016b937c0cec4f77cc452d250901aa8ff601faba7f4153a34c94ef9cdd8305e9432be8f94036d243dc1d8d5d0526d656ad179d252cf4dfdb49c78c47c65").unwrap(),
+                },
+            ],
+        };
+
+        let v = membership_to_power_table(&m, TokenAmount::DECIMALS as PowerScale).unwrap();
+
+        assert_eq!(v[0].power.0, 1);
+        assert_eq!(v[1].power.0, 1000);
+    }
 }


### PR DESCRIPTION
The power scale is used to convert collateral staked into voting power for cometbft.

With federated power, the power scale is also used to convert federated power into voting power. This has caused a lot of confusion for many ppl. For example, if one sets the federated power to 1000, with the power scale division, the voting power set in cometbft is actually 1. For those who are not aware of power scale, they constantly ask how come? This is especially bad if two validators with federated power of, say, 1000 and 1. People would assume 1000 would have a higher power, but it turns out, the two validators have the same power.

This PR makes a quick fix to resolve the above issue at genesis. If the power comes from non-collateral based, power scale is set to 18, which is effectively no power scaling.

Perhaps a more in depth refactor would be replacing the `Collateral` struct with `Power`, but that would require breaking changes in too many places, perhaps this way is faster and safer.