### PR TITLE
Docs: Fix a broken reference for the subnets webpage

### DIFF
--- a/docs-gitbook/README.md
+++ b/docs-gitbook/README.md
@@ -22,7 +22,7 @@ IPC is a scaling solution intentionally designed to achieve considerable perform
 
 It achieves scaling through the permission-less spawning of new blockchain sub-systems, which are composed of subnets.&#x20;
 
-[Subnets](broken-reference) are organized in a hierarchy, with one parent subnet being able to spawn infinite child subnets. Within a hierarchical subsystem, subnets can seamlessly communicate with each other, reducing the need for cross-chain bridges.
+[Subnets](concepts/subnets/README.md) are organized in a hierarchy, with one parent subnet being able to spawn infinite child subnets. Within a hierarchical subsystem, subnets can seamlessly communicate with each other, reducing the need for cross-chain bridges.
 
 Subnets also have their own specific consensus algorithms, whilst leveraging security features from parent subnets. This allows dApps to use subnets for hosting sets of applications or to [shard](https://en.wikipedia.org/wiki/Shard\_\(database\_architecture\)) a single application, according to its various cost or performance needs. \
 \


### PR DESCRIPTION
While reading the IPC docs, I realized the subnets link from the main page at https://docs.ipc.space/ is broken.

I suspect the link should redirect to https://docs.ipc.space/concepts/subnets and this is what this MR achieves.

### How to test

On the https://docs.ipc.space/ , clicking on the "subnets" link goes to a 404 like page.

On my local fork https://github.com/francoisthire/ipc/tree/main/docs-gitbook we can check the link works as expected.

### Note

I have tried to test it locally with [gitbook-cli](https://github.com/GitbookIO/gitbook-cli) but the tool is deprecated and does not compile anymore with a recent version of node. Maybe there is a way to test it with their online editor at https://www.gitbook.com/ but I did not find how.