### PR TITLE
fix(ci): skip update check for `aderyn`

### DIFF
--- a/.github/workflows/contracts-sast.yaml
+++ b/.github/workflows/contracts-sast.yaml
@@ -56,7 +56,7 @@ jobs:
         run: aderyn --version
 
       - name: Run aderyn
-        run: cd contracts && aderyn ./ -o report.json
+        run: cd contracts && aderyn --skip-update-check ./ -o report.json
 
       - name: Check results
         run: cd contracts && ./tools/check_aderyn.sh


### PR DESCRIPTION
Upstream has an incompatible release tag and causes the `aderyn` to `panic` when parsing the version.