### PR TITLE
fix: contracts auto-deploy GitHub Actions workflow

### DIFF
--- a/.github/workflows/auto-deploy-contracts.yaml
+++ b/.github/workflows/auto-deploy-contracts.yaml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: write
-  workflows: write
 
 env:
   GIT_USERNAME: github-actions[bot]
@@ -24,19 +23,28 @@ concurrency:
 jobs:
   deploy-contracts:
     runs-on: ubuntu-latest
+
     env:
       RPC_URL: https://calibration.filfox.io/rpc/v1
       PRIVATE_KEY: ${{ secrets.CONTRACTS_DEPLOYER_PRIVATE_KEY }}
+
     steps:
       - name: Configure git
         run: |
           git config --global user.name "$GIT_USERNAME"
           git config --global user.email "$GIT_EMAIL"
 
-      - name: Checkout cd/contracts branch-test
+      - name: Setup node and npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'pnpm-lock.yaml'
+
+      - name: Check out the branch that triggered this run
         uses: actions/checkout@v4
         with:
-          ref: cd/contracts-test
+          ref: ${{ github.ref_name }}
           submodules: recursive
           fetch-depth: 0
 
@@ -54,30 +62,6 @@ jobs:
             contracts/out
             contracts/deployments
             contracts/artifacts
-
-      - name: (Dry run) Try merge from main to fail early if there are unresolvable conflicts
-        run: |
-          git show HEAD
-          git checkout main
-          git pull --rebase origin main
-          git checkout cd/contracts-test
-          git merge main --no-edit --allow-unrelated-histories
-
-      - name: Checkout the branch that triggered this run
-        uses: actions/checkout@v4
-        with:
-          # TODO(jie): After switch to workflow_dispatch only, we should use ref_name.
-          # head_ref only works for workflow triggered by pull requests.
-          # ref: ${{ github.ref_name }}
-          ref: ${{ github.head_ref }}
-          submodules: recursive
-
-      - name: Setup node and npm
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Deploy IPC contracts to Calibrationnet
         id: deploy_contracts
@@ -105,30 +89,22 @@ jobs:
           echo "gateway_address: $gateway_address"
           echo "registry_address: $registry_address"
 
-      - name: Switch code repo to cd/contracts branch-test
+      - name: Switch code repo to cd/contracts branch
         uses: actions/checkout@v4
         with:
-          ref: cd/contracts-test
+          ref: cd/contracts
           submodules: recursive
           fetch-depth: 0
 
-      - name: Merge from main branch and update cd/contracts branch-test
-        run: |
-          git checkout main
-          git pull --rebase origin main
-          git checkout cd/contracts-test
-          git merge main --no-edit --allow-unrelated-histories
-          git push -f origin cd/contracts-test
-
-      - name: Write deployed address to output file
+      - name: Write deployment addresses
         run: |
           mkdir -p deployments
           json_str='{"commit":"'$commit_hash'","gateway_addr":"'$gateway_address'","registry_addr":"'$registry_address'"}'
           jq -n "$json_str" > deployments/r314159.json
           cat deployments/r314159.json
 
-      - name: Commit output file and push it to remote repo
+      - name: Commit and push deployment addresses file
         run: |
           git add deployments/r314159.json
-          git commit -m "Update contract address"
-          git push origin cd/contracts-test
+          git commit -m "Contracts deployed @ ${{ github.sha }}"
+          git push origin cd/contracts

--- a/.github/workflows/auto-deploy-contracts.yaml
+++ b/.github/workflows/auto-deploy-contracts.yaml
@@ -41,12 +41,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Setup node and npm
+      - name: Set up node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: 'npm'
-          cache-dependency-path: 'pnpm-lock.yaml'
+          node-version: '21'
+          cache: 'pnpm'
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/auto-deploy-contracts.yaml
+++ b/.github/workflows/auto-deploy-contracts.yaml
@@ -34,6 +34,8 @@ jobs:
           git config --global user.name "$GIT_USERNAME"
           git config --global user.email "$GIT_EMAIL"
 
+      - uses: pnpm/action-setup@v2
+
       - name: Check out the branch that triggered this run
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/auto-deploy-contracts.yaml
+++ b/.github/workflows/auto-deploy-contracts.yaml
@@ -28,10 +28,10 @@ jobs:
       RPC_URL: https://calibration.filfox.io/rpc/v1
       PRIVATE_KEY: ${{ secrets.CONTRACTS_DEPLOYER_PRIVATE_KEY }}
     steps:
-      - name: Checkout cd/contracts branch
+      - name: Checkout cd/contracts branch-test
         uses: actions/checkout@v4
         with:
-          ref: cd/contracts
+          ref: cd/contracts-test
           submodules: recursive
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
           git show HEAD
           git checkout main
           git pull --rebase origin main
-          git checkout cd/contracts
+          git checkout cd/contracts-test
           git merge main --no-edit --allow-unrelated-histories
 
       - name: Checkout the branch that triggered this run
@@ -90,20 +90,20 @@ jobs:
           echo "gateway_address: $gateway_address"
           echo "registry_address: $registry_address"
 
-      - name: Switch code repo to cd/contracts branch
+      - name: Switch code repo to cd/contracts branch-test
         uses: actions/checkout@v4
         with:
-          ref: cd/contracts
+          ref: cd/contracts-test
           submodules: recursive
           fetch-depth: 0
 
-      - name: Merge from main branch and update cd/contracts branch
+      - name: Merge from main branch and update cd/contracts branch-test
         run: |
           git checkout main
           git pull --rebase origin main
-          git checkout cd/contracts
+          git checkout cd/contracts-test
           git merge main --no-edit --allow-unrelated-histories
-          git push -f origin cd/contracts
+          git push -f origin cd/contracts-test
 
       - name: Write deployed address to output file
         run: |
@@ -116,4 +116,4 @@ jobs:
         run: |
           git add deployments/r314159.json
           git commit -m "Update contract address"
-          git push origin cd/contracts
+          git push origin cd/contracts-test

--- a/.github/workflows/auto-deploy-contracts.yaml
+++ b/.github/workflows/auto-deploy-contracts.yaml
@@ -34,19 +34,19 @@ jobs:
           git config --global user.name "$GIT_USERNAME"
           git config --global user.email "$GIT_EMAIL"
 
-      - name: Setup node and npm
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-          cache-dependency-path: 'pnpm-lock.yaml'
-
       - name: Check out the branch that triggered this run
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
           submodules: recursive
           fetch-depth: 0
+
+      - name: Setup node and npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Cache artifacts
         uses: actions/cache@v4

--- a/.github/workflows/auto-deploy-contracts.yaml
+++ b/.github/workflows/auto-deploy-contracts.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  workflows: write
 
 env:
   GIT_USERNAME: github-actions[bot]

--- a/.github/workflows/auto-deploy-contracts.yaml
+++ b/.github/workflows/auto-deploy-contracts.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           cd contracts
           pnpm install
-          output=$(make deploy-stack NETWORK=calibrationnet | tee /dev/tty)
+          output=$(make deploy-stack NETWORK=calibrationnet | tee /dev/stdout)
           echo "deploy_output<<EOF" >> $GITHUB_OUTPUT
           echo "$output" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/auto-deploy-contracts.yaml
+++ b/.github/workflows/auto-deploy-contracts.yaml
@@ -52,8 +52,9 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Cache artifacts
-        uses: actions/cache@v4
+      - name: Restore cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
         with:
           ## Hardhat is intelligent enough to perform incremental compilation. But GitHub Actions caches are immutable.
           ## Since we can't have a rolling cache, we create a new cache for each run, but use restore-keys to load the
@@ -74,26 +75,27 @@ jobs:
         run: |
           cd contracts
           pnpm install
-          output=$(make deploy-stack NETWORK=calibrationnet | tee /dev/stdout)
-          echo "deploy_output<<EOF" >> $GITHUB_OUTPUT
-          echo "$output" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          make deploy-stack NETWORK=calibrationnet
 
-      - name: Extract deployed addresses
-        run: |
-          deploy_output='${{ steps.deploy_contracts.outputs.deploy_output }}'
-          echo "$deploy_output"
-          deployed_gateway_address=$(jq -r ".address" deployments/calibrationnet/GatewayDiamond.json)
-          deployed_registry_address=$(jq -r ".address" deployments/calibrationnet/SubnetRegistryDiamond.json)
-          echo "gateway_address=$deployed_gateway_address" >> $GITHUB_ENV
-          echo "registry_address=$deployed_registry_address" >> $GITHUB_ENV
-          echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_ENV
+      - name: Save cache
+        id: cache-save
+        uses: actions/cache/save@v4
+        if: always() && steps.cache-restore.outputs.cache-hit != 'true'
+        with:
+          key: ${{ runner.os }}-contracts-artifacts-${{ github.run_id }}
+          path: |
+            contracts/out
+            contracts/deployments
+            contracts/artifacts
 
-      - name: Review deployed addresses
+      - name: Populate output
         run: |
-          echo "commit_hash: $commit_hash"
-          echo "gateway_address: $gateway_address"
-          echo "registry_address: $registry_address"
+          cd contracts
+          jq -n --arg commit "$(git rev-parse HEAD)" \
+            --arg gateway_addr "$(jq -r '.address' deployments/calibrationnet/GatewayDiamond.json)" \
+            --arg registry_addr "$(jq -r '.address' deployments/calibrationnet/SubnetRegistryDiamond.json)" \
+            '{"commit":$commit, "gateway_addr":$gateway_addr, "registry_addr":$registry_addr}' > /tmp/output.json
+          cat /tmp/output.json
 
       - name: Switch code repo to cd/contracts branch
         uses: actions/checkout@v4
@@ -102,15 +104,10 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Write deployment addresses
+      - name: Commit and push deployment info
         run: |
           mkdir -p deployments
-          json_str='{"commit":"'$commit_hash'","gateway_addr":"'$gateway_address'","registry_addr":"'$registry_address'"}'
-          jq -n "$json_str" > deployments/r314159.json
-          cat deployments/r314159.json
-
-      - name: Commit and push deployment addresses file
-        run: |
+          cp /tmp/output.json deployments/r314159.json
           git add deployments/r314159.json
           git commit -m "Contracts deployed @ ${{ github.sha }}"
           git push origin cd/contracts

--- a/.github/workflows/auto-deploy-contracts.yaml
+++ b/.github/workflows/auto-deploy-contracts.yaml
@@ -1,4 +1,4 @@
-name: Auto deploy IPC contracts when changed
+name: Auto-deploy IPC contracts to Calibrationnet when changed
 
 on:
   workflow_dispatch:
@@ -34,11 +34,14 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: (Dry run) Try merge from main branch to see if there's any conflicts that can't be resolved itself
+      - name: Configure git
         run: |
-          git show HEAD
           git config --global user.name "$GIT_USERNAME"
           git config --global user.email "$GIT_EMAIL"
+
+      - name: (Dry run) Try merge from main to fail early if there are unresolvable conflicts
+        run: |
+          git show HEAD
           git checkout main
           git pull --rebase origin main
           git checkout cd/contracts
@@ -60,25 +63,22 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
       - name: Deploy IPC contracts to Calibrationnet
         id: deploy_contracts
         run: |
           cd contracts
           npm install
-          output=$(make deploy-stack NETWORK=calibrationnet)
+          output=$(make deploy-stack NETWORK=calibrationnet | tee /dev/tty)
           echo "deploy_output<<EOF" >> $GITHUB_OUTPUT
           echo "$output" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Parse deploy output
+      - name: Extract deployed addresses
         run: |
           deploy_output='${{ steps.deploy_contracts.outputs.deploy_output }}'
           echo "$deploy_output"
-          deployed_gateway_address=$(echo "$deploy_output" | grep '"Gateway"' | awk -F'"' '{print $4}')
-          deployed_registry_address=$(echo "$deploy_output" | grep '"SubnetRegistry"' | awk -F'"' '{print $4}')
+          deployed_gateway_address=$(jq -r ".address" deployments/calibrationnet/GatewayDiamond.json)
+          deployed_registry_address=$(jq -r ".address" deployments/calibrationnet/SubnetRegistryDiamond.json)
           echo "gateway_address=$deployed_gateway_address" >> $GITHUB_ENV
           echo "registry_address=$deployed_registry_address" >> $GITHUB_ENV
           echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_ENV
@@ -98,8 +98,6 @@ jobs:
 
       - name: Merge from main branch and update cd/contracts branch
         run: |
-          git config --global user.name "$GIT_USERNAME"
-          git config --global user.email "$GIT_EMAIL"
           git checkout main
           git pull --rebase origin main
           git checkout cd/contracts
@@ -115,8 +113,6 @@ jobs:
 
       - name: Commit output file and push it to remote repo
         run: |
-          git config user.name ${{env.GIT_USERNAME}}
-          git config user.email ${{env.GIT_EMAIL}}
           git add deployments/r314159.json
           git commit -m "Update contract address"
           git push origin cd/contracts

--- a/.github/workflows/auto-deploy-contracts.yaml
+++ b/.github/workflows/auto-deploy-contracts.yaml
@@ -34,14 +34,14 @@ jobs:
           git config --global user.name "$GIT_USERNAME"
           git config --global user.email "$GIT_EMAIL"
 
-      - uses: pnpm/action-setup@v2
-
       - name: Check out the branch that triggered this run
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
           submodules: recursive
           fetch-depth: 0
+
+      - uses: pnpm/action-setup@v2
 
       - name: Set up node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/auto-deploy-contracts.yaml
+++ b/.github/workflows/auto-deploy-contracts.yaml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Deploy IPC contracts to Calibrationnet
         id: deploy_contracts
+        env:
+          REGISTRY_CREATION_PRIVILEGES: 'unrestricted'
         run: |
           cd contracts
           pnpm install

--- a/.github/workflows/auto-deploy-contracts.yaml
+++ b/.github/workflows/auto-deploy-contracts.yaml
@@ -48,6 +48,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - name: Cache artifacts
         uses: actions/cache@v4
         with:
@@ -67,7 +70,7 @@ jobs:
         id: deploy_contracts
         run: |
           cd contracts
-          npm install
+          pnpm install
           output=$(make deploy-stack NETWORK=calibrationnet | tee /dev/tty)
           echo "deploy_output<<EOF" >> $GITHUB_OUTPUT
           echo "$output" >> $GITHUB_OUTPUT

--- a/.github/workflows/auto-deploy-contracts.yaml
+++ b/.github/workflows/auto-deploy-contracts.yaml
@@ -28,6 +28,11 @@ jobs:
       RPC_URL: https://calibration.filfox.io/rpc/v1
       PRIVATE_KEY: ${{ secrets.CONTRACTS_DEPLOYER_PRIVATE_KEY }}
     steps:
+      - name: Configure git
+        run: |
+          git config --global user.name "$GIT_USERNAME"
+          git config --global user.email "$GIT_EMAIL"
+
       - name: Checkout cd/contracts branch-test
         uses: actions/checkout@v4
         with:
@@ -35,10 +40,20 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Configure git
-        run: |
-          git config --global user.name "$GIT_USERNAME"
-          git config --global user.email "$GIT_EMAIL"
+      - name: Cache artifacts
+        uses: actions/cache@v4
+        with:
+          ## Hardhat is intelligent enough to perform incremental compilation. But GitHub Actions caches are immutable.
+          ## Since we can't have a rolling cache, we create a new cache for each run, but use restore-keys to load the
+          ## most recently created cache.
+          ## Reference: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+          key: ${{ runner.os }}-contracts-artifacts-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-contracts-artifacts-
+          path: |
+            contracts/out
+            contracts/deployments
+            contracts/artifacts
 
       - name: (Dry run) Try merge from main to fail early if there are unresolvable conflicts
         run: |

--- a/.github/workflows/auto-deploy-contracts.yaml
+++ b/.github/workflows/auto-deploy-contracts.yaml
@@ -8,6 +8,9 @@ on:
     paths:
       - contracts/**
 
+permissions:
+  contents: write
+
 env:
   GIT_USERNAME: github-actions[bot]
   GIT_EMAIL: ipc+github-actions[bot]@users.noreply.github.com
@@ -21,7 +24,7 @@ jobs:
   deploy-contracts:
     runs-on: ubuntu-latest
     env:
-      RPC_URL: https://calibration.filfox.info/rpc/v1
+      RPC_URL: https://calibration.filfox.io/rpc/v1
       PRIVATE_KEY: ${{ secrets.CONTRACTS_DEPLOYER_PRIVATE_KEY }}
     steps:
       - name: Checkout cd/contracts branch
@@ -30,7 +33,6 @@ jobs:
           ref: cd/contracts
           submodules: recursive
           fetch-depth: 0
-          token: ${{ secrets.WORKFLOW_PAT_JIE }}
 
       - name: (Dry run) Try merge from main branch to see if there's any conflicts that can't be resolved itself
         run: |
@@ -61,11 +63,11 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Deploy IPC contracts to calibration net
+      - name: Deploy IPC contracts to Calibrationnet
         id: deploy_contracts
         run: |
           cd contracts
-          npm install --save hardhat
+          npm install
           output=$(make deploy-stack NETWORK=calibrationnet)
           echo "deploy_output<<EOF" >> $GITHUB_OUTPUT
           echo "$output" >> $GITHUB_OUTPUT
@@ -93,7 +95,6 @@ jobs:
           ref: cd/contracts
           submodules: recursive
           fetch-depth: 0
-          token: ${{ secrets.WORKFLOW_PAT_JIE }}
 
       - name: Merge from main branch and update cd/contracts branch
         run: |
@@ -113,13 +114,9 @@ jobs:
           cat deployments/r314159.json
 
       - name: Commit output file and push it to remote repo
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: Update contract address
-          branch: cd/contracts
-          file_pattern: deployments/r314159.json
-          commit_user_name: ${{env.GIT_USERNAME}}
-          commit_user_email: ${{env.GIT_EMAIL}}
-          push_options: '--force'
-          skip_dirty_check: true
-          create_branch: true
+        run: |
+          git config user.name ${{env.GIT_USERNAME}}
+          git config user.email ${{env.GIT_EMAIL}}
+          git add deployments/r314159.json
+          git commit -m "Update contract address"
+          git push origin cd/contracts


### PR DESCRIPTION
This fixes our GitHub Actions workflow to auto-deploy contracts to Calibnet when changes are detected. This has been failing for some months and we never got around to fixing it. New users kept tripping up regularly when following the quickstart tutorial @ docs.ipc.space, which instructs them to deploy their subnet against the existing framework contracts on Calibnet. However, those contracts were outdated leading to severe compatibility issues.

While fixing this, I also:

- Simplified the setup by removing the need for a PAT.
- Removed the merge from main, as GH rejected pushes containing modified workflow files.
- Introduce a cache for incremental compilation and deployment (leveraging hardhat-deploy's ability to skip deployment when a contract with the same bytecode already exists).
- Eliminate random env variables carrying addresses and stdout parsing; instead just read the addresses from the deployment output files and generate a JSON file.