### PR TITLE
fix: fix inconsistent network btw eth and fendermint

### DIFF
--- a/infra/fendermint/scripts/ethapi.toml
+++ b/infra/fendermint/scripts/ethapi.toml
@@ -12,6 +12,7 @@ docker run \
   --env LOG_LEVEL=${ETHAPI_LOG_LEVEL} \
   --env RUST_BACKTRACE=1 \
   ${FM_DOCKER_IMAGE} \
+  --network=${FM_NETWORK} \
   ${CMD}
 """
 dependencies = ["docker-network-create"]


### PR DESCRIPTION
Fixing a bug in infra script that causes ethapi and fendermint to be on different network config.