### PR TITLE
fix: use `rust-toolchain` defined channel for `wasm` compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "num-traits",
  "toml 0.8.20",
  "tracing",
+ "which 7.0.2",
 ]
 
 [[package]]
@@ -2600,6 +2601,12 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
@@ -8351,7 +8358,7 @@ dependencies = [
  "prost-types 0.9.0",
  "regex",
  "tempfile",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -11786,6 +11793,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12154,6 +12173,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/fendermint/actors-custom-car/Cargo.toml
+++ b/fendermint/actors-custom-car/Cargo.toml
@@ -28,3 +28,4 @@ cargo_metadata = "0.19"
 ignore = "0.4"
 tracing = "0.1"
 build-rs-utils = { path = "../../build-rs-utils" }
+which = "7"

--- a/fendermint/actors-custom-car/build.rs
+++ b/fendermint/actors-custom-car/build.rs
@@ -227,7 +227,7 @@ fn build_all_wasm_blobs(
     // Cargo build command for all test_actors at once.
     let mut cmd = Command::new(rustup);
     cmd.arg("run")
-        .arg(&channel)
+        .arg(channel)
         .arg("cargo")
         .arg("build")
         .current_dir(cwd)
@@ -403,7 +403,7 @@ fn main() -> Result<()> {
 
     build_all_wasm_blobs(
         &channel,
-        &target,
+        target,
         &actors,
         &workspace_dir,
         &actors_manifest_path,

--- a/fendermint/actors-custom-car/build.rs
+++ b/fendermint/actors-custom-car/build.rs
@@ -29,8 +29,8 @@ use toml::Value;
 use tracing::info;
 
 fn parse_dependencies_of_umbrella_crate(manifest_path: &Path) -> Result<Vec<(String, PathBuf)>> {
-    let manifest = dbg!(fs::read_to_string(manifest_path))?;
-    let document = dbg!(manifest.parse::<Value>()?);
+    let manifest = fs::read_to_string(manifest_path)?;
+    let document = manifest.parse::<Value>()?;
 
     let dependencies = document
         .get("target")
@@ -202,20 +202,49 @@ fn package_rerun_if_changed(package: &DeduplicatePackage) {
 }
 
 fn build_all_wasm_blobs(
+    workspace_dir: &Path,
     actors: &[Actor],
+    cwd: &Path,
     manifest_path: &Path,
-    cargo: &Path,
     out_dir: &Path,
 ) -> Result<Vec<Actor>> {
+    echo!(
+        "actors-custom-car",
+        purple,
+        "Building {} actors",
+        actors.len()
+    );
+
     let package_args = actors
         .iter()
         .map(|actor| format!("-p={}", actor.package_name));
+    // one cannot specify the file, so parse it and use the toolchain explicity
+    let toolchain_file_path = workspace_dir.join("rust-toolchain.toml");
+    let toolchain_file = fs_err::read_to_string(&toolchain_file_path)?;
+    let toolchain: toml::Table = toml::from_str(&toolchain_file)?;
+    let toolchain = toolchain
+        .get("toolchain")
+        .ok_or_else(|| eyre!("Missing toolchain in {}", toolchain_file_path.display()))?;
+    let channel: &toml::Value = toolchain
+        .get("channel")
+        .ok_or_else(|| eyre!("Missing channel in {}", toolchain_file_path.display()))?;
+    let channel: String = channel.clone().try_into()?;
+
+    let target = "wasm32-unknown-unknown";
+    echo!("actors-custom-car", purple, "Target: {channel} {target}");
+
+    let rustup = which::which("rustup")?;
 
     // Cargo build command for all test_actors at once.
-    let mut cmd = Command::new(cargo);
-    cmd.arg("build")
+    let mut cmd = Command::new(rustup);
+    cmd.arg("run")
+        .arg(channel)
+        .arg("cargo")
+        .arg("build")
+        .current_dir(cwd)
         .args(package_args)
-        .arg("--target=wasm32-unknown-unknown")
+        .arg("--target")
+        .arg(target)
         .arg("--profile=wasm")
         .arg("--features=fil-actor")
         .arg(format!("--manifest-path={}", manifest_path.display()))
@@ -228,6 +257,13 @@ fn build_all_wasm_blobs(
         // our own `RUSTFLAGS` and thus, we need to remove this. Otherwise cargo favors this
         // env variable.
         .env_remove("CARGO_ENCODED_RUSTFLAGS");
+
+    echo!(
+        "actors-custom-car",
+        purple,
+        "Executing WASM compilation command: {:?}",
+        &cmd
+    );
 
     // Launch the command.
     let mut child = cmd.spawn()?;
@@ -258,6 +294,8 @@ fn build_all_wasm_blobs(
 }
 
 /// Use the `Cargo.lock` file to find the workspace manifest and extract dependency information
+///
+/// Requires `rustup` to be installed.
 fn print_cargo_rerun_if_dependency_instructions(
     cargo_manifest: &Path,
     out_dir: &Path,
@@ -320,10 +358,6 @@ fn print_cargo_rerun_if_dependency_instructions(
 }
 
 fn main() -> Result<()> {
-    // Cargo executable location.
-    let cargo = std::env::var_os("CARGO").ok_or_eyre("no CARGO env var")?;
-    let cargo = Path::new(&cargo);
-
     // Rust provided out dir, used as intermediate place to store a) wasm target dir b) their outputs
     // the final `.car` file will sit under `dst`.
     let out_dir = std::env::var_os("OUT_DIR")
@@ -332,14 +366,15 @@ fn main() -> Result<()> {
         .map(|p| p.join("bundle"))
         .ok_or_eyre("Must have OUT_DIR defined, this is only ever run from build.rs")?;
 
-    let manifest_path_dir =
+    let package_dir =
         std::env::var_os("CARGO_MANIFEST_DIR").ok_or_eyre("CARGO_MANIFEST_DIR unset")?;
-    let manifest_path_dir = Path::new(&manifest_path_dir);
-    let actors_manifest_path = manifest_path_dir
+    let package_dir = Path::new(&package_dir);
+    let actors_manifest_path = package_dir
         .parent()
         .unwrap()
         .join("actors")
         .join("Cargo.toml");
+    let workspace_dir = fs_err::canonicalize(package_dir.parent().unwrap().parent().unwrap())?;
 
     let wasm_blob_dir = out_dir.join("wasm32-unknown-unknown").join("wasm");
 
@@ -352,7 +387,13 @@ fn main() -> Result<()> {
 
     print_cargo_rerun_if_dependency_instructions(&actors_manifest_path, &out_dir)?;
 
-    build_all_wasm_blobs(&actors, &actors_manifest_path, cargo, &out_dir)?;
+    build_all_wasm_blobs(
+        &workspace_dir,
+        &actors,
+        &workspace_dir,
+        &actors_manifest_path,
+        &out_dir,
+    )?;
 
     let bundle_car_dest_dir = actors_manifest_path.parent().unwrap().join("output");
 


### PR DESCRIPTION
Currently we use `cargo` as provided by the build env, but this doesn't seem to be the same version as previously, so we now do 2 things:

* use the version as prefix for out
* ensure we use the `channel = ` as defined in `rust-toolchain.toml` (assumes it exists)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/consensus-shipyard/ipc/1322)
<!-- Reviewable:end -->
