### PR TITLE
fix: include genesis validators in gateway parent validators tracker

### DIFF
--- a/contracts/contracts/lib/LibStaking.sol
+++ b/contracts/contracts/lib/LibStaking.sol
@@ -203,6 +203,11 @@ library LibValidatorSet {
         validators.validators[validator].metadata = metadata;
     }
 
+    /// @notice Set validator data using metadata from memory bytes
+    function setMetadataFromConstructor(ValidatorSet storage validators, address validator, bytes memory metadata) internal {
+        validators.validators[validator].metadata = metadata;
+    }
+
     /***********************************************************************
      * Internal helper functions, should not be called by external functions
      ***********************************************************************/

--- a/contracts/test/IntegrationTestBase.sol
+++ b/contracts/test/IntegrationTestBase.sol
@@ -305,11 +305,18 @@ contract IntegrationTestBase is Test, TestParams, TestRegistry, TestSubnetActor,
     }
 
     function defaultGatewayParams() internal view virtual returns (GatewayDiamond.ConstructorParams memory) {
+        uint256 genesisValidator = 99;
+        Validator[] memory validators = new Validator[](1);
+        validators[0] = Validator({
+            weight: 10000,
+            addr: vm.addr(genesisValidator),
+            metadata: TestUtils.derivePubKeyBytes(genesisValidator)
+        });
         GatewayDiamond.ConstructorParams memory params = GatewayDiamond.ConstructorParams({
             networkName: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
             bottomUpCheckPeriod: DEFAULT_CHECKPOINT_PERIOD,
             majorityPercentage: DEFAULT_MAJORITY_PERCENTAGE,
-            genesisValidators: new Validator[](0),
+            genesisValidators: validators,
             activeValidatorsLimit: DEFAULT_ACTIVE_VALIDATORS_LIMIT,
             commitSha: DEFAULT_COMMIT_SHA
         });

--- a/contracts/test/integration/GatewayDiamond.t.sol
+++ b/contracts/test/integration/GatewayDiamond.t.sol
@@ -965,6 +965,11 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase, SubnetWithNativeT
     }
 
     function testGatewayDiamond_applyFinality_works() public {
+        // check membership from genesis
+        require(
+            gatewayDiamond.getter().getCurrentMembership().validators.length == 1,
+            "current membership should be 1"
+        );
         // changes included for two validators joining
         address val1 = vm.addr(100);
         address val2 = vm.addr(101);
@@ -986,8 +991,8 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase, SubnetWithNativeT
         uint64 configNumber = gatewayDiamond.topDownFinalizer().applyFinalityChanges();
         require(configNumber == 2, "wrong config number after applying finality");
         require(
-            gatewayDiamond.getter().getCurrentMembership().validators.length == 2,
-            "current membership should be 2"
+            gatewayDiamond.getter().getCurrentMembership().validators.length == 3,
+            "current membership should be 3"
         );
         require(gatewayDiamond.getter().getCurrentConfigurationNumber() == 2, "unexpected config number");
         require(gatewayDiamond.getter().getLastConfigurationNumber() == 0, "unexpected last config number");
@@ -1013,10 +1018,10 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase, SubnetWithNativeT
         );
         require(gatewayDiamond.getter().getCurrentConfigurationNumber() == 3, "apply result: unexpected config number");
         require(
-            gatewayDiamond.getter().getCurrentMembership().validators.length == 1,
-            "current membership should be 1"
+            gatewayDiamond.getter().getCurrentMembership().validators.length == 2,
+            "current membership should be 2"
         );
-        require(gatewayDiamond.getter().getLastMembership().validators.length == 2, "last membership should be 2");
+        require(gatewayDiamond.getter().getLastMembership().validators.length == 3, "last membership should be 3");
 
         // no changes
         configNumber = gatewayDiamond.topDownFinalizer().applyFinalityChanges();
@@ -1024,10 +1029,10 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase, SubnetWithNativeT
         require(gatewayDiamond.getter().getLastConfigurationNumber() == 2, "no changes: unexpected last config number");
         require(gatewayDiamond.getter().getCurrentConfigurationNumber() == 3, "no changes: unexpected config number");
         require(
-            gatewayDiamond.getter().getCurrentMembership().validators.length == 1,
-            "current membership should be 1"
+            gatewayDiamond.getter().getCurrentMembership().validators.length == 2,
+            "current membership should be 2"
         );
-        require(gatewayDiamond.getter().getLastMembership().validators.length == 2, "last membership should be 2");
+        require(gatewayDiamond.getter().getLastMembership().validators.length == 3, "last membership should be 3");
 
         vm.stopPrank();
     }


### PR DESCRIPTION
This PR is the result of trying to track down the cause of the following behavior:

- Create a new subnet with min validators = 2
- Create 3 validators and join
- The first 2 validators will be considered "genesis validators", and the third one will be added to the power table (membership in the subnet gateway contract) via a top down staking change
- The subnet receives and stores the validator change, then checkpointing applies those changes. The next power table excludes the first two validators [here](https://github.com/consensus-shipyard/ipc/blob/d0892f21a1d4c7e22106abe6786fb68477e3c37e/fendermint/vm/interpreter/src/fvm/checkpoint.rs#L118). We now have only one validator with power.
- Since the genesis validators are not included in the subnet gateway's parent validator tracker, the new membership set by the top down finalizer excludes the genesis validators, ie, `listActiveValidators()` will be zero when applying this first change [here](https://github.com/consensus-shipyard/ipc/blob/d0892f21a1d4c7e22106abe6786fb68477e3c37e/contracts/contracts/gateway/router/TopDownFinalityFacet.sol#L64).
- Bottom up checkpoints fail because they are only signed by this one validator with power, but the subnet contract on the parent still thinks (correctly) that the total collateral is from three validators, ie, the quorum threshold is higher than what's included in the checkpoint. Checkpoint fails with [`WeightsSumLessThanThreshold`](https://github.com/consensus-shipyard/ipc/blob/d0892f21a1d4c7e22106abe6786fb68477e3c37e/contracts/contracts/lib/LibMultisignatureChecker.sol#L68)
- You can see this reflected in the power as known by cometbft by looking at the nodes' status endpoint (`http://localhost:<comet_rpc_port>/status`). Power is zero for the first two nodes. 

I'm not sure if this fix is ideal, but it works. It just adds the genesis validators to the parent validator tracker before setting the initial membership in the gateway constructor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/consensus-shipyard/ipc/1166)
<!-- Reviewable:end -->
