### PR TITLE
fix(node): remove hardcoding in compile abi

### DIFF
--- a/contracts/ops/compile-abi.sh
+++ b/contracts/ops/compile-abi.sh
@@ -14,4 +14,4 @@ OUTPUT=$1
 echo -e "\033[0;36mRunning a recursive submodule update to ensure build reproducibility with CI. Local uncommitted submodule changes will be overridden.\033[0m"
 git submodule update --init --recursive
 echo "[*] Compiling contracts and output core contracts ABI in $OUTPUT" 
-forge build -C ./src/ --lib-paths lib/ --via-ir --sizes --skip test --out=$OUTPUT
+forge build -C ./src/ --lib-paths lib/ --sizes --skip test --out=$OUTPUT


### PR DESCRIPTION
Remove `--via-ir` hardcoding in compile contract abi, so that one can control this parameter in `hardhat.config.ts`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/consensus-shipyard/ipc/1314)
<!-- Reviewable:end -->
