### PR TITLE
fix: update deploy command for calibration net

### DIFF
--- a/scripts/deploy_subnet_under_calibration_net/deploy.sh
+++ b/scripts/deploy_subnet_under_calibration_net/deploy.sh
@@ -153,7 +153,7 @@ cd ${IPC_FOLDER}/contracts
 npm install
 export RPC_URL=https://calibration.filfox.info/rpc/v1
 export PRIVATE_KEY=$(cat ${IPC_CONFIG_FOLDER}/validator_0.sk)
-deploy_contracts_output=$(make deploy-ipc NETWORK=calibrationnet)
+deploy_contracts_output=$(make deploy-stack NETWORK=calibrationnet)
 
 parent_gateway_address=$(echo "$deploy_contracts_output" | grep '"Gateway"' | awk -F'"' '{print $4}')
 parent_registry_address=$(echo "$deploy_contracts_output" | grep '"SubnetRegistry"' | awk -F'"' '{print $4}')


### PR DESCRIPTION
 

**Description:**  
This PR updates the deploy command in the `deploy.sh` script under the calibration net deployment process. Specifically, the command was changed from `make deploy-ipc` to `make deploy-stack` to ensure proper contract deployment on the calibration network.

**Changes:**
- Updated `deploy.sh` script to use the correct `deploy-stack` command for calibration net.

**Testing:**  
The change was tested locally and confirmed to deploy the contracts correctly on the calibration network.
 