### PR TITLE
refactor: replace LogLevel type with String

### DIFF
--- a/contracts/sdk/IpcContractUpgradeable.sol
+++ b/contracts/sdk/IpcContractUpgradeable.sol
@@ -27,6 +27,7 @@ abstract contract IpcExchangeUpgradeable is Initializable, IIpcHandler, OwnableU
         _disableInitializers();
     }
 
+    // solhint-disable-next-line func-name-mixedcase
     function __IpcExchangeUpgradeable_init(address gatewayAddr_) public onlyInitializing {
         gatewayAddr = gatewayAddr_;
         __Ownable_init(msg.sender);

--- a/ipc/observability/src/config.rs
+++ b/ipc/observability/src/config.rs
@@ -7,28 +7,6 @@ use std::path::PathBuf;
 use strum;
 use tracing_appender;
 use tracing_appender::rolling::Rotation;
-use tracing_subscriber::filter::EnvFilter;
-
-#[serde_as]
-#[derive(Debug, Deserialize, Clone, Default, strum::EnumString, strum::Display)]
-#[strum(serialize_all = "snake_case")]
-#[serde(rename_all = "lowercase")]
-pub enum LogLevel {
-    Off,
-    Error,
-    Warn,
-    #[default]
-    Info,
-    Debug,
-    Trace,
-}
-
-impl From<LogLevel> for EnvFilter {
-    fn from(val: LogLevel) -> Self {
-        // By default EnvFilter uses INFO, just like our default log level.
-        EnvFilter::try_new(val.to_string()).unwrap_or_default()
-    }
-}
 
 #[serde_as]
 #[derive(Debug, Deserialize, Clone, strum::EnumString, strum::Display)]
@@ -73,14 +51,14 @@ pub struct TracingSettings {
 #[serde_as]
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct ConsoleLayerSettings {
-    pub level: Option<LogLevel>,
+    pub level: Option<String>,
 }
 
 #[serde_as]
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct FileLayerSettings {
     pub enabled: bool,
-    pub level: Option<LogLevel>,
+    pub level: Option<String>,
     pub directory: Option<PathBuf>,
     pub max_log_files: Option<usize>,
     pub rotation: Option<RotationKind>,

--- a/ipc/observability/src/traces.rs
+++ b/ipc/observability/src/traces.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::config::{FileLayerSettings, LogLevel, TracingSettings};
+use crate::config::{FileLayerSettings, TracingSettings};
 use crate::tracing_layers::DomainEventFilterLayer;
 use std::num::NonZeroUsize;
 use tracing::Level;
@@ -95,7 +95,7 @@ pub fn set_global_tracing_subscriber(config: &TracingSettings) -> Vec<WorkerGuar
 
             let mut filter: EnvFilter = file_settings.level.clone().unwrap_or_default().into();
             filter = filter.add_directive(
-                format!("{TRACING_TARGET}={}", LogLevel::Off)
+                format!("{TRACING_TARGET}=off")
                     .parse()
                     .expect("invalid logs level"),
             );


### PR DESCRIPTION
This allows for more flexible log filters like `info,fendermint=debug`.

This also includes a small solhint fix to get `make lint` to work for me locally. My compiler uses solidity `0.8.26`.