### PR TITLE
feat: ipc cli util command to convert f4 to eth address

### DIFF
--- a/ipc/cli/src/commands/util/eth.rs
+++ b/ipc/cli/src/commands/util/eth.rs
@@ -1,0 +1,33 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: MIT
+//! Eth address util
+
+use async_trait::async_trait;
+use clap::Args;
+use fvm_shared::address::Address;
+use ipc_api::evm::payload_to_evm_address;
+use std::fmt::Debug;
+use std::str::FromStr;
+
+use crate::{CommandLineHandler, GlobalArguments};
+
+pub(crate) struct F4ToEthAddr;
+
+#[async_trait]
+impl CommandLineHandler for F4ToEthAddr {
+    type Arguments = F4ToEthAddrArgs;
+
+    async fn handle(_global: &GlobalArguments, arguments: &Self::Arguments) -> anyhow::Result<()> {
+        let addr = Address::from_str(&arguments.addr)?;
+        let eth_addr = payload_to_evm_address(addr.payload())?;
+        log::info!("eth address: {:?}", eth_addr);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Args)]
+#[command(about = "Get Ethereum address for an F4")]
+pub(crate) struct F4ToEthAddrArgs {
+    #[arg(long, help = "F4 address to get the underlying Ethereum addr from")]
+    pub addr: String,
+}

--- a/ipc/cli/src/commands/util/f4.rs
+++ b/ipc/cli/src/commands/util/f4.rs
@@ -19,7 +19,7 @@ impl CommandLineHandler for EthToF4Addr {
 
     async fn handle(_global: &GlobalArguments, arguments: &Self::Arguments) -> anyhow::Result<()> {
         let eth_addr = EthAddress::from_str(&arguments.addr)?;
-        log::info!("f4 address: {:}", Address::from(eth_addr));
+        log::info!("f4 address: {}", Address::from(eth_addr));
         Ok(())
     }
 }

--- a/ipc/cli/src/commands/util/mod.rs
+++ b/ipc/cli/src/commands/util/mod.rs
@@ -4,8 +4,10 @@ use crate::{CommandLineHandler, GlobalArguments};
 
 use clap::{Args, Subcommand};
 
+use self::eth::{F4ToEthAddr, F4ToEthAddrArgs};
 use self::f4::{EthToF4Addr, EthToF4AddrArgs};
 
+mod eth;
 mod f4;
 
 #[derive(Debug, Args)]
@@ -20,6 +22,7 @@ impl UtilCommandsArgs {
     pub async fn handle(&self, global: &GlobalArguments) -> anyhow::Result<()> {
         match &self.command {
             Commands::EthToF4Addr(args) => EthToF4Addr::handle(global, args).await,
+            Commands::F4ToEthAddr(args) => F4ToEthAddr::handle(global, args).await,
         }
     }
 }
@@ -27,4 +30,5 @@ impl UtilCommandsArgs {
 #[derive(Debug, Subcommand)]
 pub(crate) enum Commands {
     EthToF4Addr(EthToF4AddrArgs),
+    F4ToEthAddr(F4ToEthAddrArgs),
 }


### PR DESCRIPTION
This is useful when you need to get the eth contract address from a subnet ID to do, for example, a token approval from a token collateral erc20 contract to the subnet actor contract.