### PR TITLE
fix(node): set rust toolchain/job runner to a fix value

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,6 +73,8 @@ jobs:
           rustc --version
           echo "cargo version:"
           cargo -V
+          echo "glibc version"
+          ldd --version
 
       - name: Check fmt (nightly)
         run: cargo +nightly-2024-07-05 fmt --check --all

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build IPC
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       RUST_BACKTRACE: full
       RUSTFLAGS: -Dwarnings

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
           cargo -V
 
       - name: Check fmt (nightly)
-        run: cargo +nightly-2024-10-05 fmt --check --all
+        run: cargo +nightly-2024-07-05 fmt --check --all
 
       - name: Check clippy
         run: cargo clippy --release --tests --no-deps -- -D clippy::all

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: nightly-2024-07-05
           components: rustfmt,clippy
 
       - name: Print Rust toolchain default versions

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          rust: stable
+          rust: 1.81.0
 
       - name: Install Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
           cargo -V
 
       - name: Check fmt (nightly)
-        run: cargo +nightly fmt --check --all
+        run: cargo +nightly-2024-10-05 fmt --check --all
 
       - name: Check clippy
         run: cargo clippy --release --tests --no-deps -- -D clippy::all

--- a/.github/workflows/tests-e2e.yaml
+++ b/.github/workflows/tests-e2e.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          rust: stable
+          rust: 1.81.0
 
       - name: Download Docker image
         uses: actions/download-artifact@v4

--- a/.github/workflows/tests-unit.yaml
+++ b/.github/workflows/tests-unit.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          rust: stable
+          rust: 1.81.0
 
       - name: Cache Solidity ABI artifacts
         uses: actions/cache@v4


### PR DESCRIPTION
Currently CI is auto using latest ubuntu, which is now 24.04. This version of ubuntu is using glibc 2.39 and causing the debian image to fail as it only supports 2.36. This PR mainly downgrade ubuntu to 22.04 so that the image can be built correctly.

At the same time, fixing the rust toolchain to align with that specified in `toolchain.toml`. Currently if we up the rust version to 1.84.0, some updated crates requires glibc 2.39, such as:
<img width="958" alt="image" src="https://github.com/user-attachments/assets/2e30daea-abae-4a05-938e-6d9a733f9c4a" />

Also fixing the CI to have the same rust version as toolchain also makes the environments aligned.