### PR TITLE
feat: support dynamic Fendermint config loading in Materializer

### DIFF
--- a/fendermint/testing/materializer/src/arb.rs
+++ b/fendermint/testing/materializer/src/arb.rs
@@ -289,6 +289,7 @@ fn gen_subnets(
                 } else {
                     Some(choose_one(g, parent_nodes))
                 },
+                fendermint_additional_config: None,
             };
             let id = NodeId::arbitrary(g);
             node_ids.push(id.clone());

--- a/fendermint/testing/materializer/src/docker/mod.rs
+++ b/fendermint/testing/materializer/src/docker/mod.rs
@@ -767,8 +767,8 @@ impl Materializer<DockerMaterials> for DockerMaterializer {
         's: 'a,
     {
         // Overwrite the env file which has seed addresses, then start the node (unless it's already running).
-        node.start(seed_nodes).await?;
-        node.wait_for_started(*STARTUP_TIMEOUT).await?;
+        node.start_all_containers(seed_nodes).await?;
+        node.wait_for_apis_to_start(*STARTUP_TIMEOUT).await?;
         // Trying to avoid `Tendermint RPC error: server returned malformatted JSON (no 'result' or 'error')` on first subnet creation attempt.
         tokio::time::sleep(Duration::from_secs(5)).await;
         Ok(())

--- a/fendermint/testing/materializer/src/docker/node.rs
+++ b/fendermint/testing/materializer/src/docker/node.rs
@@ -9,6 +9,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+use tokio::try_join;
+
 use anyhow::{anyhow, bail, Context};
 use bollard::Docker;
 use ethers::{providers::Middleware, types::H160};
@@ -400,15 +402,19 @@ impl DockerNode {
         let fendermint = match fendermint {
             Some(c) => c,
             None => {
-                let creator = make_runner(
-                    FENDERMINT_IMAGE,
-                    volumes(vec![
-                        (keys_dir.clone(), "/fendermint/keys"),
-                        (fendermint_dir.join("data"), "/fendermint/data"),
-                        (fendermint_dir.join("logs"), "/fendermint/logs"),
-                        (fendermint_dir.join("snapshots"), "/fendermint/snapshots"),
-                    ]),
-                );
+                let mut volume_mappings = vec![
+                    (keys_dir.clone(), "/fendermint/keys"),
+                    (fendermint_dir.join("data"), "/fendermint/data"),
+                    (fendermint_dir.join("logs"), "/fendermint/logs"),
+                    (fendermint_dir.join("snapshots"), "/fendermint/snapshots"),
+                ];
+
+                if let Some(ref additional_config) = node_config.fendermint_additional_config {
+                    volume_mappings
+                        .push((additional_config.clone(), "/fendermint/config/dev.toml"));
+                }
+
+                let creator = make_runner(FENDERMINT_IMAGE, volumes(volume_mappings));
 
                 creator
                     .create(
@@ -481,7 +487,7 @@ impl DockerNode {
         })
     }
 
-    pub async fn start(&self, seed_nodes: &[&Self]) -> anyhow::Result<()> {
+    pub async fn start_all_containers(&self, seed_nodes: &[&Self]) -> anyhow::Result<()> {
         let cometbft_seeds = collect_seeds(seed_nodes, |n| {
             let host = &n.cometbft.hostname();
             let id = n.cometbft_node_id()?;
@@ -501,18 +507,20 @@ impl DockerNode {
 
         export_env(self.path.join(DYNAMIC_ENV), &env)?;
 
-        // Start all three containers.
-        self.fendermint.start().await?;
-        self.cometbft.start().await?;
-        if let Some(ref ethapi) = self.ethapi {
-            ethapi.start().await?;
-        }
+        // Start all three containers at the same time.
+        try_join!(self.fendermint.start(), self.cometbft.start(), async {
+            if let Some(ref ethapi) = self.ethapi {
+                ethapi.start().await
+            } else {
+                Ok(())
+            }
+        })?;
 
         Ok(())
     }
 
     /// Allow time for things to consolidate and APIs to start.
-    pub async fn wait_for_started(&self, timeout: Duration) -> anyhow::Result<bool> {
+    pub async fn wait_for_apis_to_start(&self, timeout: Duration) -> anyhow::Result<bool> {
         let start = Instant::now();
 
         loop {

--- a/fendermint/testing/materializer/src/manifest.rs
+++ b/fendermint/testing/materializer/src/manifest.rs
@@ -7,7 +7,12 @@ use anyhow::{bail, Context};
 use fvm_shared::econ::TokenAmount;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::{collections::BTreeMap, path::Path, path::PathBuf};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    fmt::Debug,
+    path::{Path, PathBuf},
+};
 use url::Url;
 
 use fs_err as fs;
@@ -218,7 +223,7 @@ impl Subnet {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Node {
     /// Indicate whether this is a validator node or a full node.
     pub mode: NodeMode,
@@ -253,6 +258,27 @@ impl Node {
                 *config_path = base.join(&*config_path);
             }
         }
+    }
+}
+
+/// Custom Debug implementation for the `Node` struct.
+///
+/// This implementation omits the `fendermint_additional_config` field when it is `None`,
+/// ensuring that the debug output matches the expected format used in
+/// `fendermint/testing/src/golden.rs`'s `test_txt` function.
+impl Debug for Node {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut ds = f.debug_struct("Node");
+        ds.field("mode", &self.mode)
+            .field("ethapi", &self.ethapi)
+            .field("seed_nodes", &self.seed_nodes)
+            .field("parent_node", &self.parent_node);
+
+        if let Some(ref config) = self.fendermint_additional_config {
+            ds.field("fendermint_additional_config", config);
+        }
+
+        ds.finish()
     }
 }
 

--- a/fendermint/testing/materializer/src/manifest.rs
+++ b/fendermint/testing/materializer/src/manifest.rs
@@ -53,7 +53,7 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    /// Read a manifest from file and resolve any relative extra_config paths.
+    /// Read a manifest from file and resolve any relative fendermint_additional_config paths.
     pub fn from_file(path: &Path) -> anyhow::Result<Self> {
         let ext = path
             .extension()

--- a/fendermint/testing/materializer/src/materializer.rs
+++ b/fendermint/testing/materializer/src/materializer.rs
@@ -5,6 +5,7 @@ use either::Either;
 use ethers::types::H160;
 use fvm_shared::{chainid::ChainID, econ::TokenAmount};
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use url::Url;
 
 use fendermint_vm_genesis::Collateral;
@@ -222,6 +223,8 @@ pub struct NodeConfig<'a, M: Materials> {
     pub env: &'a EnvMap,
     /// Number of nodes to be expected in the subnet, including this node, or 0 if unknown.
     pub peer_count: usize,
+    /// Additional configuration for Fendermint
+    pub fendermint_additional_config: Option<PathBuf>,
 }
 
 /// Options regarding relayer configuration

--- a/fendermint/testing/materializer/src/materializer.rs
+++ b/fendermint/testing/materializer/src/materializer.rs
@@ -5,13 +5,12 @@ use either::Either;
 use ethers::types::H160;
 use fvm_shared::{chainid::ChainID, econ::TokenAmount};
 use std::collections::BTreeMap;
-use std::path::PathBuf;
 use url::Url;
 
 use fendermint_vm_genesis::Collateral;
 
 use crate::{
-    manifest::{Balance, CheckpointConfig, EnvMap},
+    manifest::{Balance, CheckpointConfig, EnvMap, FendermintConfig},
     materials::Materials,
     AccountName, NodeName, RelayerName, ResourceHash, SubnetName, TestnetName,
 };
@@ -224,7 +223,7 @@ pub struct NodeConfig<'a, M: Materials> {
     /// Number of nodes to be expected in the subnet, including this node, or 0 if unknown.
     pub peer_count: usize,
     /// Additional configuration for Fendermint
-    pub fendermint_additional_config: Option<PathBuf>,
+    pub fendermint_additional_config: Option<&'a FendermintConfig>,
 }
 
 /// Options regarding relayer configuration

--- a/fendermint/testing/materializer/src/testnet.rs
+++ b/fendermint/testing/materializer/src/testnet.rs
@@ -333,6 +333,7 @@ where
             ethapi: node.ethapi,
             env,
             peer_count,
+            fendermint_additional_config: node.fendermint_additional_config.clone(),
         };
 
         let node = m

--- a/fendermint/testing/materializer/src/testnet.rs
+++ b/fendermint/testing/materializer/src/testnet.rs
@@ -333,7 +333,7 @@ where
             ethapi: node.ethapi,
             env,
             peer_count,
-            fendermint_additional_config: node.fendermint_additional_config.clone(),
+            fendermint_additional_config: node.loaded_fendermint_config(),
         };
 
         let node = m

--- a/fendermint/testing/materializer/tests/manifests/layer2.yaml
+++ b/fendermint/testing/materializer/tests/manifests/layer2.yaml
@@ -7,12 +7,12 @@ rootnet:
   type: New
   # Balances and collateral are in atto
   validators:
-    alice: '100'
+    alice: "100"
   balances:
     # 100FIL is 100_000_000_000_000_000_000
-    alice: '100000000000000000000'
-    bob: '200000000000000000000'
-    charlie: '300000000000000000000'
+    alice: "100000000000000000000"
+    bob: "200000000000000000000"
+    charlie: "300000000000000000000"
   env:
     CMT_CONSENSUS_TIMEOUT_COMMIT: 2s
     FM_LOG_LEVEL: info,fendermint=debug
@@ -24,18 +24,19 @@ rootnet:
         validator: alice
       seed_nodes: []
       ethapi: true
+      fendermint_additional_config: ./test.toml
 
 subnets:
   england:
     creator: bob
     # Minimum collateral is 1 nanoFIL, which is 1_000_000_000 atto
     validators:
-      charlie: '1000000000'
-      bob:     '2000000000'
+      charlie: "1000000000"
+      bob: "2000000000"
     # Submitting a signature for a checkpoint says it needs 0.059552996FIL
     balances:
-      bob:     '20000000000000000000'
-      charlie: '30000000000000000000'
+      bob: "20000000000000000000"
+      charlie: "30000000000000000000"
     bottom_up_checkpoint:
       period: 100
     env:
@@ -62,6 +63,7 @@ subnets:
         parent_node: brussels
         seed_nodes: []
         ethapi: true
+        fendermint_additional_config: ./test.toml
 
       manchester:
         mode:
@@ -70,3 +72,4 @@ subnets:
         parent_node: brussels
         seed_nodes: [london]
         ethapi: true
+        fendermint_additional_config: ./test.toml

--- a/fendermint/testing/materializer/tests/manifests/test.toml
+++ b/fendermint/testing/materializer/tests/manifests/test.toml
@@ -1,0 +1,6 @@
+[tracing.file]
+enabled = true
+level = "info"
+directory = "/fendermint/logs"
+max_log_files = 2
+rotation = "daily"


### PR DESCRIPTION
Support dynamically loading the Fendermint configuration in Materialier without rebuilding the image. This will significantly improve the testing feedback loop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/consensus-shipyard/ipc/1286)
<!-- Reviewable:end -->
