### PR TITLE
fix(contracts): fix contract audit findings

### DIFF
--- a/contracts/contracts/gateway/GatewayManagerFacet.sol
+++ b/contracts/contracts/gateway/GatewayManagerFacet.sol
@@ -27,7 +27,7 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
     using AssetHelper for Asset;
     using EnumerableSet for EnumerableSet.Bytes32Set;
 
-    event SubnetKilled(SubnetID id);
+    event SubnetDestroyed(SubnetID id);
 
     /// @notice register a subnet in the gateway. It is called by a subnet when it reaches the threshold stake
     /// @dev The subnet can optionally pass a genesis circulating supply that would be pre-allocated in the
@@ -128,7 +128,7 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
         s.subnetKeys.remove(id);
         SubnetActorGetterFacet(msg.sender).collateralSource().transferFunds(payable(msg.sender), stake);
 
-        emit SubnetKilled(subnet.id);
+        emit SubnetDestroyed(subnet.id);
     }
 
     /// @notice credits the received value to the specified address in the specified child subnet.

--- a/contracts/contracts/gateway/GatewayManagerFacet.sol
+++ b/contracts/contracts/gateway/GatewayManagerFacet.sol
@@ -27,6 +27,8 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
     using AssetHelper for Asset;
     using EnumerableSet for EnumerableSet.Bytes32Set;
 
+    event SubnetKilled(SubnetID id);
+
     /// @notice register a subnet in the gateway. It is called by a subnet when it reaches the threshold stake
     /// @dev The subnet can optionally pass a genesis circulating supply that would be pre-allocated in the
     /// subnet from genesis (without having to wait for the subnet to be spawned to propagate the funds).
@@ -35,13 +37,6 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
         // subnets in the root
         if (s.networkName.route.length + 1 >= s.maxTreeDepth) {
             revert MethodNotAllowed(ERR_CHILD_SUBNET_NOT_ALLOWED);
-        }
-
-        if (genesisCircSupply > 0) {
-            SubnetActorGetterFacet(msg.sender).supplySource().lock(genesisCircSupply);
-        }
-        if (collateral > 0) {
-            SubnetActorGetterFacet(msg.sender).collateralSource().lock(collateral);
         }
 
         SubnetID memory subnetId = s.networkName.createSubnetId(msg.sender);
@@ -58,10 +53,17 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
 
         s.subnetKeys.add(subnetId.toHash());
         s.totalSubnets += 1;
+
+        if (genesisCircSupply > 0) {
+            SubnetActorGetterFacet(msg.sender).supplySource().lock(genesisCircSupply);
+        }
+        if (collateral > 0) {
+            SubnetActorGetterFacet(msg.sender).collateralSource().lock(collateral);
+        }
     }
 
     /// @notice addStake - add collateral for an existing subnet
-    function addStake(uint256 amount) external payable {
+    function addStake(uint256 amount) external nonReentrant payable {
         if (amount == 0) {
             revert NotEnoughFunds();
         }
@@ -72,7 +74,6 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
         SubnetActorGetterFacet(msg.sender).collateralSource().lock(amount);
 
         (bool registered, Subnet storage subnet) = LibGateway.getSubnet(msg.sender);
-
         if (!registered) {
             revert NotRegisteredSubnet();
         }
@@ -126,6 +127,8 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
 
         s.subnetKeys.remove(id);
         SubnetActorGetterFacet(msg.sender).collateralSource().transferFunds(payable(msg.sender), stake);
+
+        emit SubnetKilled(subnet.id);
     }
 
     /// @notice credits the received value to the specified address in the specified child subnet.

--- a/contracts/contracts/gateway/GatewayManagerFacet.sol
+++ b/contracts/contracts/gateway/GatewayManagerFacet.sol
@@ -63,7 +63,7 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
     }
 
     /// @notice addStake - add collateral for an existing subnet
-    function addStake(uint256 amount) external payable nonReentrant {
+    function addStake(uint256 amount) external payable {
         if (amount == 0) {
             revert NotEnoughFunds();
         }

--- a/contracts/contracts/gateway/GatewayManagerFacet.sol
+++ b/contracts/contracts/gateway/GatewayManagerFacet.sol
@@ -63,7 +63,7 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
     }
 
     /// @notice addStake - add collateral for an existing subnet
-    function addStake(uint256 amount) external nonReentrant payable {
+    function addStake(uint256 amount) external payable nonReentrant {
         if (amount == 0) {
             revert NotEnoughFunds();
         }

--- a/contracts/contracts/gateway/GatewayMessengerFacet.sol
+++ b/contracts/contracts/gateway/GatewayMessengerFacet.sol
@@ -45,7 +45,7 @@ contract GatewayMessengerFacet is GatewayActorModifiers {
         }
 
         // We prevent the sender from being an EoA.
-        if (!(msg.sender.code.length > 0)) {
+        if (msg.sender.code.length == 0) {
             revert InvalidXnetMessage(InvalidXnetMessageReason.Sender);
         }
 

--- a/contracts/contracts/lib/LibGateway.sol
+++ b/contracts/contracts/lib/LibGateway.sol
@@ -423,7 +423,7 @@ library LibGateway {
                 sendReceipt(crossMsg, OutcomeType.SystemErr, abi.encodeWithSelector(InvalidXnetMessage.selector, InvalidXnetMessageReason.Nonce));
                 return;
             }
-            ++subnet.appliedBottomUpNonce;
+            subnet.appliedBottomUpNonce += 1;
 
             // The value carried in bottom-up messages needs to be treated according to the supply source
             // configuration of the subnet.
@@ -434,7 +434,7 @@ library LibGateway {
                 sendReceipt(crossMsg, OutcomeType.SystemErr, abi.encodeWithSelector(InvalidXnetMessage.selector, InvalidXnetMessageReason.Nonce));
                 return;
             }
-            ++s.appliedTopDownNonce;
+            s.appliedTopDownNonce += 1;
 
             // The value carried in top-down messages locally maps to the native coin, so we pass over the
             // native supply source.

--- a/contracts/contracts/lib/LibGateway.sol
+++ b/contracts/contracts/lib/LibGateway.sol
@@ -423,7 +423,7 @@ library LibGateway {
                 sendReceipt(crossMsg, OutcomeType.SystemErr, abi.encodeWithSelector(InvalidXnetMessage.selector, InvalidXnetMessageReason.Nonce));
                 return;
             }
-            subnet.appliedBottomUpNonce += 1;
+            ++subnet.appliedBottomUpNonce;
 
             // The value carried in bottom-up messages needs to be treated according to the supply source
             // configuration of the subnet.
@@ -434,7 +434,7 @@ library LibGateway {
                 sendReceipt(crossMsg, OutcomeType.SystemErr, abi.encodeWithSelector(InvalidXnetMessage.selector, InvalidXnetMessageReason.Nonce));
                 return;
             }
-            s.appliedTopDownNonce += 1;
+            ++s.appliedTopDownNonce;
 
             // The value carried in top-down messages locally maps to the native coin, so we pass over the
             // native supply source.

--- a/contracts/contracts/lib/LibSubnetActor.sol
+++ b/contracts/contracts/lib/LibSubnetActor.sol
@@ -120,7 +120,7 @@ library LibSubnetActor {
 
         uint256 length = validators.length;
 
-        if (length <= s.minValidators) {
+        if (length < s.minValidators) {
             revert NotEnoughGenesisValidators();
         }
 

--- a/contracts/contracts/subnet/SubnetActorManagerFacet.sol
+++ b/contracts/contracts/subnet/SubnetActorManagerFacet.sol
@@ -24,6 +24,9 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
     using LibValidatorSet for ValidatorSet;
     using Address for address payable;
 
+    event ValidatorGaterUpdated(address oldGater, address newGater);
+    event NewBootstrapNode(string netAddress, address owner);
+
     /// @notice method to add some initial balance into a subnet that hasn't yet bootstrapped.
     /// @dev This balance is added to user addresses in genesis, and becomes part of the genesis
     /// circulating supply.
@@ -73,8 +76,13 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
         }
     }
 
+    /// @notice Sets the validator gater contract implementation
+    /// @param gater The addresseof validator gater implementation.
     function setValidatorGater(address gater) external notKilled {
         LibDiamond.enforceIsContractOwner();
+
+        emit ValidatorGaterUpdated(s.validatorGater, gater);
+
         s.validatorGater = gater;
     }
 
@@ -255,7 +263,7 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
             // check if the validator had some initial balance and return it if not bootstrapped
             uint256 genesisBalance = s.genesisBalance[msg.sender];
             if (genesisBalance != 0) {
-                s.genesisBalance[msg.sender] == 0;
+                delete s.genesisBalance[msg.sender];
                 s.genesisCircSupply -= genesisBalance;
                 LibSubnetActor.rmAddressFromBalanceKey(msg.sender);
                 s.collateralSource.transferFunds(payable(msg.sender), genesisBalance);
@@ -284,7 +292,7 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
 
     /// @notice Add a bootstrap node.
     /// @param netAddress The network address of the new bootstrap node.
-    function addBootstrapNode(string memory netAddress) external whenNotPaused {
+    function addBootstrapNode(string calldata netAddress) external whenNotPaused {
         if (!s.validatorSet.isActiveValidator(msg.sender)) {
             revert NotValidator(msg.sender);
         }
@@ -294,5 +302,7 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
         s.bootstrapNodes[msg.sender] = netAddress;
         // slither-disable-next-line unused-return
         s.bootstrapOwners.add(msg.sender);
+
+        emit NewBootstrapNode(netAddress, msg.sender);
     }
 }

--- a/contracts/contracts/subnet/SubnetActorManagerFacet.sol
+++ b/contracts/contracts/subnet/SubnetActorManagerFacet.sol
@@ -77,7 +77,7 @@ contract SubnetActorManagerFacet is SubnetActorModifiers, ReentrancyGuard, Pausa
     }
 
     /// @notice Sets the validator gater contract implementation
-    /// @param gater The addresseof validator gater implementation.
+    /// @param gater The addresse of validator gater implementation.
     function setValidatorGater(address gater) external notKilled {
         LibDiamond.enforceIsContractOwner();
 

--- a/contracts/test/integration/SubnetActorDiamond.t.sol
+++ b/contracts/test/integration/SubnetActorDiamond.t.sol
@@ -1584,7 +1584,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
             gatewayAddress,
             ConsensusType.Fendermint,
             DEFAULT_MIN_VALIDATOR_STAKE,
-            DEFAULT_MIN_VALIDATORS,
+            2,
             DEFAULT_CHECKPOINT_PERIOD,
             DEFAULT_MAJORITY_PERCENTAGE,
             PermissionMode.Federated,


### PR DESCRIPTION
This PR addresses the review audits.

## Fixes

**Mediums:**
- [x] M1: Addressed

**Lows:**
- [x] L1: I dont think we should address this. The subnet does not really know if the destination subnet exists. Caller should be aware.
- [x] L2: Updated, this one is known to have created tons of confusion.

**Informationals:**
- [x] I1: Addressed
- [x] I2: Addressed
- [x] I3: Addressed
- [x] I5: Addressed
- [x] I6: Addressed
- [x] I8: Addressed

## To discuss
- [ ] L3: We should taggle gas_limit in cross message transactions, but the issue is more complex than described. Maybe delay to another issue?
- [ ] I4: We should discuss if we need this, but I think it’s a good practice
- [ ] I7:  I dont see the line mentioned, maybe the codebase is different







