### PR TITLE
feat(node): call state from exec state

### DIFF
--- a/fendermint/vm/interpreter/src/fvm/externs.rs
+++ b/fendermint/vm/interpreter/src/fvm/externs.rs
@@ -36,9 +36,10 @@ where
     }
 }
 
-impl <DB> FendermintExterns<DB>
-    where
-        DB: Blockstore + 'static + Clone,{
+impl<DB> FendermintExterns<DB>
+where
+    DB: Blockstore + 'static + Clone,
+{
     pub fn read_only_clone(&self) -> FendermintExterns<ReadOnlyBlockstore<DB>> {
         FendermintExterns {
             blockstore: ReadOnlyBlockstore::new(self.blockstore.clone()),

--- a/fendermint/vm/interpreter/src/fvm/externs.rs
+++ b/fendermint/vm/interpreter/src/fvm/externs.rs
@@ -36,6 +36,17 @@ where
     }
 }
 
+impl <DB> FendermintExterns<DB>
+    where
+        DB: Blockstore + 'static + Clone,{
+    pub fn read_only_clone(&self) -> FendermintExterns<ReadOnlyBlockstore<DB>> {
+        FendermintExterns {
+            blockstore: ReadOnlyBlockstore::new(self.blockstore.clone()),
+            state_root: self.state_root,
+        }
+    }
+}
+
 impl<DB> Rand for FendermintExterns<DB>
 where
     DB: Blockstore + 'static,

--- a/fendermint/vm/interpreter/src/fvm/state/exec.rs
+++ b/fendermint/vm/interpreter/src/fvm/state/exec.rs
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
 use anyhow::Ok;
@@ -14,6 +15,7 @@ use fvm::{
     state_tree::StateTree,
     DefaultKernel,
 };
+use fvm::engine::EnginePool;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{
@@ -26,6 +28,7 @@ use serde_with::serde_as;
 use crate::fvm::externs::FendermintExterns;
 use fendermint_vm_core::{chainid::HasChainID, Timestamp};
 use fendermint_vm_encoding::IsHumanReadable;
+use crate::fvm::store::ReadOnlyBlockstore;
 
 pub type BlockHash = [u8; 32];
 
@@ -113,6 +116,8 @@ where
 
     /// Indicate whether the parameters have been updated.
     params_dirty: bool,
+
+    executor_info: ExecutorInfo<DB>,
 }
 
 impl<DB> FvmExecState<DB>
@@ -145,8 +150,8 @@ where
 
         let engine = multi_engine.get(&nc)?;
         let externs = FendermintExterns::new(blockstore.clone(), params.state_root);
-        let machine = DefaultMachine::new(&mc, blockstore, externs)?;
-        let executor = DefaultExecutor::new(engine, machine)?;
+        let machine = DefaultMachine::new(&mc, blockstore.clone(), externs)?;
+        let executor = DefaultExecutor::new(engine.clone(), machine)?;
 
         Ok(Self {
             executor,
@@ -159,6 +164,10 @@ where
                 power_scale: params.power_scale,
             },
             params_dirty: false,
+            executor_info: ExecutorInfo {
+                engine_pool: engine,
+                store: blockstore.clone(),
+            },
         })
     }
 
@@ -310,6 +319,21 @@ where
         f(&mut self.params);
         self.params_dirty = true;
     }
+
+    pub fn call_state(&self) -> anyhow::Result<FvmCallState<DB>> {
+        let externs = self.executor.externs().read_only_clone();
+        let machine = DefaultMachine::new(
+            self.executor.context(),
+            ReadOnlyBlockstore::new(self.executor_info.store.clone()),
+            externs
+        )?;
+
+        Ok(FvmCallState {
+            executor: RefCell::new(
+                DefaultExecutor::new(self.executor_info.engine_pool.clone(), machine)?
+            )
+        })
+    }
 }
 
 impl<DB> HasChainID for FvmExecState<DB>
@@ -349,4 +373,30 @@ fn check_error(e: anyhow::Error) -> (ApplyRet, ActorAddressMap) {
         events: Vec::new(),
     };
     (ret, Default::default())
+}
+
+/// Tracks the metadata about the executor, so that it can be used to clone itself or create call state
+struct ExecutorInfo<DB> {
+    engine_pool: EnginePool,
+    store: DB,
+}
+
+type CallExecutor<DB> = DefaultExecutor<
+    DefaultKernel<DefaultCallManager<DefaultMachine<ReadOnlyBlockstore<DB>, FendermintExterns<ReadOnlyBlockstore<DB>>>>>,
+>;
+
+/// A state we create for the calling the getters through fvm
+pub struct FvmCallState<DB>
+    where
+        DB: Blockstore + Clone + 'static,
+{
+    executor: RefCell<CallExecutor<DB>>,
+}
+
+impl <DB: Blockstore + Clone + 'static> FvmCallState<DB> {
+    pub fn call(&self, msg: Message) -> anyhow::Result<ApplyRet> {
+        let mut inner = self.executor.borrow_mut();
+        let raw_length = fvm_ipld_encoding::to_vec(&msg).map(|bz| bz.len())?;
+        Ok(inner.execute_message(msg, ApplyKind::Implicit, raw_length)?)
+    }
 }


### PR DESCRIPTION
Currently to invoke getter fvm actors, one must use the `FvmExecState` which is taking `&mut self`. This imposes some restrictions on how tratis, query functions are written as it forces getter to use `&mut self` if the getter is hold `FvmExecState`.

This PR creates a `FvmCallState` from `FvmExecState` so that when calling getters, it's a `&self` instead of `&mut self`. Behind the scene it's using a `ReadOnlyBlockStore` wrapper for the blockstore to ensure no data will be committed.

Fendermint already has `FvmQueryState` for the `App`, I also looked into that strcut first, but it seems to be holding quite a few fields which is pretty difficult to derive from `FvmExecState`. The current approach might be easier or smaller a change.