### PR TITLE
fix(CI): re-enable CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   commonmark:
-    uses: ./.github/workflows/lint-commonmark.yaml
+    uses: ./.github/workflows/commonmark-lint.yaml
 
   license:
     uses: ./.github/workflows/license.yaml


### PR DESCRIPTION
A misnamed subtask broke the CI.

Mea culpa.

Mitigation for the future: Add required PR status checks in GH