### PR TITLE
fix: add `--artifacts-path` flag documentation

### DIFF
--- a/docs/fendermint/running.md
+++ b/docs/fendermint/running.md
@@ -221,7 +221,8 @@ cargo run -p fendermint_app --release -- \
     seal-genesis \
       --builtin-actors-path fendermint/builtin-actors/output/bundle.car \
       --custom-actors-path fendermint/actors/output/custom_actors_bundle.car \
-      --output-path test-network/sealed.car
+      --output-path test-network/sealed.car \ 
+      --artifacts-path contracts/out
 ```
 
 ### Configure CometBFT


### PR DESCRIPTION
Small fix for specifying the `--artifacts-path` flag needed for `seal-genesis` command. 

Without it, the command fails with the following output: 
```
2024-11-12T08:55:38.110971Z ERROR fendermint/app/src/main.rs:45: failed to execute Options { home_dir: "~/.fendermint", config_dir: None, mode: "dev", global: GlobalArgs { network: Testnet }, command: Genesis(GenesisArgs { genesis_file: "test-network/genesis.json", command: Ipc { command: SealGenesis(SealGenesisArgs { builtin_actors_path: "fendermint/builtin-actors/output/bundle.car", custom_actors_path: "fendermint/actors/output/custom_actors_bundle.car", artifacts_path: None, output_path: "test-network/sealed.car" }) } }) }: ipc enabled but artifacts path not provided