### PR TITLE
fix: fix HumanReadable serialization error

### DIFF
--- a/ipc/api/src/lib.rs
+++ b/ipc/api/src/lib.rs
@@ -96,7 +96,11 @@ impl serde_with::SerializeAs<Vec<u8>> for HumanReadable {
     where
         S: Serializer,
     {
-        hex::encode(source).serialize(serializer)
+        if serializer.is_human_readable() {
+            hex::encode(source).serialize(serializer)
+        } else {
+            source.serialize(serializer)
+        }
     }
 }
 
@@ -112,5 +116,34 @@ impl<'de> serde_with::DeserializeAs<'de, Vec<u8>> for HumanReadable {
         } else {
             Vec::<u8>::deserialize(deserializer)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::HumanReadable;
+    use serde::{Deserialize, Serialize};
+    use serde_with::serde_as;
+
+    #[test]
+    fn test_human_readable() {
+        #[serde_as]
+        #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+        struct T {
+            #[serde_as(as = "HumanReadable")]
+            bytes: Vec<u8>,
+        }
+
+        let t = T {
+            bytes: vec![1, 2, 3, 4],
+        };
+
+        let serialized_t = serde_json::to_vec(&t).unwrap();
+        let dserialized_t = serde_json::from_slice(&serialized_t).unwrap();
+        assert_eq!(t, dserialized_t);
+
+        let serialized_t = fvm_ipld_encoding::to_vec(&t).unwrap();
+        let dserialized_t = fvm_ipld_encoding::from_slice(&serialized_t).unwrap();
+        assert_eq!(t, dserialized_t);
     }
 }


### PR DESCRIPTION
Fix a human readable serialisation error from testing new topdown checkpointing. I think I have fixed this before in one of the PRs, but somehow the commit is lost.

Basically the fix is about when Human Readable serialiser is used, it should be doing a check instead of using string serialisation all the way.