### PR TITLE
docs: add markdown linter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ on:
 
 
 jobs:
+  commonmark:
+    uses: ./.github/workflows/lint-commonmark.yaml
 
   license:
     uses: ./.github/workflows/license.yaml

--- a/.github/workflows/commonmark-lint.yaml
+++ b/.github/workflows/commonmark-lint.yaml
@@ -1,0 +1,25 @@
+name: "Commonmark/Markdown: Lint"
+
+# This workflow is triggered from the main CI workflow.
+on:
+  workflow_call:
+
+jobs:
+  lint-commonmark:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - name: Check out the project
+      uses: actions/checkout@v4
+
+    - name: Lint all commonmark/markdown files
+      uses: DavidAnson/markdownlint-cli2-action@v19
+      continue-on-error: true
+      with:
+        fix: true
+        globs: '(scripts|crates)/**/README.md;contracts/specs/**/*.md;specs/**/*.md;docs/**/*.md'
+        separator: ';'
+
+    - name: Check compliance
+      run: |
+        git diff --exit-code

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,4 +1,4 @@
-name: "Lint PR"
+name: "Lint PR title"
 
 on:
   pull_request:

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,6 @@ license:
 	./scripts/add_license.sh
 
 lint: license $(patsubst %, lint/%, $(SUBTREES_ALL))
+
+markdownlint:
+	$(MARKDOWNLINT_CLI) --fix $$(find . -iwholename './crates/**/README.md' -or -iwholename './contracts/**/*.md' -or -iwholename './specs/**/*.md' -or -iwholename './docs*/**/*.md')


### PR DESCRIPTION
All our documentation is in markdown format, but it's not linted for consistency. This PR adds `markdownlint-cli2` checks per PR, to replicated locally a `Makefile` rule was added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/consensus-shipyard/ipc/1270)
<!-- Reviewable:end -->
