### PR TITLE
fix: docs for deploy command

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -31,7 +31,7 @@ and run `source .env` before running the deployment scripts.
 To deploy the IPC Solidity contracts in an FEVM network, you can directly run the following:
 
 ```bash
-make deploy-ipc
+make deploy-stack
 ```
 
 The scripts run by `make` make use of hardhat under the hood.
@@ -40,7 +40,7 @@ and perform the deployment according to the configuration in `hardhat.config.ts`
 To deploy the contracts in some other network configured in the Hardhat config you can run the following:
 
 ```bash
-make deploy-ipc NETWORK=<network-name>
+make deploy-stack NETWORK=<network-name>
 ```
 
 # Upgrading IPC Solidity Contracts

--- a/docs/ipc/deploying-hierarchy.md
+++ b/docs/ipc/deploying-hierarchy.md
@@ -4,15 +4,17 @@ We recommend that you connect to the existing contracts on CalibrationNet. Never
 
 ## Install prerequisites
 
-* Install the basic requirements for IPC (see [README](../../README.md#Prerequisites))
+- Install the basic requirements for IPC (see [README](../../README.md#Prerequisites))
 
-* Install Node.js [Ubuntu] ([details](https://github.com/nodesource/distributions))
+- Install Node.js [Ubuntu] ([details](https://github.com/nodesource/distributions))
+
 ```bash
 curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
 sudo apt-get install nodejs
 ```
 
-* Get the Solidity actors and install dependencies
+- Get the Solidity actors and install dependencies
+
 ```bash
 cd contracts
 npm install
@@ -20,16 +22,16 @@ npm install
 
 ## Set up and fund an EVM account
 
-* Connect Metamask to the parent network (for calibrationnet, use `https://api.calibration.node.glif.io/rpc/v1` as the RPC and `314159` as the chain id)
+- Connect Metamask to the parent network (for calibrationnet, use `https://api.calibration.node.glif.io/rpc/v1` as the RPC and `314159` as the chain id)
 
-* Create a new account (or use an existing one)
+- Create a new account (or use an existing one)
 
-* Export the corresponding private key according to [these steps](https://support.metamask.io/hc/en-us/articles/360015289632-How-to-export-an-account-s-private-key)
-
+- Export the corresponding private key according to [these steps](https://support.metamask.io/hc/en-us/articles/360015289632-How-to-export-an-account-s-private-key)
 
 ## Deploy the contracts
 
 Once inside the repo, you'll need to populate the `.env.template` file with the private key of the address you provided with funds in the previous step, and the endpoint of the target network on which you want to deploy
+
 ```bash
 export PRIVATE_KEY=<your_private_key>
 export RPC_URL=https://api.calibration.node.glif.io/rpc/v1
@@ -39,7 +41,7 @@ In your currently open terminal, you'll need to load these variables into your e
 
 ```bash
 source .env.template
-make deploy-ipc NETWORK=calibrationnet
+make deploy-stack NETWORK=calibrationnet
 ```
 
 If the deployment is successful, you should receive an output similar to this one:
@@ -65,4 +67,4 @@ registry contract deployed to: <REGISTRY_ADDRESS>
 
 Keep the addresses of the gateway and the registry contracts deployed, as you will need them to configure the IPC agent.
 
->💡If instead of deploying IPC Solidity in Calibration, you want to test them in a local network, the only thing that you need to do is to configure the `RPC_URL` of your `.env` to point to the corresponding network's RPC endpoint, and `make deploy-ipc NETWORK=localnet`. You can also use `NETWORK=auto` to let the deployment scripts figure out the chain ID and all the information required to deploy IPC over the network that `RPC_URL` is pointing to.
+> 💡If instead of deploying IPC Solidity in Calibration, you want to test them in a local network, the only thing that you need to do is to configure the `RPC_URL` of your `.env` to point to the corresponding network's RPC endpoint, and `make deploy-stack NETWORK=localnet`. You can also use `NETWORK=auto` to let the deployment scripts figure out the chain ID and all the information required to deploy IPC over the network that `RPC_URL` is pointing to.


### PR DESCRIPTION
Following up on the previous fix in [PR #1184](https://github.com/consensus-shipyard/ipc/pull/1184) — aligning documentation with these changes.