### PR TITLE
feat(tests): concurrent materializer tests

### DIFF
--- a/fendermint/testing/materializer/src/concurrency.rs
+++ b/fendermint/testing/materializer/src/concurrency.rs
@@ -1,0 +1,13 @@
+pub struct Config {
+    pub parallelism_level: usize
+}
+
+impl Config {
+    pub fn with_parallelism_level(v: usize) -> Self {
+        Self { parallelism_level: v }
+    }
+}
+
+
+
+

--- a/fendermint/testing/materializer/src/lib.rs
+++ b/fendermint/testing/materializer/src/lib.rs
@@ -20,6 +20,7 @@ pub mod validation;
 
 #[cfg(feature = "arb")]
 mod arb;
+pub mod concurrency;
 
 /// An ID identifying a resource within its parent.
 #[derive(Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]

--- a/fendermint/testing/materializer/src/testnet.rs
+++ b/fendermint/testing/materializer/src/testnet.rs
@@ -140,6 +140,15 @@ where
             .ok_or_else(|| anyhow!("account {id} does not exist"))
     }
 
+    pub fn account_mod_nth(&self, v: usize) -> &M::Account {
+        let nth = v % self.accounts.len();
+        self.accounts
+            .iter()
+            .nth(nth)
+            .map(|(_, account)| account)
+            .unwrap()
+    }
+
     /// Get a node by name.
     pub fn node(&self, name: &NodeName) -> anyhow::Result<&M::Node> {
         self.nodes

--- a/fendermint/testing/materializer/tests/docker.rs
+++ b/fendermint/testing/materializer/tests/docker.rs
@@ -16,13 +16,8 @@ use std::{
 
 use anyhow::{anyhow, Context};
 use ethers::providers::Middleware;
-use fendermint_materializer::{
-    docker::{DockerMaterializer, DockerMaterials},
-    manifest::Manifest,
-    testnet::Testnet,
-    HasCometBftApi, HasEthApi, TestnetName,
-};
-use futures::Future;
+use fendermint_materializer::{concurrency, docker::{DockerMaterializer, DockerMaterials}, manifest::Manifest, testnet::Testnet, HasCometBftApi, HasEthApi, TestnetName};
+use futures::{future, Future};
 use lazy_static::lazy_static;
 use tendermint_rpc::Client;
 
@@ -59,13 +54,14 @@ fn read_manifest(file_name: &str) -> anyhow::Result<Manifest> {
 
 /// Parse a manifest file in the `manifests` directory, clean up any corresponding
 /// testnet resources, then materialize a testnet and run some tests.
-pub async fn with_testnet<F, G>(manifest_file_name: &str, alter: G, test: F) -> anyhow::Result<()>
+pub async fn with_testnet<F, G>(manifest_file_name: &str, concurrency: Option<concurrency::Config>, alter: G, test: F) -> anyhow::Result<()>
 where
-    // https://users.rust-lang.org/t/function-that-takes-a-closure-with-mutable-reference-that-returns-a-future/54324
-    F: for<'a> FnOnce(
+// https://users.rust-lang.org/t/function-that-takes-a-closure-with-mutable-reference-that-returns-a-future/54324
+    F: for<'a> Fn(
         &Manifest,
-        &mut DockerMaterializer,
-        &'a mut DockerTestnet,
+        &DockerMaterializer,
+        &'a DockerTestnet,
+        usize
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + 'a>>,
     G: FnOnce(&mut Manifest),
 {
@@ -98,14 +94,40 @@ where
         .await
         .context("failed to remove testnet")?;
 
-    let mut testnet = Testnet::setup(&mut materializer, &testnet_name, &manifest)
+    let testnet = Testnet::setup(&mut materializer, &testnet_name, &manifest)
         .await
         .context("failed to set up testnet")?;
 
     let started = wait_for_startup(&testnet).await?;
 
     let res = if started {
-        test(&manifest, &mut materializer, &mut testnet).await
+        match concurrency {
+            None => test(&manifest, &materializer, &testnet, 0).await,
+            Some(cfg) => {
+                let mut futures = Vec::new();
+                let mut test_ids = Vec::new();
+                for i in 0..cfg.parallelism_level {
+                    let test_id = i;
+                    let task = test(&manifest, &materializer, &testnet, test_id);
+                    futures.push(task);
+                    test_ids.push(test_id);
+                }
+
+                let results: Vec<Result<(), anyhow::Error>> = future::join_all(futures).await;
+                let mut err = None;
+                for (i, result) in results.into_iter().enumerate() {
+                    let test_id = test_ids[i];
+                    match result {
+                        Ok(_) => println!("test completed successfully (test_id={})", test_id),
+                        Err(e) => {
+                            println!("test failed: {} (test_id={})", e, test_id);
+                            err = Some(e);
+                        },
+                    }
+                }
+                err.map_or(Ok(()), Err)
+            }
+        }
     } else {
         Err(anyhow!("the startup sequence timed out"))
     };

--- a/fendermint/testing/materializer/tests/docker_tests/layer2.rs
+++ b/fendermint/testing/materializer/tests/docker_tests/layer2.rs
@@ -27,6 +27,7 @@ const MAX_RETRIES: u32 = 5;
 async fn test_topdown_and_bottomup() {
     with_testnet(
         MANIFEST,
+        None,
         |manifest| {
             // Try to make sure the bottom-up checkpoint period is quick enough for reasonable test runtime.
             let subnet = manifest
@@ -36,7 +37,7 @@ async fn test_topdown_and_bottomup() {
 
             subnet.bottom_up_checkpoint.period = CHECKPOINT_PERIOD;
         },
-        |_, _, testnet| {
+        |_, _, testnet, _| {
             let test = async {
                 let brussels = testnet.node(&testnet.root().node("brussels"))?;
                 let london = testnet.node(&testnet.root().subnet("england").node("london"))?;

--- a/fendermint/testing/materializer/tests/docker_tests/root_only.rs
+++ b/fendermint/testing/materializer/tests/docker_tests/root_only.rs
@@ -16,8 +16,9 @@ const MANIFEST: &str = "root-only.yaml";
 async fn test_full_node_sync() {
     with_testnet(
         MANIFEST,
+        None,
         |_| {},
-        |_, _, testnet| {
+        |_, _, testnet, _| {
             let test = async {
                 // Allow a little bit of time for node-2 to catch up with node-1.
                 tokio::time::sleep(Duration::from_secs(5)).await;


### PR DESCRIPTION
Introducing concurrency as a middleware in `materializer`, enabling the generation of traceable workloads without altering how test scenarios are written, except for the addition of a unique `test_id` parameter.

`docket_tests::standalone::test_sent_tx_found_in_mempool` was refactored as an example. 

TODOs
* [ ] Extract / incapsulate concurrent execution implementation (currently inlined in `docker::with_testnet`)
* [ ] Apply actual parallelism
* [ ] Utilize `test_id` to derive non-static scenarios in all tests
* [ ] Introduce basic workload generation features (rate, duration, etc.)

For follow-up PRs
* Introduce profiling features
* Introduce tracing / statistical analysis features
