### PR TITLE
docs: add node.js as a prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ On Linux (links and instructions for Ubuntu):
 - Install [rust](https://www.rust-lang.org/tools/install).
 - Install cargo-make: `cargo install --force cargo-make`.
 - Install [docker](https://docs.docker.com/engine/install/ubuntu/).
+- Install [node.js](https://nodejs.org/en/download).
 - Install [foundry](https://book.getfoundry.sh/getting-started/installation).
 
 On MacOS:
@@ -24,6 +25,7 @@ On MacOS:
 - Install [rust](https://www.rust-lang.org/tools/install) (if you have homebrew installed rust, you may need to uninstall that if you get errors in the build)
 - Install Cargo make: cargo install --force cargo-make
 - Install [docker](https://docs.docker.com/desktop/install/mac-install/)
+- Install [node.js](https://nodejs.org/en/download).
 - Install [foundry](https://book.getfoundry.sh/getting-started/installation)
 
 ## Building

--- a/docs-gitbook/quickstarts/deploy-a-subnet.md
+++ b/docs-gitbook/quickstarts/deploy-a-subnet.md
@@ -19,6 +19,7 @@ Several steps in this guide involve running long-lived processes. In each of the
 * Install Rust. See [instructions](https://www.rust-lang.org/tools/install).
 * Install cargo-make: `cargo install --force cargo-make`.
 * Install Docker. See [instructions](https://docs.docker.com/engine/install/ubuntu/).
+* Install Node.js. See [instructions](https://nodejs.org/en/download).
 * Install Foundry. See [instructions](https://book.getfoundry.sh/getting-started/installation).
 
 Also install the following dependencies ([details](https://lotus.filecoin.io/lotus/install/prerequisites/#supported-platforms))
@@ -37,6 +38,7 @@ sudo apt update && sudo apt install build-essential libssl-dev mesa-opencl-icd o
 * Install Rust. See [instructions](https://www.rust-lang.org/tools/install). (if you have homebrew installed rust, you may need to uninstall that if you get errors in the build)
 * Install Cargo make: `cargo install --force cargo-make`
 * Install docker. See [instructions](https://docs.docker.com/desktop/install/mac-install/).
+* Install Node.js. See [instructions](https://nodejs.org/en/download).
 * Install foundry. See [instructions](https://book.getfoundry.sh/getting-started/installation).
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
Hey! We've noticed Node/npm isn't mentioned as a dependency of the project, and it's used to install pnpm and manage contract dependencies (#1020). This adds links for installation to the README and the quickstart gitbook page.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/consensus-shipyard/ipc/1292)
<!-- Reviewable:end -->
