### PR TITLE
fix: metrics validator label to use address instead of pk struct formatting

### DIFF
--- a/fendermint/app/src/cmd/run.rs
+++ b/fendermint/app/src/cmd/run.rs
@@ -125,7 +125,7 @@ async fn run(settings: Settings) -> anyhow::Result<()> {
         .with_max_retries(settings.broadcast.max_retries)
         .with_retry_delay(settings.broadcast.retry_delay);
 
-        ValidatorContext::new(sk, broadcaster)
+        ValidatorContext::new(sk, addr, broadcaster)
     });
 
     let testing_settings = match settings.testing.as_ref() {

--- a/fendermint/vm/interpreter/src/fvm/checkpoint.rs
+++ b/fendermint/vm/interpreter/src/fvm/checkpoint.rs
@@ -261,7 +261,7 @@ where
                 role: CheckpointSignedRole::Own,
                 height: height.value(),
                 hash: HexEncodableBlockHash(cp.block_hash.to_vec()),
-                validator: validator_ctx.public_key,
+                validator: validator_ctx.addr,
             });
 
             tracing::debug!(?height, "submitted checkpoint signature");

--- a/fendermint/vm/interpreter/src/fvm/mod.rs
+++ b/fendermint/vm/interpreter/src/fvm/mod.rs
@@ -24,6 +24,7 @@ pub use exec::FvmApplyRet;
 use fendermint_crypto::{PublicKey, SecretKey};
 pub use fendermint_vm_message::query::FvmQuery;
 use fvm_ipld_blockstore::Blockstore;
+use fvm_shared::address::Address;
 pub use query::FvmQueryRet;
 use tendermint_rpc::Client;
 
@@ -40,18 +41,21 @@ pub struct ValidatorContext<C> {
     secret_key: SecretKey,
     /// The public key identifying the validator (corresponds to the secret key.)
     public_key: PublicKey,
+    /// The address associated with the public key.
+    addr: Address,
     /// Used to broadcast transactions. It might use a different secret key for
     /// signing transactions than the validator's block producing key.
     broadcaster: Broadcaster<C>,
 }
 
 impl<C> ValidatorContext<C> {
-    pub fn new(secret_key: SecretKey, broadcaster: Broadcaster<C>) -> Self {
+    pub fn new(secret_key: SecretKey, addr: Address, broadcaster: Broadcaster<C>) -> Self {
         // Derive the public keys so it's available to check whether this node is a validator at any point in time.
         let public_key = secret_key.public_key();
         Self {
             secret_key,
             public_key,
+            addr,
             broadcaster,
         }
     }

--- a/fendermint/vm/interpreter/src/fvm/observe.rs
+++ b/fendermint/vm/interpreter/src/fvm/observe.rs
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fvm_shared::address::Address;
 use ipc_observability::{
     impl_traceable, impl_traceables, lazy_static, register_metrics, serde::HexEncodableBlockHash,
     Recordable, TraceLevel, Traceable,
@@ -115,8 +116,10 @@ pub struct CheckpointSigned {
 
 impl Recordable for CheckpointSigned {
     fn record_metrics(&self) {
+        let pk = self.validator.serialize();
+        let addr = Address::new_secp256k1(&pk).unwrap();
         BOTTOMUP_CHECKPOINT_SIGNED_HEIGHT
-            .with_label_values(&[format!("{:?}", self.validator).as_str()])
+            .with_label_values(&[format!("{}", addr).as_str()])
             .set(self.height as i64);
     }
 }

--- a/fendermint/vm/interpreter/src/fvm/observe.rs
+++ b/fendermint/vm/interpreter/src/fvm/observe.rs
@@ -146,11 +146,9 @@ mod tests {
 
     #[test]
     fn test_emit() {
-        use fendermint_crypto::SecretKey;
         use fvm_ipld_encoding::RawBytes;
         use fvm_shared::address::Address;
         use fvm_shared::econ::TokenAmount;
-        use rand::thread_rng;
 
         let message = Message {
             version: 1,
@@ -181,16 +179,11 @@ mod tests {
             config_number: 3,
         });
 
-        let mut r = thread_rng();
-        let secret_key = SecretKey::random(&mut r);
-        let pk = secret_key.public_key().serialize();
-        let addr = Address::new_secp256k1(&pk).unwrap();
-
         emit(CheckpointSigned {
             role: CheckpointSignedRole::Own,
             height: 1,
             hash: HexEncodableBlockHash(hash.clone()),
-            validator: addr,
+            validator: Address::new_id(1),
         });
     }
 }

--- a/fendermint/vm/interpreter/src/fvm/observe.rs
+++ b/fendermint/vm/interpreter/src/fvm/observe.rs
@@ -184,7 +184,7 @@ mod tests {
         let mut r = thread_rng();
         let secret_key = SecretKey::random(&mut r);
         let pk = secret_key.public_key().serialize();
-        let addr =  Address::new_secp256k1(&pk).unwrap();
+        let addr = Address::new_secp256k1(&pk).unwrap();
 
         emit(CheckpointSigned {
             role: CheckpointSignedRole::Own,


### PR DESCRIPTION
Closes https://github.com/consensus-shipyard/ipc/issues/1190

I used address instead of the public key hex encoding. Can change that if wanted. 