### PR TITLE
fix: enforce paris evm version

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -16,6 +16,7 @@ remappings = [
     "murky/=lib/murky/src/",
 ]
 allow_paths = ["../node_modules"]
+evm_version = "paris"
 
 [fuzz]
 runs = 512


### PR DESCRIPTION
The newest foundry nightly build now uses cancun as the default EVM version (https://github.com/foundry-rs/foundry/pull/9131). This breaks everything in IPC because transient storage opcodes are not supported.