### PR TITLE
feat(node): integrate with ref-fvm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cid"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
+dependencies = [
+ "core2",
+ "multibase",
+ "multihash 0.19.2",
+ "serde",
+ "serde_bytes",
+ "unsigned-varint 0.8.0",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2934,12 +2948,12 @@ name = "fendermint_actor_activity_tracker"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.10.1",
  "fil_actors_evm_shared",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex-literal 0.4.1",
  "log",
@@ -2955,12 +2969,12 @@ name = "fendermint_actor_chainmetadata"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.10.1",
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_ipld_amt",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "num-derive 0.3.3",
  "num-traits",
@@ -2973,13 +2987,13 @@ name = "fendermint_actor_eam"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.10.1",
  "fil_actor_eam",
  "fil_actors_evm_shared",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex-literal 0.4.1",
  "log",
@@ -2994,13 +3008,13 @@ name = "fendermint_actor_gas_market_eip1559"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.10.1",
  "fendermint_actors_api",
  "fil_actors_evm_shared",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex-literal 0.4.1",
  "log",
@@ -3015,15 +3029,15 @@ name = "fendermint_actors"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.10.1",
  "fendermint_actor_activity_tracker",
  "fendermint_actor_chainmetadata",
  "fendermint_actor_eam",
  "fendermint_actor_gas_market_eip1559",
  "fil_actor_bundler",
  "fil_actors_runtime",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "num-traits",
  "toml 0.8.19",
 ]
@@ -3033,12 +3047,12 @@ name = "fendermint_actors_api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.10.1",
  "fil_actors_evm_shared",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex-literal 0.4.1",
  "log",
@@ -3056,7 +3070,7 @@ dependencies = [
  "async-stm",
  "async-trait",
  "bytes",
- "cid",
+ "cid 0.10.1",
  "fendermint_abci",
  "fendermint_actor_gas_market_eip1559",
  "fendermint_actors_api",
@@ -3080,9 +3094,9 @@ dependencies = [
  "fendermint_vm_snapshot",
  "fendermint_vm_topdown",
  "fvm",
- "fvm_ipld_blockstore",
- "fvm_ipld_car",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_car 0.7.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex",
  "ipc-api",
@@ -3127,12 +3141,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "cid",
+ "cid 0.10.1",
  "clap 4.5.21",
  "fendermint_materializer",
  "fendermint_vm_actor_interface",
  "fendermint_vm_genesis",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex",
  "ipc-api",
@@ -3155,7 +3169,7 @@ dependencies = [
  "dirs",
  "fendermint_vm_encoding",
  "fendermint_vm_topdown",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "ipc-api",
  "ipc-observability",
@@ -3182,7 +3196,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
- "cid",
+ "cid 0.10.1",
  "ethers",
  "fendermint_actor_gas_market_eip1559",
  "fendermint_actors_api",
@@ -3195,8 +3209,8 @@ dependencies = [
  "fendermint_vm_interpreter",
  "fendermint_vm_message",
  "fvm",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex",
  "ipc-api",
@@ -3226,7 +3240,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "cid",
+ "cid 0.10.1",
  "clap 4.5.21",
  "erased-serde",
  "ethers",
@@ -3239,7 +3253,7 @@ dependencies = [
  "fendermint_vm_message",
  "fil_actors_evm_shared",
  "futures",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex",
  "jsonrpc-v2",
@@ -3328,10 +3342,10 @@ name = "fendermint_rocksdb"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.10.1",
  "fendermint_storage",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "num_cpus",
  "quickcheck",
  "rocksdb",
@@ -3348,14 +3362,14 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bytes",
- "cid",
+ "cid 0.10.1",
  "clap 4.5.21",
  "ethers",
  "fendermint_crypto",
  "fendermint_vm_actor_interface",
  "fendermint_vm_genesis",
  "fendermint_vm_message",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex",
  "lazy_static",
@@ -3382,7 +3396,7 @@ version = "0.1.0"
 name = "fendermint_storage"
 version = "0.1.0"
 dependencies = [
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "im",
  "quickcheck",
  "quickcheck_macros",
@@ -3396,10 +3410,10 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "arbtest",
- "cid",
+ "cid 0.10.1",
  "ethers",
  "fendermint_testing",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex",
  "ipc-api",
@@ -3425,14 +3439,14 @@ name = "fendermint_vm_actor_interface"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.10.1",
  "ethers",
  "ethers-core",
  "fendermint_crypto",
  "fendermint_vm_genesis",
  "fil_actors_evm_shared",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_ipld_hamt",
  "fvm_shared",
  "hex",
@@ -3455,7 +3469,7 @@ name = "fendermint_vm_core"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "cid",
+ "cid 0.10.1",
  "fnv",
  "fvm_shared",
  "lazy_static",
@@ -3470,7 +3484,7 @@ dependencies = [
 name = "fendermint_vm_encoding"
 version = "0.1.0"
 dependencies = [
- "cid",
+ "cid 0.10.1",
  "fvm_shared",
  "ipc-api",
  "num-traits",
@@ -3491,14 +3505,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "cid",
+ "cid 0.10.1",
  "fendermint_actor_eam",
  "fendermint_crypto",
  "fendermint_testing",
  "fendermint_vm_core",
  "fendermint_vm_encoding",
  "fendermint_vm_genesis",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex",
  "ipc-api",
@@ -3523,7 +3537,7 @@ dependencies = [
  "async-stm",
  "async-trait",
  "base64 0.21.7",
- "cid",
+ "cid 0.10.1",
  "ethers",
  "fendermint_actor_activity_tracker",
  "fendermint_actor_chainmetadata",
@@ -3548,9 +3562,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "fvm",
- "fvm_ipld_blockstore",
- "fvm_ipld_car",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_car 0.7.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex",
  "ipc-api",
@@ -3587,7 +3601,7 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "blake2b_simd",
- "cid",
+ "cid 0.10.1",
  "ethers",
  "ethers-core",
  "fendermint_crypto",
@@ -3595,7 +3609,7 @@ dependencies = [
  "fendermint_vm_actor_interface",
  "fendermint_vm_encoding",
  "fendermint_vm_message",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex",
  "ipc-api",
@@ -3615,7 +3629,7 @@ name = "fendermint_vm_resolver"
 version = "0.1.0"
 dependencies = [
  "async-stm",
- "cid",
+ "cid 0.10.1",
  "im",
  "ipc-api",
  "ipc_ipld_resolver",
@@ -3631,7 +3645,7 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "async-stm",
- "cid",
+ "cid 0.10.1",
  "dircpy",
  "fendermint_testing",
  "fendermint_vm_core",
@@ -3640,9 +3654,9 @@ dependencies = [
  "fendermint_vm_snapshot",
  "futures",
  "fvm",
- "fvm_ipld_blockstore",
- "fvm_ipld_car",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_car 0.7.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "im",
  "multihash 0.18.1",
@@ -3668,7 +3682,7 @@ dependencies = [
  "async-stm",
  "async-trait",
  "bytes",
- "cid",
+ "cid 0.10.1",
  "clap 4.5.21",
  "ethers",
  "fendermint_crypto",
@@ -3676,7 +3690,7 @@ dependencies = [
  "fendermint_tracing",
  "fendermint_vm_event",
  "fendermint_vm_genesis",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex",
  "im",
@@ -3734,28 +3748,28 @@ checksum = "e0b1448c65c9a054c640fc086e03b730919ca4feca697c34ed3bda9f16aa982f"
 dependencies = [
  "anyhow",
  "async-std",
- "cid",
+ "cid 0.10.1",
  "clap 4.5.21",
  "futures",
- "fvm_ipld_blockstore",
- "fvm_ipld_car",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_car 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
- "serde_ipld_dagcbor",
+ "serde_ipld_dagcbor 0.4.2",
  "serde_json",
 ]
 
 [[package]]
 name = "fil_actor_eam"
 version = "15.0.0-rc1"
-source = "git+https://github.com/filecoin-project/builtin-actors?tag=v15.0.0#831bf1b9fe281835409c39a8c454a68dd3200bbc"
+source = "git+https://github.com/cryptoAtwill/builtin-actors.git#10ad0be7992c822aa6464cc2c55e733b61251066"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.10.1",
  "fil_actors_evm_shared",
  "fil_actors_runtime",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex-literal 0.3.4",
  "log",
@@ -3769,10 +3783,10 @@ dependencies = [
 [[package]]
 name = "fil_actors_evm_shared"
 version = "15.0.0-rc1"
-source = "git+https://github.com/filecoin-project/builtin-actors?tag=v15.0.0#831bf1b9fe281835409c39a8c454a68dd3200bbc"
+source = "git+https://github.com/cryptoAtwill/builtin-actors.git#10ad0be7992c822aa6464cc2c55e733b61251066"
 dependencies = [
  "fil_actors_runtime",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex",
  "serde",
@@ -3782,18 +3796,18 @@ dependencies = [
 [[package]]
 name = "fil_actors_runtime"
 version = "15.0.0-rc1"
-source = "git+https://github.com/filecoin-project/builtin-actors?tag=v15.0.0#831bf1b9fe281835409c39a8c454a68dd3200bbc"
+source = "git+https://github.com/cryptoAtwill/builtin-actors.git#10ad0be7992c822aa6464cc2c55e733b61251066"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
  "blake2b_simd",
  "byteorder",
  "castaway",
- "cid",
+ "cid 0.10.1",
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_ipld_hamt",
  "fvm_sdk",
  "fvm_shared",
@@ -4002,7 +4016,7 @@ version = "8.0.0"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_sdk",
  "fvm_shared",
  "thiserror 1.0.69",
@@ -4218,19 +4232,18 @@ dependencies = [
 [[package]]
 name = "fvm"
 version = "4.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2bc545e9b8a6c4e08ec78c712469c542b3e9310ae3091c1b60ddb48e20862b"
+source = "git+https://github.com/cryptoAtwill/ref-fvm.git#c09d9a272fe5a8e4b5cf6b5982d33af7c9c4f164"
 dependencies = [
  "ambassador",
  "anyhow",
  "arbitrary",
- "cid",
+ "cid 0.10.1",
  "derive_more",
  "filecoin-proofs-api",
  "fvm-wasm-instrument",
  "fvm_ipld_amt",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_ipld_hamt",
  "fvm_shared",
  "lazy_static",
@@ -4266,14 +4279,13 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_amt"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fea333475130094f27ce67809aae3f69eb5247541d835950b7c5da733dbbb34"
+source = "git+https://github.com/cryptoAtwill/ref-fvm.git#c09d9a272fe5a8e4b5cf6b5982d33af7c9c4f164"
 dependencies = [
  "anyhow",
- "cid",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
- "itertools 0.11.0",
+ "cid 0.10.1",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "itertools 0.13.0",
  "once_cell",
  "serde",
  "thiserror 1.0.69",
@@ -4282,13 +4294,12 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_bitfield"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da94287cafa663c2e295fe45c4c9dbf5ab7b52f648568f9ae3823deaf9873a89"
+source = "git+https://github.com/cryptoAtwill/ref-fvm.git#c09d9a272fe5a8e4b5cf6b5982d33af7c9c4f164"
 dependencies = [
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "serde",
  "thiserror 1.0.69",
- "unsigned-varint 0.7.2",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -4298,7 +4309,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d064b957420f5ecc137a153baaa6c32e2eb19b674135317200b6f2537eabdbfd"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.10.1",
+ "multihash 0.18.1",
+]
+
+[[package]]
+name = "fvm_ipld_blockstore"
+version = "0.2.1"
+source = "git+https://github.com/cryptoAtwill/ref-fvm.git#c09d9a272fe5a8e4b5cf6b5982d33af7c9c4f164"
+dependencies = [
+ "anyhow",
+ "cid 0.10.1",
  "multihash 0.18.1",
 ]
 
@@ -4308,13 +4329,27 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6190f03442b67b21a3d4e115c4d4dd3468aed24e27ebb074218822c1b3df41ba"
 dependencies = [
- "cid",
+ "cid 0.10.1",
  "futures",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fvm_ipld_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "thiserror 1.0.69",
  "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "fvm_ipld_car"
+version = "0.7.1"
+source = "git+https://github.com/cryptoAtwill/ref-fvm.git#c09d9a272fe5a8e4b5cf6b5982d33af7c9c4f164"
+dependencies = [
+ "cid 0.10.1",
+ "futures",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "serde",
+ "thiserror 1.0.69",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -4324,11 +4359,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90608092e31d9a06236268c58f7c36668ab4b2a48afafe3a97e08f094ad7ae50"
 dependencies = [
  "anyhow",
- "cid",
- "fvm_ipld_blockstore",
+ "cid 0.10.1",
+ "fvm_ipld_blockstore 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "multihash 0.18.1",
  "serde",
- "serde_ipld_dagcbor",
+ "serde_ipld_dagcbor 0.4.2",
+ "serde_repr",
+ "serde_tuple",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "fvm_ipld_encoding"
+version = "0.4.0"
+source = "git+https://github.com/cryptoAtwill/ref-fvm.git#c09d9a272fe5a8e4b5cf6b5982d33af7c9c4f164"
+dependencies = [
+ "anyhow",
+ "cid 0.10.1",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "multihash 0.18.1",
+ "serde",
+ "serde_ipld_dagcbor 0.6.2",
  "serde_repr",
  "serde_tuple",
  "thiserror 1.0.69",
@@ -4337,15 +4388,14 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_hamt"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c900736087ff87cc51f669eee2f8e000c80717472242eb3f712aaa059ac3b3"
+source = "git+https://github.com/cryptoAtwill/ref-fvm.git#c09d9a272fe5a8e4b5cf6b5982d33af7c9c4f164"
 dependencies = [
  "anyhow",
  "byteorder",
- "cid",
+ "cid 0.10.1",
  "forest_hash_utils",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "libipld-core",
  "multihash 0.18.1",
  "once_cell",
@@ -4357,11 +4407,10 @@ dependencies = [
 [[package]]
 name = "fvm_sdk"
 version = "4.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2df521d41de41c34ac712720abdd6e29e68e3ed922554db70dbf8bc49a82b7"
+source = "git+https://github.com/cryptoAtwill/ref-fvm.git#c09d9a272fe5a8e4b5cf6b5982d33af7c9c4f164"
 dependencies = [
- "cid",
- "fvm_ipld_encoding",
+ "cid 0.10.1",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "lazy_static",
  "log",
@@ -4372,19 +4421,18 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "4.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7838d3fc1eeeb47c7a8e32bdc3b37e6d806ac261cb96e38f15b503df671648"
+source = "git+https://github.com/cryptoAtwill/ref-fvm.git#c09d9a272fe5a8e4b5cf6b5982d33af7c9c4f164"
 dependencies = [
  "anyhow",
  "arbitrary",
  "bitflags 2.6.0",
  "blake2b_simd",
  "bls-signatures 0.15.0",
- "cid",
+ "cid 0.10.1",
  "data-encoding",
  "data-encoding-macro",
  "filecoin-proofs-api",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "lazy_static",
  "libsecp256k1",
  "multihash 0.18.1",
@@ -5326,12 +5374,12 @@ name = "ipc-api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.10.1",
  "ethers",
  "fil_actors_runtime",
  "fnv",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_ipld_hamt",
  "fvm_shared",
  "integer-encoding",
@@ -5360,7 +5408,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bytes",
- "cid",
+ "cid 0.10.1",
  "clap 4.5.21",
  "clap_complete",
  "env_logger 0.10.2",
@@ -5368,7 +5416,7 @@ dependencies = [
  "ethers-contract",
  "fil_actors_runtime",
  "futures-util",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex",
  "ipc-api",
@@ -5423,13 +5471,13 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bytes",
- "cid",
+ "cid 0.10.1",
  "dirs",
  "ethers",
  "ethers-contract",
  "fil_actors_runtime",
  "futures-util",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_shared",
  "hex",
  "http",
@@ -5468,10 +5516,10 @@ name = "ipc-types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.10.1",
  "fvm_ipld_amt",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_ipld_hamt",
  "fvm_shared",
  "hex",
@@ -5507,7 +5555,7 @@ dependencies = [
  "quickcheck_macros",
  "rand",
  "serde",
- "serde_ipld_dagcbor",
+ "serde_ipld_dagcbor 0.4.2",
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
@@ -5534,10 +5582,10 @@ dependencies = [
  "base64 0.21.7",
  "blake2b_simd",
  "bloom",
- "cid",
+ "cid 0.10.1",
  "env_logger 0.10.2",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_ipld_hamt",
  "fvm_shared",
  "gcra",
@@ -5573,6 +5621,17 @@ dependencies = [
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
+]
+
+[[package]]
+name = "ipld-core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104718b1cc124d92a6d01ca9c9258a7df311405debb3408c445a36452f9bf8db"
+dependencies = [
+ "cid 0.11.1",
+ "serde",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -5639,6 +5698,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -5851,7 +5919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5acd707e8d8b092e967b2af978ed84709eaded82b75effe6cb6f6cc797ef8158"
 dependencies = [
  "anyhow",
- "cid",
+ "cid 0.10.1",
  "core2",
  "multibase",
  "multihash 0.18.1",
@@ -8877,9 +8945,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -8904,9 +8972,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8920,7 +8988,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e880e0b1f9c7a8db874642c1217f7e19b29e325f24ab9f0fcb11818adec7f01"
 dependencies = [
  "cbor4ii",
- "cid",
+ "cid 0.10.1",
+ "scopeguard",
+ "serde",
+]
+
+[[package]]
+name = "serde_ipld_dagcbor"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6851dcd54a7271dd9013195fdccbdaba70c8e71014364e396d4b938d0e67f324"
+dependencies = [
+ "cbor4ii",
+ "ipld-core",
  "scopeguard",
  "serde",
 ]
@@ -10587,6 +10667,10 @@ name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+dependencies = [
+ "futures-io",
+ "futures-util",
+]
 
 [[package]]
 name = "untrusted"
@@ -10679,12 +10763,12 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vm_api"
 version = "1.0.0"
-source = "git+https://github.com/filecoin-project/builtin-actors?tag=v15.0.0#831bf1b9fe281835409c39a8c454a68dd3200bbc"
+source = "git+https://github.com/cryptoAtwill/builtin-actors.git#10ad0be7992c822aa6464cc2c55e733b61251066"
 dependencies = [
  "anyhow",
- "cid",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "cid 0.10.1",
+ "fvm_ipld_blockstore 0.2.1 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
+ "fvm_ipld_encoding 0.4.0 (git+https://github.com/cryptoAtwill/ref-fvm.git)",
  "fvm_ipld_hamt",
  "fvm_shared",
  "num-derive 0.3.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ rand_chacha = "0.3"
 regex = "1"
 reqwest = { version = "0.11.13", features = ["json"] }
 sha2 = "0.10"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0.217", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1", features = ["raw_value"] }
 serde_yaml = { version = "0.9" }
@@ -196,18 +196,18 @@ openssl = { version = "0.10", features = ["vendored"] }
 # pull in crates as transitive dependencies that do not support Wasm architector. If this
 # happens, try removing "crypto" feature from fvm_shared dependency in contracts/binding/Cargo.toml
 # and run `cargo build`. Then add the "crypto" feature back and run `cargo build` again.
-fvm = { version = "4.4.0", features = [
+fvm = { git = "https://github.com/cryptoAtwill/ref-fvm.git", features = [
   "verify-signature",
 ], default-features = false } # no opencl feature or it fails on CI
-fvm_shared = { version = "4.4.0" }
-fvm_sdk = { version = "4.4.0" }
+fvm_shared = { git = "https://github.com/cryptoAtwill/ref-fvm.git" }
+fvm_sdk = { git = "https://github.com/cryptoAtwill/ref-fvm.git" }
 
 
-fvm_ipld_blockstore = "0.2.0"
-fvm_ipld_car = "0.7.1"
-fvm_ipld_encoding = "0.4.0"
-fvm_ipld_hamt = "0.9.0"
-fvm_ipld_amt = "0.6.2"
+fvm_ipld_blockstore = { git = "https://github.com/cryptoAtwill/ref-fvm.git" }
+fvm_ipld_car = { git = "https://github.com/cryptoAtwill/ref-fvm.git" }
+fvm_ipld_encoding = { git = "https://github.com/cryptoAtwill/ref-fvm.git" }
+fvm_ipld_hamt = { git = "https://github.com/cryptoAtwill/ref-fvm.git" }
+fvm_ipld_amt = { git = "https://github.com/cryptoAtwill/ref-fvm.git" }
 
 # Local FVM debugging
 # fvm = { path = "../ref-fvm/fvm", default-features = false }
@@ -221,9 +221,9 @@ fvm_ipld_amt = "0.6.2"
 # to cut down the time it takes to compile everything. However, some projects have a "shared" part,
 # and this copy-paste is clunky, so at least for those that have it, we should use it.
 # Keep the version here in sync with the Makefile!
-fil_actors_evm_shared = { git = "https://github.com/filecoin-project/builtin-actors", tag = "v15.0.0" }
-fil_actor_eam = { git = "https://github.com/filecoin-project/builtin-actors", tag = "v15.0.0" }
-fil_actors_runtime = { git = "https://github.com/filecoin-project/builtin-actors", tag = "v15.0.0" }
+fil_actors_evm_shared = { git = "https://github.com/cryptoAtwill/builtin-actors.git" }
+fil_actor_eam = { git = "https://github.com/cryptoAtwill/builtin-actors.git" }
+fil_actors_runtime = { git = "https://github.com/cryptoAtwill/builtin-actors.git" }
 
 fendermint_actor_eam = { path = "./fendermint/actors/eam" }
 fendermint_actor_activity_tracker = { path = "./fendermint/actors/activity-tracker" }


### PR DESCRIPTION
This PR attends to integrate a forked `ref-fvm` into `ipc`. However there are some challenges as mentioned [here](https://github.com/consensus-shipyard/ipc/issues/1278#issuecomment-2655757996). 

But this PR finds a sweet spot by just importing the required actors from `builtin-actors` and removed the rest of the crates. This makes the compiler happy and everything compiles.

Please checkout:
- https://github.com/cryptoAtwill/ref-fvm
- https://github.com/cryptoAtwill/builtin-actors