### PR TITLE
fix: tracing deserialization

### DIFF
--- a/docs/fendermint/observability.md
+++ b/docs/fendermint/observability.md
@@ -357,7 +357,7 @@ directory = "/path/to/log/directory"
 max_log_files = 5 # Number of files to keep after rotation
 rotation = "daily" # Options: minutely, hourly, daily, never
 ## Optional: filter events by domain
-domain_filter = ["Bottomup", "Consenesus", "Mpool", "Execution", "Topdown", "System"]
+domain_filter = ["Bottomup", "Consensus", "Mpool", "Execution", "Topdown", "System"]
 ## Optional: filter events by event name
 events_filter = ["ParentFinalityAcquired", "ParentRpcCalled"]
 ```

--- a/docs/fendermint/observability.md
+++ b/docs/fendermint/observability.md
@@ -357,9 +357,9 @@ directory = "/path/to/log/directory"
 max_log_files = 5 # Number of files to keep after rotation
 rotation = "daily" # Options: minutely, hourly, daily, never
 ## Optional: filter events by domain
-domain_filter = "Bottomup, Consenesus, Mpool, Execution, Topdown, TracingError"
+domain_filter = ["Bottomup", "Consenesus", "Mpool", "Execution", "Topdown", "System"]
 ## Optional: filter events by event name
-events_filter = "ParentFinalityAcquired, ParentRpcCalled"
+events_filter = ["ParentFinalityAcquired", "ParentRpcCalled"]
 ```
 
 By configuring these options, you can control the behavior of metrics and tracing, enabling fine-grained monitoring and logging for your application.

--- a/fendermint/app/settings/src/lib.rs
+++ b/fendermint/app/settings/src/lib.rs
@@ -326,12 +326,16 @@ impl Settings {
                     .ignore_empty(true) // otherwise "" will be parsed as a list item
                     .try_parsing(true) // required for list separator
                     .list_separator(",") // need to list keys explicitly below otherwise it can't pase simple `String` type
+                    .with_list_parse_key("tracing.file.domain_filter")
+                    .with_list_parse_key("tracing.file.events_filter")
                     .with_list_parse_key("resolver.connection.external_addresses")
                     .with_list_parse_key("resolver.discovery.static_addresses")
                     .with_list_parse_key("resolver.membership.static_subnets")
                     .with_list_parse_key("eth.cors.allowed_origins")
                     .with_list_parse_key("eth.cors.allowed_methods")
-                    .with_list_parse_key("eth.cors.allowed_headers"),
+                    .with_list_parse_key("eth.cors.allowed_headers")
+                    .with_list_parse_key("eth.tracing.file.domain_filter")
+                    .with_list_parse_key("eth.tracing.file.events_filter"),
             ))
             // Set the home directory based on what was passed to the CLI,
             // so everything in the config can be relative to it.

--- a/ipc/observability/src/config.rs
+++ b/ipc/observability/src/config.rs
@@ -12,6 +12,7 @@ use tracing_subscriber::filter::EnvFilter;
 #[serde_as]
 #[derive(Debug, Deserialize, Clone, Default, strum::EnumString, strum::Display)]
 #[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "lowercase")]
 pub enum LogLevel {
     Off,
     Error,
@@ -32,6 +33,7 @@ impl From<LogLevel> for EnvFilter {
 #[serde_as]
 #[derive(Debug, Deserialize, Clone, strum::EnumString, strum::Display)]
 #[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "lowercase")]
 pub enum RotationKind {
     Minutely,
     Hourly,


### PR DESCRIPTION
- Allow passing `domain_filter` and `events_filter` via env
- Allow passing lowercase log level, e.g., "info", instead of "Info"