### PR TITLE
feat(node): support l2 plus value transfer

### DIFF
--- a/contracts/contracts/errors/IPCErrors.sol
+++ b/contracts/contracts/errors/IPCErrors.sol
@@ -94,7 +94,8 @@ enum InvalidXnetMessageReason {
     Value,
     Kind,
     CannotSendToItself,
-    CommonParentNotExist
+    CommonParentNotExist,
+    IncompatibleSupplySource
 }
 
 string constant ERR_PERMISSIONED_AND_BOOTSTRAPPED = "Method not allowed if permissioned is enabled and subnet bootstrapped";

--- a/contracts/contracts/gateway/GatewayMessengerFacet.sol
+++ b/contracts/contracts/gateway/GatewayMessengerFacet.sol
@@ -49,10 +49,6 @@ contract GatewayMessengerFacet is GatewayActorModifiers {
             revert InvalidXnetMessage(InvalidXnetMessageReason.Sender);
         }
 
-        if (msg.value != envelope.value) {
-            revert InvalidXnetMessage(InvalidXnetMessageReason.Value);
-        }
-
         // Will revert if the message won't deserialize into a CallMsg.
         abi.decode(envelope.message, (CallMsg));
 

--- a/contracts/contracts/gateway/GatewayMessengerFacet.sol
+++ b/contracts/contracts/gateway/GatewayMessengerFacet.sol
@@ -15,6 +15,7 @@ import {FvmAddressHelper} from "../lib/FvmAddressHelper.sol";
 import {ISubnetActor} from "../interfaces/ISubnetActor.sol";
 
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {console} from "forge-std/Test.sol";
 
 string constant ERR_GENERAL_CROSS_MSG_DISABLED = "Support for general-purpose cross-net messages is disabled";
 string constant ERR_MULTILEVEL_CROSS_MSG_DISABLED = "Support for multi-level cross-net messages is disabled";
@@ -53,6 +54,7 @@ contract GatewayMessengerFacet is GatewayActorModifiers {
 
         // Will revert if the message won't deserialize into a CallMsg.
         abi.decode(envelope.message, (CallMsg));
+        console.log("here0");
 
         committed = IpcEnvelope({
             kind: IpcMsgKind.Call,
@@ -67,13 +69,18 @@ contract GatewayMessengerFacet is GatewayActorModifiers {
 
         if (outcome != CrossMessageValidationOutcome.Valid) {
             if (outcome == CrossMessageValidationOutcome.InvalidDstSubnet) {
+                console.log("here2");
                 revert InvalidXnetMessage(InvalidXnetMessageReason.DstSubnet);
             } else if (outcome == CrossMessageValidationOutcome.CannotSendToItself) {
+                console.log("here3");
                 revert CannotSendCrossMsgToItself();
             } else if (outcome == CrossMessageValidationOutcome.CommonParentNotExist) {
+                console.log("here4");
                 revert UnroutableMessage("no common parent");
             }
         }
+
+        console.log("here1");
 
         // Commit xnet message for dispatch.
         bool shouldBurn = LibGateway.commitValidatedCrossMessage(committed);

--- a/contracts/contracts/gateway/GatewayMessengerFacet.sol
+++ b/contracts/contracts/gateway/GatewayMessengerFacet.sol
@@ -49,6 +49,10 @@ contract GatewayMessengerFacet is GatewayActorModifiers {
             revert InvalidXnetMessage(InvalidXnetMessageReason.Sender);
         }
 
+        if (msg.value != envelope.value) {
+            revert InvalidXnetMessage(InvalidXnetMessageReason.Value);
+        }
+
         // Will revert if the message won't deserialize into a CallMsg.
         abi.decode(envelope.message, (CallMsg));
 

--- a/contracts/contracts/interfaces/ISubnetActor.sol
+++ b/contracts/contracts/interfaces/ISubnetActor.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.23;
+
+import {Asset} from "../structs/Subnet.sol";
+
+/// @title Subnet actor interface
+interface ISubnetActor {
+    function supplySource() external view returns(Asset memory);
+}

--- a/contracts/contracts/interfaces/ISubnetActor.sol
+++ b/contracts/contracts/interfaces/ISubnetActor.sol
@@ -5,5 +5,5 @@ import {Asset} from "../structs/Subnet.sol";
 
 /// @title Subnet actor interface
 interface ISubnetActor {
-    function supplySource() external view returns(Asset memory);
+    function supplySource() external view returns (Asset memory);
 }

--- a/contracts/contracts/lib/AssetHelper.sol
+++ b/contracts/contracts/lib/AssetHelper.sol
@@ -38,7 +38,7 @@ library AssetHelper {
     }
 
     function equals(Asset memory asset, Asset memory asset2) internal pure returns (bool) {
-        return asset.tokenAddress == asset2.tokenAddress;
+        return asset.tokenAddress == asset2.tokenAddress && asset.kind == asset2.kind;
     }
 
     /// @notice Locks the specified amount from msg.sender into custody.

--- a/contracts/contracts/lib/AssetHelper.sol
+++ b/contracts/contracts/lib/AssetHelper.sol
@@ -240,4 +240,7 @@ library AssetHelper {
         return Asset({kind: AssetKind.Native, tokenAddress: address(0)});
     }
 
+    function erc20(address token) internal pure returns (Asset memory) {
+        return Asset({kind: AssetKind.ERC20, tokenAddress: token});
+    }
 }

--- a/contracts/contracts/lib/AssetHelper.sol
+++ b/contracts/contracts/lib/AssetHelper.sol
@@ -6,7 +6,7 @@ import {Asset, AssetKind} from "../structs/Subnet.sol";
 import {EMPTY_BYTES} from "../constants/Constants.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {SubnetActorGetterFacet} from "../subnet/SubnetActorGetterFacet.sol";
+import {ISubnetActor} from "../interfaces/ISubnetActor.sol";
 
 /// @notice Helpers to deal with a supply source.
 library AssetHelper {
@@ -16,7 +16,7 @@ library AssetHelper {
     ///         and checks if its supply kind matches the provided one.
     ///         It reverts if the address does not correspond to a subnet actor.
     function hasSupplyOfKind(address subnetActor, AssetKind compare) internal view returns (bool) {
-        return SubnetActorGetterFacet(subnetActor).supplySource().kind == compare;
+        return ISubnetActor(subnetActor).supplySource().kind == compare;
     }
 
     /// @notice Checks that a given supply strategy is correctly formed and its preconditions are met.
@@ -35,6 +35,10 @@ library AssetHelper {
     /// @notice Asserts that the supply strategy is of the given kind. If not, it reverts.
     function expect(Asset memory asset, AssetKind kind) internal pure {
         require(asset.kind == kind, "Unexpected asset");
+    }
+
+    function equals(Asset memory asset, Asset memory asset2) internal pure returns (bool) {
+        return asset.tokenAddress == asset2.tokenAddress;
     }
 
     /// @notice Locks the specified amount from msg.sender into custody.

--- a/contracts/contracts/lib/CrossMsgHelper.sol
+++ b/contracts/contracts/lib/CrossMsgHelper.sol
@@ -181,11 +181,13 @@ library CrossMsgHelper {
         }
 
         address recipient = crossMsg.to.rawAddress.extractEvmAddress().normalize();
-        // If the cross msg kind is Result, create result message should have handled the value correctly.
-        // If the execution is ok, value should be 0, else one should perform refund.
-        if (crossMsg.kind == IpcMsgKind.Transfer || crossMsg.kind == IpcMsgKind.Result) {
+        if (crossMsg.kind == IpcMsgKind.Transfer) {
             return supplySource.transferFunds({recipient: payable(recipient), value: crossMsg.value});
-        } else if (crossMsg.kind == IpcMsgKind.Call) {
+        } else if (crossMsg.kind == IpcMsgKind.Call || crossMsg.kind == IpcMsgKind.Result) {
+            // For a Result message, the idea is to perform a call as this returns control back to the caller.
+            // If it's an account, there will be no code to invoke, so this will be have like a bare transfer.
+            // But if the original caller was a contract, this give it control so it can handle the result
+
             // send the envelope directly to the entrypoint
             // use supplySource so the tokens in the message are handled successfully
             // and by the right supply source

--- a/contracts/contracts/lib/CrossMsgHelper.sol
+++ b/contracts/contracts/lib/CrossMsgHelper.sol
@@ -72,8 +72,7 @@ library CrossMsgHelper {
         uint256 value = crossMsg.value;
         // if the message was executed successfully, the value stayed
         // in the subnet and there's no need to return it.
-        // or if the message is a call, the value is always 0 because transfers for calls are not allowed
-        if (outcome == OutcomeType.Ok || crossMsg.kind == IpcMsgKind.Call) {
+        if (outcome == OutcomeType.Ok) {
             value = 0;
         }
         return
@@ -185,9 +184,6 @@ library CrossMsgHelper {
         if (crossMsg.kind == IpcMsgKind.Transfer) {
             return supplySource.transferFunds({recipient: payable(recipient), value: crossMsg.value});
         } else if (crossMsg.kind == IpcMsgKind.Call || crossMsg.kind == IpcMsgKind.Result) {
-            // transferring funds is not allowed for Call messages
-            uint256 value = crossMsg.kind == IpcMsgKind.Call ? 0 : crossMsg.value;
-
             // send the envelope directly to the entrypoint
             // use supplySource so the tokens in the message are handled successfully
             // and by the right supply source
@@ -195,7 +191,7 @@ library CrossMsgHelper {
                 supplySource.performCall(
                     payable(recipient),
                     abi.encodeCall(IIpcHandler.handleIpcMessage, (crossMsg)),
-                    value
+                    crossMsg.value
                 );
         }
         return (false, EMPTY_BYTES);

--- a/contracts/contracts/lib/CrossMsgHelper.sol
+++ b/contracts/contracts/lib/CrossMsgHelper.sol
@@ -220,7 +220,7 @@ library CrossMsgHelper {
         return true;
     }
 
-    function validateCrossMessage(IpcEnvelope memory crossMsg) internal view returns (CrossMessageValidationOutcome)  {
-        return LibGateway.validateCrossMessage(crossMsg);
+    function validateCrossMessage(IpcEnvelope memory crossMsg) internal view returns (CrossMessageValidationOutcome, IPCMsgType)  {
+        return LibGateway.checkCrossMessage(crossMsg);
     }
 }

--- a/contracts/contracts/lib/CrossMsgHelper.sol
+++ b/contracts/contracts/lib/CrossMsgHelper.sol
@@ -181,9 +181,11 @@ library CrossMsgHelper {
         }
 
         address recipient = crossMsg.to.rawAddress.extractEvmAddress().normalize();
-        if (crossMsg.kind == IpcMsgKind.Transfer) {
+        // If the cross msg kind is Result, create result message should have handled the value correctly.
+        // If the execution is ok, value should be 0, else one should perform refund.
+        if (crossMsg.kind == IpcMsgKind.Transfer || crossMsg.kind == IpcMsgKind.Result) {
             return supplySource.transferFunds({recipient: payable(recipient), value: crossMsg.value});
-        } else if (crossMsg.kind == IpcMsgKind.Call || crossMsg.kind == IpcMsgKind.Result) {
+        } else if (crossMsg.kind == IpcMsgKind.Call) {
             // send the envelope directly to the entrypoint
             // use supplySource so the tokens in the message are handled successfully
             // and by the right supply source

--- a/contracts/contracts/lib/LibGateway.sol
+++ b/contracts/contracts/lib/LibGateway.sol
@@ -466,7 +466,7 @@ library LibGateway {
             emit MessageStoredInPostbox({id: crossMsg.toDeterministicHash()});
             return;
         }
-    
+
         // execute the message and get the receipt.
         (bool success, bytes memory ret) = executeCrossMsg(crossMsg, supplySource);
         if (success) {

--- a/contracts/contracts/lib/LibGateway.sol
+++ b/contracts/contracts/lib/LibGateway.sol
@@ -253,9 +253,7 @@ library LibGateway {
 
         crossMessage.nonce = topDownNonce;
         subnet.topDownNonce = topDownNonce + 1;
-        if (crossMessage.kind != IpcMsgKind.Call) {
-            subnet.circSupply += crossMessage.value;
-        }
+        subnet.circSupply += crossMessage.value;
 
         emit NewTopDownMessage({subnet: subnet.id.getAddress(), message: crossMessage, id: crossMessage.toDeterministicHash()});
     }

--- a/contracts/contracts/lib/LibGateway.sol
+++ b/contracts/contracts/lib/LibGateway.sol
@@ -22,7 +22,7 @@ enum CrossMessageValidationOutcome {
     InvalidDstSubnet,
     CannotSendToItself,
     CommonParentNotExist,
-    InvalidSupplySource
+    IncompatibleSupplySource
 }
 
 library LibGateway {
@@ -571,13 +571,13 @@ library LibGateway {
 
     /// Checks if the incoming and outgoing subnet supply sources can be mapped.
     /// Caller should make sure the incoming/outgoing subnets and current subnet are immediate parent/child subnets.
-    function checkSubnetsAssets(
+    function checkSubnetsSupplyCompatible(
         bool isLCA,
         IPCMsgType applyType,
         SubnetID memory incoming,
         SubnetID memory outgoing,
         SubnetID memory current
-    ) internal view returns(CrossMessageValidationOutcome) {
+    ) internal view returns(bool) {
         if (isLCA) {
             // now, it's pivoting @ LCA (i.e. upwards => downwards)
             // if incoming bottom up subnet and outgoing target subnet have the same 
@@ -647,15 +647,15 @@ library LibGateway {
             }
         }
 
-        bool validSupplySources = checkSubnetsAssets({
+        bool supplySourcesCompatible = checkSubnetsSupplyCompatible({
             isLCA: isLCA,
             applyType: applyType, 
             incoming: envelope.from.subnetId,
             outgoing: envelope.to.subnetId,
             current: currentNetwork
         });
-        if (validSupplySources) {
-            return CrossMessageValidationOutcome.InvalidSupplySource;
+        if (supplySourcesCompatible) {
+            return CrossMessageValidationOutcome.IncompatibleSupplySource;
         }
 
         return CrossMessageValidationOutcome.Valid;

--- a/contracts/test/integration/GatewayDiamondToken.t.sol
+++ b/contracts/test/integration/GatewayDiamondToken.t.sol
@@ -232,7 +232,7 @@ contract GatewayDiamondTokenTest is Test, IntegrationTestBase {
         vm.prank(address(saDiamond));
         vm.expectCall(recipient, abi.encodeCall(IIpcHandler.handleIpcMessage, (msgs[0])), 1);
         gatewayDiamond.checkpointer().commitCheckpoint(batch);
-        assertEq(token.balanceOf(recipient), 0);
+        assertEq(token.balanceOf(recipient), 8);
     }
 
     function test_propagation() public {

--- a/contracts/test/integration/L2PlusSubnet.t.sol
+++ b/contracts/test/integration/L2PlusSubnet.t.sol
@@ -219,50 +219,12 @@ contract L2PlusSubnetTest is Test, IntegrationTestBase {
         sendCrossMessageFromChildToParentWithResult(params);
     }
 
-    function testL2PlusSubnet_TokenMixed_SendCrossMessageFromChildToParentWithOkResult() public {
-        MockIpcContractResult caller = new MockIpcContractResult();
-        Params memory params = Params({
-            root: rootNetwork,
-            subnet: tokenL2Subnet,
-            subnetL3: tokenL3SubnetsWithTokenParent[0],
-            caller: caller,
-            callerAddr: address(caller),
-            recipientAddr: address(new MockIpcContractPayable()),
-            amount: 3,
-            expectedOutcome: OutcomeType.Ok,
-            expectedRet: abi.encode(EMPTY_BYTES),
-            callerAmount: 1 ether,
-            fundAmount: 100000
-        });
-
-        sendCrossMessageFromChildToParentWithResult(params);
-    }
-
     function testL2PlusSubnet_Token_SendCrossMessageFromParentToChildWithOkResult() public {
         MockIpcContractResult caller = new MockIpcContractResult();
         Params memory params = Params({
             root: rootNetwork,
             subnet: tokenL2Subnet,
             subnetL3: nativeL3SubnetsWithTokenParent[0],
-            caller: caller,
-            callerAddr: address(caller),
-            recipientAddr: address(new MockIpcContractPayable()),
-            amount: 3,
-            expectedOutcome: OutcomeType.Ok,
-            expectedRet: abi.encode(EMPTY_BYTES),
-            callerAmount: 1 ether,
-            fundAmount: 100000
-        });
-
-        sendCrossMessageFromParentToChildWithResult(params);
-    }
-
-    function testL2PlusSubnet_TokenMixed_SendCrossMessageFromParentToChildWithOkResult() public {
-        MockIpcContractResult caller = new MockIpcContractResult();
-        Params memory params = Params({
-            root: rootNetwork,
-            subnet: tokenL2Subnet,
-            subnetL3: tokenL3SubnetsWithTokenParent[0],
             caller: caller,
             callerAddr: address(caller),
             recipientAddr: address(new MockIpcContractPayable()),
@@ -599,6 +561,16 @@ contract L2PlusSubnetTest is Test, IntegrationTestBase {
             0
         );
 
+        Asset memory subnetSupply = params.subnet.subnetActor.getter().supplySource();
+
+        if (subnetSupply.kind == AssetKind.ERC20) {
+            // increase callerAddr's token balance
+            IERC20(subnetSupply.tokenAddress).transfer(params.callerAddr, params.amount);
+            // increase allowance so that send xnet msg will make it
+            vm.prank(params.callerAddr);
+            IERC20(subnetSupply.tokenAddress).approve(address(params.root.gatewayAddr), params.amount);
+        }
+
         crossMessage.nonce = 1;
         // send the cross message from the root network to the L3 subnet
         vm.prank(params.callerAddr);
@@ -609,9 +581,15 @@ contract L2PlusSubnetTest is Test, IntegrationTestBase {
             id: crossMessage.toDeterministicHash()
         });
 
+        console.log("here");
         crossMessage.nonce = 0;
-        params.root.gateway.messenger().sendContractXnetMessage{value: params.amount}(crossMessage);
+        if (subnetSupply.kind == AssetKind.ERC20) {
+            params.root.gateway.messenger().sendContractXnetMessage(crossMessage);
+        } else {
+            params.root.gateway.messenger().sendContractXnetMessage{value: params.amount}(crossMessage);
+        }
 
+        console.log("here2");
         IpcEnvelope[] memory msgs = new IpcEnvelope[](1);
         msgs[0] = crossMessage;
 
@@ -623,22 +601,22 @@ contract L2PlusSubnetTest is Test, IntegrationTestBase {
             params.subnetL3.subnetActorAddr,
             params.subnet.gatewayAddr
         );
-
+        console.log("here3");
         // apply the cross message in the L3 subnet
         executeTopDownMsgs(msgs, params.subnetL3.gateway);
-
+        console.log("here4");
         // submit checkoint so the result message can be propagated to L2
         submitBottomUpCheckpoint(
             callCreateBottomUpCheckpointFromChildSubnet(params.subnetL3.id, params.subnetL3.gateway),
             params.subnetL3.subnetActor
         );
-
+        console.log("here5");
         // submit checkoint so the result message can be propagated to root network
         submitBottomUpCheckpoint(
             callCreateBottomUpCheckpointFromChildSubnet(params.subnet.id, params.subnet.gateway),
             params.subnet.subnetActor
         );
-
+        console.log("here6");
         assertTrue(params.caller.hasResult(), "missing result");
         assertTrue(params.caller.result().outcome == params.expectedOutcome, "wrong result outcome");
         assertTrue(keccak256(params.caller.result().ret) == keccak256(params.expectedRet), "wrong result outcome");

--- a/contracts/test/integration/L2PlusSubnet.t.sol
+++ b/contracts/test/integration/L2PlusSubnet.t.sol
@@ -581,7 +581,6 @@ contract L2PlusSubnetTest is Test, IntegrationTestBase {
             id: crossMessage.toDeterministicHash()
         });
 
-        console.log("here");
         crossMessage.nonce = 0;
         if (subnetSupply.kind == AssetKind.ERC20) {
             params.root.gateway.messenger().sendContractXnetMessage(crossMessage);
@@ -589,7 +588,6 @@ contract L2PlusSubnetTest is Test, IntegrationTestBase {
             params.root.gateway.messenger().sendContractXnetMessage{value: params.amount}(crossMessage);
         }
 
-        console.log("here2");
         IpcEnvelope[] memory msgs = new IpcEnvelope[](1);
         msgs[0] = crossMessage;
 
@@ -601,22 +599,18 @@ contract L2PlusSubnetTest is Test, IntegrationTestBase {
             params.subnetL3.subnetActorAddr,
             params.subnet.gatewayAddr
         );
-        console.log("here3");
         // apply the cross message in the L3 subnet
         executeTopDownMsgs(msgs, params.subnetL3.gateway);
-        console.log("here4");
         // submit checkoint so the result message can be propagated to L2
         submitBottomUpCheckpoint(
             callCreateBottomUpCheckpointFromChildSubnet(params.subnetL3.id, params.subnetL3.gateway),
             params.subnetL3.subnetActor
         );
-        console.log("here5");
         // submit checkoint so the result message can be propagated to root network
         submitBottomUpCheckpoint(
             callCreateBottomUpCheckpointFromChildSubnet(params.subnet.id, params.subnet.gateway),
             params.subnet.subnetActor
         );
-        console.log("here6");
         assertTrue(params.caller.hasResult(), "missing result");
         assertTrue(params.caller.result().outcome == params.expectedOutcome, "wrong result outcome");
         assertTrue(keccak256(params.caller.result().ret) == keccak256(params.expectedRet), "wrong result outcome");

--- a/contracts/test/integration/L2PlusXNet.t.sol
+++ b/contracts/test/integration/L2PlusXNet.t.sol
@@ -35,6 +35,7 @@ import {ActivityHelper} from "../helpers/ActivityHelper.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {ISubnetActor} from "../../contracts/interfaces/ISubnetActor.sol";
 import {IPCMsgType} from "../../contracts/enums/IPCMsgType.sol";
+import {IIpcHandler} from "../../sdk/interfaces/IIpcHandler.sol";
 
 import "forge-std/console.sol";
 
@@ -137,7 +138,7 @@ interface IGateway {
     function fundWithToken(SubnetID calldata subnetId, FvmAddress calldata to, uint256 amount) external;
 }
 
-contract L2PlusSubnetTest is Test, IntegrationTestBase {
+contract L2PlusSubnetTest is Test, IntegrationTestBase, IIpcHandler {
     using SubnetIDHelper for SubnetID;
     using CrossMsgHelper for IpcEnvelope;
     using GatewayFacetsHelper for GatewayDiamond;
@@ -160,6 +161,17 @@ contract L2PlusSubnetTest is Test, IntegrationTestBase {
         // get some free money.
         vm.deal(address(this), 10 ether);
     }
+
+    // ======= implements ipc handler =======
+
+    /* solhint-disable-next-line unused-vars */
+    function handleIpcMessage(IpcEnvelope calldata envelope) external payable returns (bytes memory ret) {
+        ret = bytes("");
+    }
+
+    receive() external payable {}
+
+    // ======= internal util methods ========
 
     function executeTopdownMessages(IpcEnvelope[] memory msgs, GatewayDiamond gw) internal {
         uint256 minted_tokens;

--- a/contracts/test/integration/L2PlusXNet.t.sol
+++ b/contracts/test/integration/L2PlusXNet.t.sol
@@ -459,20 +459,26 @@ contract L2PlusSubnetTest is Test, IntegrationTestBase {
         vm.recordLogs();
 
         uint256 originalBalance = IERC20(erc20_1).balanceOf(address(this));
+        uint256 amount = 0.01 ether;
 
-        // fund the L3 address should throw an error
+        // fund the L3 address should throw an error and triggers an result xnet message
         fundContract({
             originSubnet: l1SubnetID,
             targetSubnet: l3SubnetIDs[0],
             targetRecipient: address(recipientContract),
-            amount: 0.01 ether
+            amount: amount
         });
         propagateDown();
+
+        // funds should now be locked
+        require(IERC20(erc20_1).balanceOf(address(this)) == originalBalance - amount, "balance should have droppped");
+
+        // relayer carries the bottom up checkpoint
         propagateUp(l2SubnetIDs[0], l1SubnetID);
 
         // post xnet message conditions
         uint256 postBalance = IERC20(erc20_1).balanceOf(address(this));
-        require(postBalance == originalBalance, "balance should not have changed");
+        require(postBalance == originalBalance, "token should be refunded");
     }
 
     // testing Native L1 => ERC20 L2 => Native L3

--- a/contracts/test/integration/L2PlusXNet.t.sol
+++ b/contracts/test/integration/L2PlusXNet.t.sol
@@ -1,0 +1,1136 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.23;
+
+import "forge-std/Test.sol";
+import "../../contracts/errors/IPCErrors.sol";
+import {EMPTY_BYTES} from "../../contracts/constants/Constants.sol";
+import {IpcEnvelope, BottomUpMsgBatch, BottomUpCheckpoint, ParentFinality, IpcMsgKind, OutcomeType} from "../../contracts/structs/CrossNet.sol";
+import {SubnetID, Subnet, IPCAddress, Validator} from "../../contracts/structs/Subnet.sol";
+import {SubnetIDHelper} from "../../contracts/lib/SubnetIDHelper.sol";
+import {AssetHelper} from "../../contracts/lib/AssetHelper.sol";
+import {Asset, AssetKind} from "../../contracts/structs/Subnet.sol";
+import {FvmAddressHelper} from "../../contracts/lib/FvmAddressHelper.sol";
+import {CrossMsgHelper} from "../../contracts/lib/CrossMsgHelper.sol";
+import {GatewayDiamond} from "../../contracts/GatewayDiamond.sol";
+import {SubnetActorDiamond} from "../../contracts/SubnetActorDiamond.sol";
+import {SubnetActorManagerFacet} from "../../contracts/subnet/SubnetActorManagerFacet.sol";
+import {SubnetActorCheckpointingFacet} from "../../contracts/subnet/SubnetActorCheckpointingFacet.sol";
+import {GatewayGetterFacet} from "../../contracts/gateway/GatewayGetterFacet.sol";
+import {LibGateway} from "../../contracts/lib/LibGateway.sol";
+import {TopDownFinalityFacet} from "../../contracts/gateway/router/TopDownFinalityFacet.sol";
+import {CheckpointingFacet} from "../../contracts/gateway/router/CheckpointingFacet.sol";
+import {XnetMessagingFacet} from "../../contracts/gateway/router/XnetMessagingFacet.sol";
+import {DiamondCutFacet} from "../../contracts/diamond/DiamondCutFacet.sol";
+import {GatewayMessengerFacet} from "../../contracts/gateway/GatewayMessengerFacet.sol";
+import {IntegrationTestBase, RootSubnetDefinition, TestSubnetDefinition} from "../IntegrationTestBase.sol";
+import {TestUtils, MockIpcContract, MockIpcContractPayable, MockIpcContractResult} from "../helpers/TestUtils.sol";
+import {FilAddress} from "fevmate/contracts/utils/FilAddress.sol";
+import {MerkleTreeHelper} from "../helpers/MerkleTreeHelper.sol";
+import {GatewayFacetsHelper} from "../helpers/GatewayFacetsHelper.sol";
+import {SubnetActorFacetsHelper} from "../helpers/SubnetActorFacetsHelper.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20PresetFixedSupply} from "../helpers/ERC20PresetFixedSupply.sol";
+
+import {ActivityHelper} from "../helpers/ActivityHelper.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+import "forge-std/console.sol";
+
+struct SubnetsHierarchy {
+    /// @dev The lookup key to l1 SubnetNode
+    bytes32 l1NodeLookupKey;
+    /// @dev The lookup keys to the children and beyond
+    EnumerableSet.Bytes32Set subnetKeys;
+    mapping(bytes32 => SubnetNode) nodes;
+    mapping(bytes32 => SubnetDefinition) definitions;
+}
+
+struct SubnetDefinition {
+    address gatewayAddr;
+    SubnetID id;
+}
+
+struct SubnetNode {
+    /// @dev The list of child subnet actor address
+    EnumerableSet.AddressSet childActors;
+}
+
+struct SubnetCreationParams {
+    SubnetID parent;
+    Asset supplySource;
+}
+
+library LibSubnetsHierarchy {
+    using EnumerableSet for EnumerableSet.AddressSet;
+    using SubnetIDHelper for SubnetID;
+
+    function initL1(SubnetsHierarchy storage self, SubnetDefinition memory l1) internal {
+        bytes32 lookupId = l1.id.toHash();
+
+        self.l1NodeLookupKey = lookupId;
+        storeNewNode(self, lookupId, l1.id, l1.gatewayAddr);
+    }
+
+    function getSubnetGateway(SubnetsHierarchy storage self, SubnetID memory id) internal view returns (address) {
+        bytes32 lookupId = id.toHash();
+        require(self.definitions[lookupId].gatewayAddr != address(0), "subnet not found");
+        return self.definitions[lookupId].gatewayAddr;
+    }
+
+    function storeNewNode(
+        SubnetsHierarchy storage self,
+        bytes32 lookupId,
+        SubnetID memory id,
+        address gateway
+    ) internal {
+        self.definitions[lookupId].gatewayAddr = gateway;
+        self.definitions[lookupId].id = id;
+    }
+
+    function linkNewChild(SubnetsHierarchy storage self, bytes32 lookupId, address subnetActor) internal {
+        self.nodes[lookupId].childActors.add(subnetActor);
+    }
+
+    function registerNewSubnet(
+        SubnetsHierarchy storage self,
+        SubnetID memory parent,
+        address subnetActor,
+        address gateway
+    ) internal returns (SubnetID memory) {
+        // ensure parent exists
+        getSubnetGateway(self, parent);
+
+        SubnetID memory child = SubnetIDHelper.createSubnetId(parent, subnetActor);
+
+        bytes32 lookupId = child.toHash();
+        storeNewNode(self, lookupId, child, gateway);
+        linkNewChild(self, lookupId, subnetActor);
+
+        return child;
+    }
+}
+
+interface IMessager {
+    function sendContractXnetMessage(
+        IpcEnvelope memory envelope
+    ) external payable returns (IpcEnvelope memory committed);
+}
+
+contract L2PlusSubnetTest is Test, IntegrationTestBase {
+    using SubnetIDHelper for SubnetID;
+    using CrossMsgHelper for IpcEnvelope;
+    using GatewayFacetsHelper for GatewayDiamond;
+    using SubnetActorFacetsHelper for SubnetActorDiamond;
+    using AssetHelper for Asset;
+
+    using LibSubnetsHierarchy for SubnetsHierarchy;
+
+    SubnetsHierarchy private subnets;
+
+    function setUp() public override {
+        vm.deal(address(this), 10 ether);
+    }
+
+    function createNativeSubnet(
+        address parentGatewayAddress,
+        SubnetID memory parentNetworkName
+    ) internal returns (TestSubnetDefinition memory) {
+        SubnetActorDiamond subnetActor = createSubnetActor(
+            defaultSubnetActorParamsWith(parentGatewayAddress, parentNetworkName)
+        );
+
+        return createSubnet(parentNetworkName.route, subnetActor);
+    }
+
+    function createTokenSubnet(
+        address tokenAddress,
+        address parentGatewayAddress,
+        SubnetID memory parentNetworkName
+    ) internal returns (TestSubnetDefinition memory) {
+        SubnetActorDiamond subnetActor = createSubnetActor(
+            defaultSubnetActorParamsWith(parentGatewayAddress, parentNetworkName, tokenAddress)
+        );
+
+        return createSubnet(parentNetworkName.route, subnetActor);
+    }
+
+    function createSubnet(
+        address[] memory subnetPath,
+        SubnetActorDiamond subnetActor
+    ) internal returns (TestSubnetDefinition memory) {
+        address[] memory newPath = new address[](subnetPath.length + 1);
+        for (uint i = 0; i < subnetPath.length; i++) {
+            newPath[i] = subnetPath[i];
+        }
+
+        newPath[subnetPath.length] = address(subnetActor);
+
+        SubnetID memory subnetName = SubnetID({root: ROOTNET_CHAINID, route: newPath});
+        GatewayDiamond subnetGateway = createGatewayDiamond(gatewayParams(subnetName));
+
+        return
+            TestSubnetDefinition({
+                gateway: subnetGateway,
+                gatewayAddr: address(subnetGateway),
+                id: subnetName,
+                subnetActor: subnetActor,
+                subnetActorAddr: address(subnetActor),
+                path: newPath
+            });
+    }
+
+    struct Params {
+        RootSubnetDefinition root;
+        TestSubnetDefinition subnet;
+        TestSubnetDefinition subnetL3;
+        MockIpcContractResult caller;
+        address callerAddr;
+        address recipientAddr;
+        uint256 callerAmount;
+        uint256 fundAmount;
+        uint256 amount;
+        OutcomeType expectedOutcome;
+        bytes expectedRet;
+    }
+
+    function call(IpcEnvelope memory xnetMsg) internal {
+        address gateway = subnets.getSubnetGateway(xnetMsg.from.subnetId);
+        IMessager(gateway).sendContractXnetMessage{value: xnetMsg.value}(xnetMsg);
+    }
+
+    function initL1() internal returns (SubnetID memory) {
+        SubnetID memory rootNetworkName = SubnetID({root: ROOTNET_CHAINID, route: new address[](0)});
+        GatewayDiamond rootGateway = createGatewayDiamond(gatewayParams(rootNetworkName));
+
+        SubnetDefinition memory l1Defi = SubnetDefinition({gatewayAddr: address(rootGateway), id: rootNetworkName});
+        subnets.initL1(l1Defi);
+
+        return l1Defi.id;
+    }
+
+    function newSubnets(SubnetCreationParams[] memory params) internal returns (SubnetID[] memory subnetIds) {
+        uint256 length = params.length;
+
+        subnetIds = new SubnetID[](length);
+
+        for (uint256 i = 0; i < length; i++) {
+            address parentGateway = subnets.getSubnetGateway(params[i].parent);
+
+            TestSubnetDefinition memory t;
+            if (params[i].supplySource.kind == AssetKind.Native) {
+                t = createNativeSubnet(parentGateway, params[i].parent);
+            } else {
+                t = createTokenSubnet(
+                    params[i].supplySource.tokenAddress,
+                    parentGateway,
+                    params[i].parent
+                );
+            }
+
+            // register child subnet to parent gateway
+            vm.prank(t.subnetActorAddr);
+            registerSubnetGW(0, t.subnetActorAddr, GatewayDiamond(payable(parentGateway)));
+            
+            subnetIds[i] = subnets.registerNewSubnet(params[i].parent, t.subnetActorAddr, t.gatewayAddr);
+        }
+    }
+
+    function propagateUp(SubnetID memory from, SubnetID memory to) internal {
+        require(from.commonParent(to).equals(to), "not related subnets");
+
+        bool finished = false;
+        while (!finished) {
+            SubnetID memory parent = from.getParentSubnet();
+
+            address gateway = subnets.getSubnetGateway(from);
+            // this would normally submitted by releayer. It call the subnet actor on the L2 network.
+            submitBottomUpCheckpoint(
+                callCreateBottomUpCheckpointFromChildSubnet(from, GatewayDiamond(payable(gateway))),
+                SubnetActorDiamond(payable(from.getActor()))
+            );
+
+            from = parent;
+            finished = parent.equals(to);
+        }
+    }
+    
+    function propagateDown(SubnetID memory from, SubnetID memory to) internal {
+        
+    }
+
+    //--------------------
+    // Call flow tests.
+    //---------------------
+
+    // Native supply source subnets
+    function test_NativeL3SendToNativeL3() public {
+        SubnetID memory l1SubnetID = initL1();
+
+        address erc20 = address(new ERC20PresetFixedSupply("TestToken", "TT", 21_000_000 ether, address(this)));
+
+        // define L2s
+        SubnetCreationParams[] memory l2Params = new SubnetCreationParams[](2);
+        l2Params[0] = SubnetCreationParams({parent: l1SubnetID, supplySource: AssetHelper.erc20(erc20)});
+        l2Params[1] = SubnetCreationParams({parent: l1SubnetID, supplySource: AssetHelper.erc20(erc20)});
+        SubnetID[] memory l2SubnetIDs = newSubnets(l2Params);
+
+        // define L3s
+        SubnetCreationParams[] memory l3Params = new SubnetCreationParams[](2);
+        l3Params[0] = SubnetCreationParams({parent: l2SubnetIDs[0], supplySource: AssetHelper.native()});
+        l3Params[1] = SubnetCreationParams({parent: l2SubnetIDs[1], supplySource: AssetHelper.native()});
+        SubnetID[] memory l3SubnetIDs = newSubnets(l3Params);
+
+        // create the message
+        MockIpcContractResult callerContract = new MockIpcContractResult();
+        MockIpcContractResult recipientContract = new MockIpcContractResult();
+        uint256 amount = 1;
+        IpcEnvelope memory crossMessage = TestUtils.newXnetCallMsg(
+            IPCAddress({subnetId: l3SubnetIDs[0], rawAddress: FvmAddressHelper.from(address(callerContract))}),
+            IPCAddress({subnetId: l3SubnetIDs[1], rawAddress: FvmAddressHelper.from(address(recipientContract))}),
+            amount,
+            0 // the nonce, does not matter, should be handled by contract calls
+        );
+
+        call(crossMessage);
+
+        propagateUp(l3SubnetIDs[0], l1SubnetID);
+        propagateDown(l1SubnetID, l3SubnetIDs[1]);
+    }
+
+    // // Native supply source subnets
+    // function testL2PlusSubnet_Native_SendCrossMessageFromChildToParentWithOkResult() public {
+    //     MockIpcContractResult caller = new MockIpcContractResult();
+    //     Params memory params = Params({
+    //         root: rootNetwork,
+    //         subnet: nativeL2Subnet,
+    //         subnetL3: nativeL3Subnets[0],
+    //         caller: caller,
+    //         callerAddr: address(caller),
+    //         recipientAddr: address(new MockIpcContractPayable()),
+    //         amount: 3,
+    //         expectedOutcome: OutcomeType.Ok,
+    //         expectedRet: abi.encode(EMPTY_BYTES),
+    //         callerAmount: 1 ether,
+    //         fundAmount: 100000
+    //     });
+
+    //     sendCrossMessageFromChildToParentWithResult(params);
+    // }
+
+    // function testL2PlusSubnet_Native_SendCrossMessageFromParentToChildWithOkResult() public {
+    //     MockIpcContractResult caller = new MockIpcContractResult();
+    //     Params memory params = Params({
+    //         root: rootNetwork,
+    //         subnet: nativeL2Subnet,
+    //         subnetL3: nativeL3Subnets[0],
+    //         caller: caller,
+    //         callerAddr: address(caller),
+    //         recipientAddr: address(new MockIpcContractPayable()),
+    //         amount: 3,
+    //         expectedOutcome: OutcomeType.Ok,
+    //         expectedRet: abi.encode(EMPTY_BYTES),
+    //         callerAmount: 1 ether,
+    //         fundAmount: 100000
+    //     });
+
+    //     sendCrossMessageFromParentToChildWithResult(params);
+    // }
+
+    // function testL2PlusSubnet_Native_SendCrossMessageFromSiblingToSiblingWithOkResult() public {
+    //     sendCrossMessageFromSiblingToSiblingWithOkResult(rootNetwork, nativeL2Subnet, nativeL3Subnets);
+    // }
+
+    // // Token supply source subnets
+    // function testL2PlusSubnet_Token_SendCrossMessageFromChildToParentWithOkResult() public {
+    //     MockIpcContractResult caller = new MockIpcContractResult();
+    //     Params memory params = Params({
+    //         root: rootNetwork,
+    //         subnet: tokenL2Subnet,
+    //         subnetL3: nativeL3SubnetsWithTokenParent[0],
+    //         caller: caller,
+    //         callerAddr: address(caller),
+    //         recipientAddr: address(new MockIpcContractPayable()),
+    //         amount: 3,
+    //         expectedOutcome: OutcomeType.Ok,
+    //         expectedRet: abi.encode(EMPTY_BYTES),
+    //         callerAmount: 1 ether,
+    //         fundAmount: 100000
+    //     });
+
+    //     sendCrossMessageFromChildToParentWithResult(params);
+    // }
+
+    // function testL2PlusSubnet_TokenMixed_SendCrossMessageFromChildToParentWithOkResult() public {
+    //     MockIpcContractResult caller = new MockIpcContractResult();
+    //     Params memory params = Params({
+    //         root: rootNetwork,
+    //         subnet: tokenL2Subnet,
+    //         subnetL3: tokenL3SubnetsWithTokenParent[0],
+    //         caller: caller,
+    //         callerAddr: address(caller),
+    //         recipientAddr: address(new MockIpcContractPayable()),
+    //         amount: 3,
+    //         expectedOutcome: OutcomeType.Ok,
+    //         expectedRet: abi.encode(EMPTY_BYTES),
+    //         callerAmount: 1 ether,
+    //         fundAmount: 100000
+    //     });
+
+    //     sendCrossMessageFromChildToParentWithResult(params);
+    // }
+
+    // function testL2PlusSubnet_Token_SendCrossMessageFromParentToChildWithOkResult() public {
+    //     MockIpcContractResult caller = new MockIpcContractResult();
+    //     Params memory params = Params({
+    //         root: rootNetwork,
+    //         subnet: tokenL2Subnet,
+    //         subnetL3: nativeL3SubnetsWithTokenParent[0],
+    //         caller: caller,
+    //         callerAddr: address(caller),
+    //         recipientAddr: address(new MockIpcContractPayable()),
+    //         amount: 3,
+    //         expectedOutcome: OutcomeType.Ok,
+    //         expectedRet: abi.encode(EMPTY_BYTES),
+    //         callerAmount: 1 ether,
+    //         fundAmount: 100000
+    //     });
+
+    //     sendCrossMessageFromParentToChildWithResult(params);
+    // }
+
+    // function testL2PlusSubnet_TokenMixed_SendCrossMessageFromParentToChildWithOkResult() public {
+    //     MockIpcContractResult caller = new MockIpcContractResult();
+    //     Params memory params = Params({
+    //         root: rootNetwork,
+    //         subnet: tokenL2Subnet,
+    //         subnetL3: tokenL3SubnetsWithTokenParent[0],
+    //         caller: caller,
+    //         callerAddr: address(caller),
+    //         recipientAddr: address(new MockIpcContractPayable()),
+    //         amount: 3,
+    //         expectedOutcome: OutcomeType.Ok,
+    //         expectedRet: abi.encode(EMPTY_BYTES),
+    //         callerAmount: 1 ether,
+    //         fundAmount: 100000
+    //     });
+
+    //     sendCrossMessageFromParentToChildWithResult(params);
+    // }
+
+    // function testL2PlusSubnet_Token_SendCrossMessageFromSiblingToSiblingWithOkResult() public {
+    //     sendCrossMessageFromSiblingToSiblingWithOkResult(rootNetwork, tokenL2Subnet, nativeL3SubnetsWithTokenParent);
+    // }
+
+    // function testL2PlusSubnet_TokenMixed_SendCrossMessageFromSiblingToSiblingWithOkResult() public {
+    //     sendCrossMessageFromSiblingToSiblingWithOkResult(rootNetwork, tokenL2Subnet, tokenL3SubnetsWithTokenParent);
+    // }
+
+    // // Error scenarios
+    // function testL2PlusSubnet_Native_SendCrossMessageFromChildToNonExistingActorError() public {
+    //     MockIpcContractResult caller = new MockIpcContractResult();
+    //     Params memory params = Params({
+    //         root: rootNetwork,
+    //         subnet: nativeL2Subnet,
+    //         subnetL3: nativeL3Subnets[0],
+    //         caller: caller,
+    //         callerAddr: address(caller),
+    //         recipientAddr: 0x53c82507aA03B1a6e695000c302674ef1ecb880B,
+    //         amount: 3,
+    //         expectedOutcome: OutcomeType.ActorErr,
+    //         expectedRet: abi.encodeWithSelector(InvalidSubnetActor.selector),
+    //         callerAmount: 1 ether,
+    //         fundAmount: 100000
+    //     });
+
+    //     sendCrossMessageFromChildToParentWithResult(params);
+    // }
+
+    // function testL2PlusSubnet_Token_SendCrossMessageFromChildToNonExistingActorError() public {
+    //     MockIpcContractResult caller = new MockIpcContractResult();
+    //     Params memory params = Params({
+    //         root: rootNetwork,
+    //         subnet: tokenL2Subnet,
+    //         subnetL3: nativeL3SubnetsWithTokenParent[0],
+    //         caller: caller,
+    //         callerAddr: address(caller),
+    //         recipientAddr: 0x53c82507aA03B1a6e695000c302674ef1ecb880B,
+    //         amount: 3,
+    //         expectedOutcome: OutcomeType.ActorErr,
+    //         expectedRet: abi.encodeWithSelector(InvalidSubnetActor.selector),
+    //         callerAmount: 1 ether,
+    //         fundAmount: 100000
+    //     });
+
+    //     sendCrossMessageFromChildToParentWithResult(params);
+    // }
+
+    // function testL2PlusSubnet_Native_SendCrossMessageFromParentToNonExistingActorError() public {
+    //     MockIpcContractResult caller = new MockIpcContractResult();
+    //     Params memory params = Params({
+    //         root: rootNetwork,
+    //         subnet: nativeL2Subnet,
+    //         subnetL3: nativeL3Subnets[0],
+    //         caller: caller,
+    //         callerAddr: address(caller),
+    //         recipientAddr: 0x53c82507aA03B1a6e695000c302674ef1ecb880B,
+    //         amount: 3,
+    //         expectedOutcome: OutcomeType.ActorErr,
+    //         expectedRet: abi.encodeWithSelector(InvalidSubnetActor.selector),
+    //         callerAmount: 1 ether,
+    //         fundAmount: 100000
+    //     });
+
+    //     sendCrossMessageFromParentToChildWithResult(params);
+    // }
+
+    // function testL2PlusSubnet_Token_SendCrossMessageFromParentToNonExistingActorError() public {
+    //     MockIpcContractResult caller = new MockIpcContractResult();
+    //     Params memory params = Params({
+    //         root: rootNetwork,
+    //         subnet: tokenL2Subnet,
+    //         subnetL3: nativeL3SubnetsWithTokenParent[0],
+    //         caller: caller,
+    //         callerAddr: address(caller),
+    //         recipientAddr: 0x53c82507aA03B1a6e695000c302674ef1ecb880B,
+    //         amount: 3,
+    //         expectedOutcome: OutcomeType.ActorErr,
+    //         expectedRet: abi.encodeWithSelector(InvalidSubnetActor.selector),
+    //         callerAmount: 1 ether,
+    //         fundAmount: 100000
+    //     });
+
+    //     sendCrossMessageFromParentToChildWithResult(params);
+    // }
+
+    // function testL2PlusSubnet_ParentToChildTopDownNoncePropagatedCorrectly() public {
+    //     MockIpcContractResult caller = new MockIpcContractResult();
+    //     Params memory params = Params({
+    //         root: rootNetwork,
+    //         subnet: nativeL2Subnet,
+    //         subnetL3: nativeL3Subnets[0],
+    //         caller: caller,
+    //         callerAddr: address(caller),
+    //         recipientAddr: address(new MockIpcContractPayable()),
+    //         amount: 3,
+    //         expectedOutcome: OutcomeType.Ok,
+    //         expectedRet: abi.encode(EMPTY_BYTES),
+    //         callerAmount: 1 ether,
+    //         fundAmount: 100000
+    //     });
+
+    //     // register L2 into root network
+    //     registerSubnet(params.subnet.subnetActorAddr, params.root.gateway);
+    //     // register L3 into L2 subnet
+    //     registerSubnet(params.subnetL3.subnetActorAddr, params.subnet.gateway);
+
+    //     vm.deal(params.callerAddr, params.callerAmount);
+
+    //     IpcEnvelope memory fundCrossMessage = CrossMsgHelper.createFundMsg({
+    //         subnet: params.subnet.id,
+    //         signer: params.callerAddr,
+    //         to: FvmAddressHelper.from(params.callerAddr),
+    //         value: params.amount
+    //     });
+
+    //     // 0 is default but we set it explicitly here to make it clear
+    //     fundCrossMessage.nonce = 0;
+
+    //     vm.prank(params.callerAddr);
+    //     vm.expectEmit(true, true, true, true, params.root.gatewayAddr);
+    //     emit LibGateway.NewTopDownMessage({
+    //         subnet: params.subnet.subnetActorAddr,
+    //         message: fundCrossMessage,
+    //         id: fundCrossMessage.toDeterministicHash()
+    //     });
+
+    //     params.root.gateway.manager().fund{value: params.amount}(
+    //         params.subnet.id,
+    //         FvmAddressHelper.from(params.callerAddr)
+    //     );
+
+    //     IpcEnvelope memory callCrossMessage = TestUtils.newXnetCallMsg(
+    //         IPCAddress({subnetId: params.root.id, rawAddress: FvmAddressHelper.from(params.callerAddr)}),
+    //         IPCAddress({subnetId: params.subnetL3.id, rawAddress: FvmAddressHelper.from(params.recipientAddr)}),
+    //         params.amount,
+    //         1
+    //     );
+
+    //     // send the cross message from the root network to the L3 subnet
+    //     vm.prank(params.callerAddr);
+    //     vm.expectEmit(true, true, true, true, params.root.gatewayAddr);
+    //     emit LibGateway.NewTopDownMessage({
+    //         subnet: params.subnet.subnetActorAddr,
+    //         message: callCrossMessage,
+    //         id: callCrossMessage.toDeterministicHash()
+    //     });
+
+    //     params.root.gateway.messenger().sendContractXnetMessage{value: params.amount}(callCrossMessage);
+    //     (, uint64 rootTopDownNonce) = params.root.gateway.getter().getTopDownNonce(params.subnet.id);
+    //     assertEq(rootTopDownNonce, 2, "wrong root top down nonce");
+
+    //     IpcEnvelope[] memory msgsForL2 = new IpcEnvelope[](2);
+    //     msgsForL2[0] = fundCrossMessage;
+    //     msgsForL2[1] = callCrossMessage;
+
+    //     // the expected nonce for the top down message for L3 subnet is 0 because no previous message was sent
+    //     // from L2 to L3
+    //     msgsForL2[1].nonce = 0;
+    //     vm.prank(FilAddress.SYSTEM_ACTOR);
+    //     vm.expectEmit(true, true, true, true, params.subnet.gatewayAddr);
+    //     emit LibGateway.NewTopDownMessage({
+    //         subnet: params.subnetL3.subnetActorAddr,
+    //         message: callCrossMessage,
+    //         id: callCrossMessage.toDeterministicHash()
+    //     });
+
+    //     // nonce needs to be 1 because of the fund message.
+    //     msgsForL2[1].nonce = 1;
+    //     params.subnet.gateway.xnetMessenger().applyCrossMessages(msgsForL2);
+
+    //     uint64 subnetAppliedTopDownNonce = params.subnet.gateway.getter().appliedTopDownNonce();
+    //     assertEq(subnetAppliedTopDownNonce, 2, "wrong L2 subnet applied top down nonce");
+
+    //     IpcEnvelope[] memory msgsForL3 = new IpcEnvelope[](1);
+    //     msgsForL3[0] = callCrossMessage;
+
+    //     vm.prank(FilAddress.SYSTEM_ACTOR);
+    //     // nonce is zero because this is a first message touching the L3 subnet
+    //     msgsForL3[0].nonce = 0;
+    //     params.subnetL3.gateway.xnetMessenger().applyCrossMessages(msgsForL3);
+
+    //     uint64 subnetL3AppliedTopDownNonce = params.subnetL3.gateway.getter().appliedTopDownNonce();
+    //     assertEq(subnetL3AppliedTopDownNonce, 1, "wrong L3 subnet applied top down nonce");
+
+    //     // now fund from L2 to L3 to check to nonce propagation
+    //     vm.deal(params.callerAddr, params.callerAmount);
+
+    //     IpcEnvelope memory fundCrossMessageL3 = CrossMsgHelper.createFundMsg({
+    //         subnet: params.subnetL3.id,
+    //         signer: params.callerAddr,
+    //         to: FvmAddressHelper.from(params.callerAddr),
+    //         value: params.amount
+    //     });
+
+    //     // nonce should be 1 because this is the first cross message from L1 to L3
+    //     fundCrossMessageL3.nonce = 1;
+
+    //     vm.prank(params.callerAddr);
+    //     vm.expectEmit(true, true, true, true, params.subnet.gatewayAddr);
+    //     emit LibGateway.NewTopDownMessage({
+    //         subnet: params.subnetL3.subnetActorAddr,
+    //         message: fundCrossMessageL3,
+    //         id: fundCrossMessageL3.toDeterministicHash()
+    //     });
+
+    //     params.subnet.gateway.manager().fund{value: params.amount}(
+    //         params.subnetL3.id,
+    //         FvmAddressHelper.from(params.callerAddr)
+    //     );
+
+    //     uint64 subnetL3AppliedTopDownNonceAfterFund = params.subnetL3.gateway.getter().appliedTopDownNonce();
+    //     assertEq(subnetL3AppliedTopDownNonceAfterFund, 1, "wrong L3 subnet applied top down nonce");
+    // }
+
+    // function fundSubnet(
+    //     GatewayDiamond gateway,
+    //     TestSubnetDefinition memory subnet,
+    //     address callerAddr,
+    //     uint256 amount
+    // ) internal {
+    //     Asset memory subnetSupply = subnet.subnetActor.getter().supplySource();
+    //     if (subnetSupply.kind == AssetKind.ERC20) {
+    //         IERC20(subnetSupply.tokenAddress).approve(address(gateway), amount);
+    //         gateway.manager().fundWithToken(subnet.id, FvmAddressHelper.from(callerAddr), amount);
+    //     } else {
+    //         gateway.manager().fund{value: amount}(subnet.id, FvmAddressHelper.from(callerAddr));
+    //     }
+    // }
+
+    // function registerSubnet(address subnetActorAddr, GatewayDiamond gateway) internal {
+    //     vm.deal(subnetActorAddr, DEFAULT_COLLATERAL_AMOUNT);
+    //     vm.prank(subnetActorAddr);
+    //     registerSubnetGW(DEFAULT_COLLATERAL_AMOUNT, subnetActorAddr, gateway);
+    //     vm.stopPrank();
+    // }
+
+    // function sendCrossMessageFromChildToParentWithResult(Params memory params) public {
+    //     // register L2 into root nerwork
+    //     registerSubnet(params.subnet.subnetActorAddr, params.root.gateway);
+    //     // register L3 into L2 subnet
+    //     registerSubnet(params.subnetL3.subnetActorAddr, params.subnet.gateway);
+
+    //     vm.deal(params.callerAddr, params.callerAmount);
+    //     vm.prank(params.callerAddr);
+
+    //     fundSubnet(params.root.gateway, params.subnet, params.callerAddr, params.fundAmount);
+    //     fundSubnet(params.subnet.gateway, params.subnetL3, params.callerAddr, params.fundAmount);
+
+    //     // create the xnet message on the subnet L3 - it's local gateway
+    //     IpcEnvelope memory crossMessage = TestUtils.newXnetCallMsg(
+    //         IPCAddress({subnetId: params.subnetL3.id, rawAddress: FvmAddressHelper.from(params.callerAddr)}),
+    //         IPCAddress({subnetId: params.root.id, rawAddress: FvmAddressHelper.from(params.recipientAddr)}),
+    //         params.amount,
+    //         0
+    //     );
+
+    //     vm.prank(params.callerAddr);
+    //     params.subnetL3.gateway.messenger().sendContractXnetMessage{value: params.amount}(crossMessage);
+
+    //     // this would normally submitted by releayer. It call the subnet actor on the L2 network.
+    //     submitBottomUpCheckpoint(
+    //         callCreateBottomUpCheckpointFromChildSubnet(params.subnetL3.id, params.subnetL3.gateway),
+    //         params.subnetL3.subnetActor
+    //     );
+
+    //     // create checkpoint in L2 and submit it to the root network (L2 subnet actor)
+    //     BottomUpCheckpoint memory checkpoint = callCreateBottomUpCheckpointFromChildSubnet(
+    //         params.subnet.id,
+    //         params.subnet.gateway
+    //     );
+
+    //     // expected result top down message from root to L2. This is a response to the xnet call.
+    //     IpcEnvelope memory resultMessage = crossMessage.createResultMsg(params.expectedOutcome, params.expectedRet);
+    //     resultMessage.nonce = 1;
+
+    //     submitBottomUpCheckpointAndExpectTopDownMessageEvent(
+    //         checkpoint,
+    //         params.subnet.subnetActor,
+    //         resultMessage,
+    //         params.subnet.subnetActorAddr,
+    //         params.root.gatewayAddr
+    //     );
+
+    //     // apply the result message in the L2 subnet and expect another top down message to be emitted
+    //     IpcEnvelope[] memory msgs = new IpcEnvelope[](1);
+    //     msgs[0] = cloneIpcEnvelopeWithDifferentNonce(resultMessage, 0);
+
+    //     commitParentFinality(params.subnet.gatewayAddr);
+    //     executeTopDownMsgsAndExpectTopDownMessageEvent(
+    //         msgs,
+    //         params.subnet.gateway,
+    //         resultMessage,
+    //         params.subnetL3.subnetActorAddr,
+    //         params.subnet.gatewayAddr
+    //     );
+
+    //     // apply the result and check it was propagated to the correct actor
+    //     commitParentFinality(params.subnetL3.gatewayAddr);
+    //     executeTopDownMsgs(msgs, params.subnetL3.gateway);
+
+    //     assertTrue(params.caller.hasResult(), "missing result");
+    //     assertTrue(params.caller.result().outcome == params.expectedOutcome, "wrong result outcome");
+    //     assertTrue(keccak256(params.caller.result().ret) == keccak256(params.expectedRet), "wrong result outcome");
+    // }
+
+    // function sendCrossMessageFromParentToChildWithResult(Params memory params) public {
+    //     // register L2 into root network
+    //     registerSubnet(params.subnet.subnetActorAddr, params.root.gateway);
+    //     // register L3 into L2 subnet
+    //     registerSubnet(params.subnetL3.subnetActorAddr, params.subnet.gateway);
+
+    //     vm.deal(params.callerAddr, params.callerAmount);
+    //     vm.prank(params.callerAddr);
+
+    //     fundSubnet(params.root.gateway, params.subnet, params.callerAddr, params.fundAmount);
+
+    //     IpcEnvelope memory crossMessage = TestUtils.newXnetCallMsg(
+    //         IPCAddress({subnetId: params.root.id, rawAddress: FvmAddressHelper.from(params.callerAddr)}),
+    //         IPCAddress({subnetId: params.subnetL3.id, rawAddress: FvmAddressHelper.from(params.recipientAddr)}),
+    //         params.amount,
+    //         0
+    //     );
+
+    //     crossMessage.nonce = 1;
+    //     // send the cross message from the root network to the L3 subnet
+    //     vm.prank(params.callerAddr);
+    //     vm.expectEmit(true, true, true, true, params.root.gatewayAddr);
+    //     emit LibGateway.NewTopDownMessage({
+    //         subnet: params.subnet.subnetActorAddr,
+    //         message: crossMessage,
+    //         id: crossMessage.toDeterministicHash()
+    //     });
+
+    //     crossMessage.nonce = 0;
+    //     params.root.gateway.messenger().sendContractXnetMessage{value: params.amount}(crossMessage);
+
+    //     IpcEnvelope[] memory msgs = new IpcEnvelope[](1);
+    //     msgs[0] = crossMessage;
+
+    //     // propagate the message from the L2 to the L3 subnet
+    //     executeTopDownMsgsAndExpectTopDownMessageEvent(
+    //         msgs,
+    //         params.subnet.gateway,
+    //         crossMessage,
+    //         params.subnetL3.subnetActorAddr,
+    //         params.subnet.gatewayAddr
+    //     );
+
+    //     // apply the cross message in the L3 subnet
+    //     executeTopDownMsgs(msgs, params.subnetL3.gateway);
+
+    //     // submit checkoint so the result message can be propagated to L2
+    //     submitBottomUpCheckpoint(
+    //         callCreateBottomUpCheckpointFromChildSubnet(params.subnetL3.id, params.subnetL3.gateway),
+    //         params.subnetL3.subnetActor
+    //     );
+
+    //     // submit checkoint so the result message can be propagated to root network
+    //     submitBottomUpCheckpoint(
+    //         callCreateBottomUpCheckpointFromChildSubnet(params.subnet.id, params.subnet.gateway),
+    //         params.subnet.subnetActor
+    //     );
+
+    //     assertTrue(params.caller.hasResult(), "missing result");
+    //     assertTrue(params.caller.result().outcome == params.expectedOutcome, "wrong result outcome");
+    //     assertTrue(keccak256(params.caller.result().ret) == keccak256(params.expectedRet), "wrong result outcome");
+    // }
+
+    // function sendCrossMessageFromSiblingToSiblingWithOkResult(
+    //     RootSubnetDefinition memory root,
+    //     TestSubnetDefinition memory subnet,
+    //     TestSubnetDefinition[] memory subnetL3s
+    // ) public {
+    //     MockIpcContractResult caller = new MockIpcContractResult();
+    //     address callerAddr = address(caller);
+    //     address recipientAddr = address(new MockIpcContract());
+    //     uint256 amount = 3;
+
+    //     vm.deal(callerAddr, 1 ether);
+
+    //     // register L2 into root nerwork
+    //     registerSubnet(subnet.subnetActorAddr, root.gateway);
+
+    //     // register L3s into L2 subnet
+    //     for (uint256 i; i < subnetL3s.length; i++) {
+    //         registerSubnet(subnetL3s[i].subnetActorAddr, subnet.gateway);
+    //     }
+
+    //     // fund account in the L3-0 subnet
+    //     vm.prank(callerAddr);
+
+    //     fundSubnet(subnet.gateway, subnetL3s[0], callerAddr, 100000);
+
+    //     // create the xnet message to send fund from L3-0 to L3-1
+    //     IpcEnvelope memory crossMessage = TestUtils.newXnetCallMsg(
+    //         IPCAddress({subnetId: subnetL3s[0].id, rawAddress: FvmAddressHelper.from(callerAddr)}),
+    //         IPCAddress({subnetId: subnetL3s[1].id, rawAddress: FvmAddressHelper.from(recipientAddr)}),
+    //         amount,
+    //         0
+    //     );
+
+    //     vm.prank(callerAddr);
+    //     subnetL3s[0].gateway.messenger().sendContractXnetMessage{value: amount}(crossMessage);
+
+    //     // submit the checkpoint from L3-0 to L2
+    //     BottomUpCheckpoint memory checkpoint = callCreateBottomUpCheckpointFromChildSubnet(
+    //         subnetL3s[0].id,
+    //         subnetL3s[0].gateway
+    //     );
+
+    //     // submit the checkpoint in L2 produces top down message to L3-1
+    //     submitBottomUpCheckpointAndExpectTopDownMessageEvent(
+    //         checkpoint,
+    //         subnetL3s[0].subnetActor,
+    //         crossMessage,
+    //         subnetL3s[1].subnetActorAddr,
+    //         subnet.gatewayAddr
+    //     );
+
+    //     // mimics the execution of the top down messages in the L3-1 subnet
+    //     IpcEnvelope[] memory msgs = new IpcEnvelope[](1);
+    //     msgs[0] = crossMessage;
+
+    //     executeTopDownMsgs(msgs, subnetL3s[1].gateway);
+
+    //     // submit the checkpoint from L3-1 to L2 for result propagation
+    //     BottomUpCheckpoint memory resultCheckpoint = callCreateBottomUpCheckpointFromChildSubnet(
+    //         subnetL3s[1].id,
+    //         subnetL3s[1].gateway
+    //     );
+
+    //     // expected result top down message from L2 to L3. This is a response to the xnet call.
+    //     IpcEnvelope memory resultMessage = crossMessage.createResultMsg(OutcomeType.Ok, abi.encode(EMPTY_BYTES));
+    //     resultMessage.nonce = 1;
+
+    //     // submit the checkpoint in L2 produces top down message to L3-1
+    //     submitBottomUpCheckpointAndExpectTopDownMessageEvent(
+    //         resultCheckpoint,
+    //         subnetL3s[1].subnetActor,
+    //         resultMessage,
+    //         subnetL3s[0].subnetActorAddr,
+    //         subnet.gatewayAddr
+    //     );
+
+    //     // apply the result message in the L3-1 subnet
+    //     resultMessage.nonce = 0;
+    //     IpcEnvelope[] memory resultMsgs = new IpcEnvelope[](1);
+    //     resultMsgs[0] = resultMessage;
+
+    //     executeTopDownMsgs(resultMsgs, subnetL3s[0].gateway);
+    //     assertTrue(caller.hasResult(), "missing result");
+    //     assertTrue(caller.result().outcome == OutcomeType.Ok, "wrong result outcome");
+    // }
+
+    // function commitParentFinality(address gateway) internal {
+    //     vm.roll(10);
+    //     ParentFinality memory finality = ParentFinality({height: block.number, blockHash: bytes32(0)});
+
+    //     TopDownFinalityFacet gwTopDownFinalityFacet = TopDownFinalityFacet(address(gateway));
+
+    //     vm.prank(FilAddress.SYSTEM_ACTOR);
+    //     gwTopDownFinalityFacet.commitParentFinality(finality);
+    // }
+
+    // function executeTopDownMsgs(IpcEnvelope[] memory msgs, GatewayDiamond gw) internal {
+    //     uint256 minted_tokens;
+
+    //     for (uint256 i; i < msgs.length; ) {
+    //         minted_tokens += msgs[i].value;
+    //         unchecked {
+    //             ++i;
+    //         }
+    //     }
+    //     console.log("minted tokens in executed top-downs: %d", minted_tokens);
+
+    //     // The implementation of the function in fendermint is in
+    //     // https://github.com/consensus-shipyard/ipc/blob/main/fendermint/vm/interpreter/contracts/fvm/topdown.rs#L43
+
+    //     // This emulates minting tokens.
+    //     vm.deal(address(gw), minted_tokens);
+
+    //     vm.prank(FilAddress.SYSTEM_ACTOR);
+    //     XnetMessagingFacet xnetMessenger = gw.xnetMessenger();
+    //     xnetMessenger.applyCrossMessages(msgs);
+    // }
+
+    // function executeTopDownMsgsAndExpectTopDownMessageEvent(
+    //     IpcEnvelope[] memory msgs,
+    //     GatewayDiamond gw,
+    //     IpcEnvelope memory expectedMessage,
+    //     address expectedSubnetAddr,
+    //     address expectedGatewayAddr
+    // ) internal {
+    //     uint256 minted_tokens;
+
+    //     for (uint256 i; i < msgs.length; ) {
+    //         minted_tokens += msgs[i].value;
+    //         unchecked {
+    //             ++i;
+    //         }
+    //     }
+    //     console.log("minted tokens in executed top-downs: %d", minted_tokens);
+
+    //     // The implementation of the function in fendermint is in
+    //     // https://github.com/consensus-shipyard/ipc/blob/main/fendermint/vm/interpreter/contracts/fvm/topdown.rs#L43
+
+    //     // This emulates minting tokens.
+    //     vm.deal(address(gw), minted_tokens);
+
+    //     vm.prank(FilAddress.SYSTEM_ACTOR);
+    //     vm.expectEmit(true, true, true, true, expectedGatewayAddr);
+    //     emit LibGateway.NewTopDownMessage({
+    //         subnet: expectedSubnetAddr,
+    //         message: expectedMessage,
+    //         id: expectedMessage.toDeterministicHash()
+    //     });
+    //     XnetMessagingFacet xnetMessenger = gw.xnetMessenger();
+    //     xnetMessenger.applyCrossMessages(msgs);
+    // }
+
+    function callCreateBottomUpCheckpointFromChildSubnet(
+        SubnetID memory subnet,
+        GatewayDiamond gw
+    ) internal returns (BottomUpCheckpoint memory checkpoint) {
+        uint256 e = getNextEpoch(block.number, DEFAULT_CHECKPOINT_PERIOD);
+
+        GatewayGetterFacet getter = gw.getter();
+        CheckpointingFacet checkpointer = gw.checkpointer();
+
+        BottomUpMsgBatch memory batch = getter.bottomUpMsgBatch(e);
+        require(batch.msgs.length == 1, "batch length incorrect");
+
+        (, address[] memory addrs, uint256[] memory weights) = TestUtils.getFourValidators(vm);
+
+        (bytes32 membershipRoot, ) = MerkleTreeHelper.createMerkleProofsForValidators(addrs, weights);
+
+        checkpoint = BottomUpCheckpoint({
+            subnetID: subnet,
+            blockHeight: batch.blockHeight,
+            blockHash: keccak256("block1"),
+            nextConfigurationNumber: 0,
+            msgs: batch.msgs,
+            activity: ActivityHelper.newCompressedActivityRollup(1, 3, bytes32(uint256(0)))
+        });
+
+        vm.prank(FilAddress.SYSTEM_ACTOR);
+        checkpointer.createBottomUpCheckpoint(
+            checkpoint,
+            membershipRoot,
+            weights[0] + weights[1] + weights[2],
+            ActivityHelper.dummyActivityRollup()
+        );
+
+        return checkpoint;
+    }
+
+    // function callCreateBottomUpCheckpointFromChildSubnet(
+    //     SubnetID memory subnet,
+    //     GatewayDiamond gw,
+    //     IpcEnvelope[] memory msgs
+    // ) internal returns (BottomUpCheckpoint memory checkpoint) {
+    //     uint256 e = getNextEpoch(block.number, DEFAULT_CHECKPOINT_PERIOD);
+
+    //     CheckpointingFacet checkpointer = gw.checkpointer();
+
+    //     (, address[] memory addrs, uint256[] memory weights) = TestUtils.getFourValidators(vm);
+
+    //     (bytes32 membershipRoot, ) = MerkleTreeHelper.createMerkleProofsForValidators(addrs, weights);
+
+    //     checkpoint = BottomUpCheckpoint({
+    //         subnetID: subnet,
+    //         blockHeight: e,
+    //         blockHash: keccak256("block1"),
+    //         nextConfigurationNumber: 0,
+    //         msgs: msgs,
+    //         activity: ActivityHelper.newCompressedActivityRollup(1, 3, bytes32(uint256(0)))
+    //     });
+
+    //     vm.startPrank(FilAddress.SYSTEM_ACTOR);
+    //     checkpointer.createBottomUpCheckpoint(
+    //         checkpoint,
+    //         membershipRoot,
+    //         weights[0] + weights[1] + weights[2],
+    //         ActivityHelper.dummyActivityRollup()
+    //     );
+    //     vm.stopPrank();
+
+    //     return checkpoint;
+    // }
+
+    function prepareValidatorsSignatures(
+        BottomUpCheckpoint memory checkpoint,
+        SubnetActorDiamond sa
+    ) internal returns (address[] memory, bytes[] memory) {
+        (uint256[] memory parentKeys, address[] memory parentValidators, ) = TestUtils.getThreeValidators(vm);
+        bytes[] memory parentPubKeys = new bytes[](3);
+        bytes[] memory parentSignatures = new bytes[](3);
+
+        SubnetActorManagerFacet manager = sa.manager();
+
+        for (uint256 i = 0; i < 3; i++) {
+            vm.deal(parentValidators[i], 10 gwei);
+            parentPubKeys[i] = TestUtils.deriveValidatorPubKeyBytes(parentKeys[i]);
+            vm.prank(parentValidators[i]);
+            manager.join{value: 10}(parentPubKeys[i], 10);
+        }
+
+        bytes32 hash = keccak256(abi.encode(checkpoint));
+
+        for (uint256 i = 0; i < 3; i++) {
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(parentKeys[i], hash);
+            parentSignatures[i] = abi.encodePacked(r, s, v);
+        }
+
+        return (parentValidators, parentSignatures);
+    }
+
+    function submitBottomUpCheckpoint(BottomUpCheckpoint memory checkpoint, SubnetActorDiamond sa) internal {
+        (address[] memory parentValidators, bytes[] memory parentSignatures) = prepareValidatorsSignatures(
+            checkpoint,
+            sa
+        );
+
+        SubnetActorCheckpointingFacet checkpointer = sa.checkpointer();
+
+        vm.deal(address(1), 1 ether);
+        vm.prank(address(1));
+        checkpointer.submitCheckpoint(checkpoint, parentValidators, parentSignatures);
+    }
+
+    // function submitBottomUpCheckpointAndExpectTopDownMessageEvent(
+    //     BottomUpCheckpoint memory checkpoint,
+    //     SubnetActorDiamond subnetActor,
+    //     IpcEnvelope memory expectedMessage,
+    //     address expectedSubnetAddr,
+    //     address expectedGatewayAddr
+    // ) internal {
+    //     (address[] memory parentValidators, bytes[] memory parentSignatures) = prepareValidatorsSignatures(
+    //         checkpoint,
+    //         subnetActor
+    //     );
+
+    //     SubnetActorCheckpointingFacet checkpointer = subnetActor.checkpointer();
+
+    //     vm.startPrank(address(subnetActor));
+    //     vm.expectEmit(true, true, true, true, expectedGatewayAddr);
+    //     emit LibGateway.NewTopDownMessage({
+    //         subnet: expectedSubnetAddr,
+    //         message: expectedMessage,
+    //         id: expectedMessage.toDeterministicHash()
+    //     });
+    //     checkpointer.submitCheckpoint(checkpoint, parentValidators, parentSignatures);
+    //     vm.stopPrank();
+    // }
+
+    // function submitBottomUpCheckpointRevert(BottomUpCheckpoint memory checkpoint, SubnetActorDiamond sa) internal {
+    //     vm.expectRevert();
+    //     submitBottomUpCheckpoint(checkpoint, sa);
+    // }
+
+    function getNextEpoch(uint256 blockNumber, uint256 checkPeriod) internal pure returns (uint256) {
+        return ((uint64(blockNumber) / checkPeriod) + 1) * checkPeriod;
+    }
+
+    // function cloneIpcEnvelopeWithDifferentNonce(
+    //     IpcEnvelope memory original,
+    //     uint64 newNonce
+    // ) internal pure returns (IpcEnvelope memory) {
+    //     return
+    //         IpcEnvelope({
+    //             kind: original.kind,
+    //             to: original.to,
+    //             from: original.from,
+    //             nonce: newNonce,
+    //             value: original.value,
+    //             message: original.message
+    //         });
+    // }
+
+    // function printActors() internal view {
+    //     console.log("root name: %s", rootNetwork.id.toString());
+    //     console.log("root gateway: %s", rootNetwork.gatewayAddr);
+    //     console.log("root actor: %s", rootNetwork.id.getActor());
+    //     console.log("--------------------");
+
+    //     console.log("native L2 subnet name: %s", nativeL2Subnet.id.toString());
+    //     console.log("native L2 subnet gateway: %s", nativeL2Subnet.gatewayAddr);
+    //     console.log("native L2 subnet actor: %s", (nativeL2Subnet.subnetActorAddr));
+
+    //     for (uint256 i; i < nativeL3Subnets.length; i++) {
+    //         console.log("--------------------");
+    //         console.log("native L3-%d subnet name: %s", i, nativeL3Subnets[i].id.toString());
+    //         console.log("native L3-%d subnet gateway: %s", i, nativeL3Subnets[i].gatewayAddr);
+    //         console.log("native L3-%d subnet actor: %s", i, (nativeL3Subnets[i].subnetActorAddr));
+    //     }
+
+    //     for (uint256 i; i < nativeL3SubnetsWithTokenParent.length; i++) {
+    //         console.log("--------------------");
+    //         console.log(
+    //             "native L3-%d subnet with token parent name: %s",
+    //             i,
+    //             nativeL3SubnetsWithTokenParent[i].id.toString()
+    //         );
+    //         console.log(
+    //             "native L3-%d subnet with token parent gateway: %s",
+    //             i,
+    //             nativeL3SubnetsWithTokenParent[i].gatewayAddr
+    //         );
+    //         console.log(
+    //             "native L3-%d subnet with token parent actor: %s",
+    //             i,
+    //             (nativeL3SubnetsWithTokenParent[i].subnetActorAddr)
+    //         );
+    //     }
+    // }
+}

--- a/contracts/test/integration/MultiSubnet.t.sol
+++ b/contracts/test/integration/MultiSubnet.t.sol
@@ -1150,15 +1150,17 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
         vm.deal(tokenSubnet.subnetActorAddr, DEFAULT_COLLATERAL_AMOUNT);
         vm.deal(caller, 1 ether);
 
-        uint256 fundToSend = 10;
+        uint256 balance = 100;
 
         // Fund an account in the subnet.
-        token.transfer(caller, fundToSend);
+        token.transfer(caller, balance);
         vm.prank(caller);
-        token.approve(rootSubnet.gatewayAddr, fundToSend);
+        token.approve(rootSubnet.gatewayAddr, balance);
 
         vm.prank(tokenSubnet.subnetActorAddr);
         registerSubnetGW(DEFAULT_COLLATERAL_AMOUNT, tokenSubnet.subnetActorAddr, rootSubnet.gateway);
+
+        uint256 fundToSend = 10;
 
         vm.prank(caller);
         rootSubnet.gateway.manager().fundWithToken(tokenSubnet.id, FvmAddressHelper.from(address(caller)), fundToSend);
@@ -1190,14 +1192,14 @@ contract MultiSubnetTest is Test, IntegrationTestBase {
         // but the caller is MockIpcContractRevert, which reverts whatever
         // call made to `handleIpcMessage`, we should make sure:
         // 1. The submission of checkpoint is never blocked
+        // 2. The fund is locked in the gateway as execution is rejected
         submitBottomUpCheckpoint(checkpoint, tokenSubnet.subnetActor);
 
-        // because error result xnet message should have refunded the token
-        require(token.balanceOf(caller) == amount, "caller fund should not be locked in gateway");
         require(
-            token.balanceOf(address(rootSubnet.gateway.manager())) == fundToSend - amount,
-            "fund should not be locked in gateway"
+            token.balanceOf(address(rootSubnet.gateway.manager())) == fundToSend,
+            "fund should still be locked in gateway"
         );
+        require(token.balanceOf(caller) == balance - fundToSend, "fund should still be locked in gateway");
     }
 
     function testMultiSubnet_Token_CallFromChildToParent() public {

--- a/contracts/test/unit/CrossMsgHelper.t.sol
+++ b/contracts/test/unit/CrossMsgHelper.t.sol
@@ -175,9 +175,10 @@ contract CrossMsgHelperTest is Test {
         crossMsg = crossMsg.setCallMsg(message);
 
         vm.deal(sender, 1 ether);
-        vm.expectCall(recipient, 0, new bytes(0), 1);
+        vm.expectCall(recipient, crossMsg.value, new bytes(0), 1);
 
-        (, bytes memory result) = crossMsg.execute(AssetHelper.native());
+        (bool ok, bytes memory result) = crossMsg.execute(AssetHelper.native());
+        console.log(ok);
 
         require(keccak256(result) == keccak256(EMPTY_BYTES));
     }

--- a/contracts/test/unit/LibGateway.t.sol
+++ b/contracts/test/unit/LibGateway.t.sol
@@ -198,13 +198,12 @@ contract LibGatewayTest is Test {
         address fromRaw = address(1000);
         address toRaw = address(1001);
 
-        IPCAddress memory from = IPCAddress({subnetId: parentSubnet, rawAddress: FvmAddressHelper.from(fromRaw)});
-        IPCAddress memory to = IPCAddress({subnetId: childSubnet, rawAddress: FvmAddressHelper.from(toRaw)});
+        uint256 value = 1000;
 
         IpcEnvelope memory crossMsg = CrossMsgHelper.createCallMsg({
-            from: from,
-            to: to,
-            value: 1000,
+            from: IPCAddress({subnetId: parentSubnet, rawAddress: FvmAddressHelper.from(fromRaw)}),
+            to: IPCAddress({subnetId: childSubnet, rawAddress: FvmAddressHelper.from(toRaw)}),
+            value: value,
             method: bytes4(0),
             params: new bytes(0)
         });
@@ -219,7 +218,7 @@ contract LibGatewayTest is Test {
             kind: IpcMsgKind.Result,
             from: crossMsg.to,
             to: crossMsg.from,
-            value: 0,
+            value: value,
             message: abi.encode(message),
             nonce: 0
         });
@@ -311,13 +310,12 @@ contract LibGatewayTest is Test {
         address fromRaw = address(1000);
         address toRaw = callingContract;
 
-        IPCAddress memory from = IPCAddress({subnetId: childSubnet, rawAddress: FvmAddressHelper.from(fromRaw)});
-        IPCAddress memory to = IPCAddress({subnetId: parentSubnet, rawAddress: FvmAddressHelper.from(toRaw)});
+        uint256 value = 1000;
 
         IpcEnvelope memory crossMsg = CrossMsgHelper.createCallMsg({
-            from: from,
-            to: to,
-            value: 1000,
+            from: IPCAddress({subnetId: childSubnet, rawAddress: FvmAddressHelper.from(fromRaw)}),
+            to: IPCAddress({subnetId: parentSubnet, rawAddress: FvmAddressHelper.from(toRaw)}),
+            value: value,
             method: GatewayDummyContract.reverts.selector,
             params: new bytes(0)
         });
@@ -332,7 +330,7 @@ contract LibGatewayTest is Test {
             kind: IpcMsgKind.Result,
             from: crossMsg.to,
             to: crossMsg.from,
-            value: 0,
+            value: value,
             message: abi.encode(message),
             nonce: 0
         });
@@ -365,13 +363,12 @@ contract LibGatewayTest is Test {
         address fromRaw = address(1000);
         address toRaw = callingContract;
 
-        IPCAddress memory from = IPCAddress({subnetId: childSubnet, rawAddress: FvmAddressHelper.from(fromRaw)});
-        IPCAddress memory to = IPCAddress({subnetId: parentSubnet, rawAddress: FvmAddressHelper.from(toRaw)});
+        uint256 value = 1000;
 
         IpcEnvelope memory crossMsg = CrossMsgHelper.createCallMsg({
-            from: from,
-            to: to,
-            value: 1000,
+            from: IPCAddress({subnetId: childSubnet, rawAddress: FvmAddressHelper.from(fromRaw)}),
+            to: IPCAddress({subnetId: parentSubnet, rawAddress: FvmAddressHelper.from(toRaw)}),
+            value: value,
             method: GatewayDummyContract.reverts.selector,
             params: new bytes(0)
         });
@@ -386,7 +383,7 @@ contract LibGatewayTest is Test {
             kind: IpcMsgKind.Result,
             from: crossMsg.to,
             to: crossMsg.from,
-            value: 0,
+            value: value,
             message: abi.encode(message),
             nonce: 0
         });


### PR DESCRIPTION
This PR builds on previous PR but instead enables the value transfer in cross network messages. 

Update 27/12/24:
- If the message is topdown, lock the value from the supply source of the NEXT child subnet: https://github.com/consensus-shipyard/ipc/pull/1240/files#diff-71559bfe927afaf1a3980c01ffe9f4d15c77d58650b2d850bbae821de9c009d0R76
- Fix postbox key index issue: https://github.com/consensus-shipyard/ipc/pull/1240/files#diff-b26838f2cc5f8bf764313ca069618747d9171766dc768ece47de2d9c38ffddfbR699
- A simple test framework to simulate xnet message flow: https://github.com/consensus-shipyard/ipc/pull/1240/files#diff-53695b3660cd8c2d5418a61e61a1abda1cd2ba05dcc0f607ddd3251b9cc8f57dR466