### PR TITLE
fix: add ExcessivelySafeCall

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "demos/axelar-token/lib/forge-std"]
 	path = demos/axelar-token/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "contracts/lib/ExcessivelySafeCall"]
+	path = contracts/lib/ExcessivelySafeCall
+	url = https://github.com/nomad-xyz/ExcessivelySafeCall

--- a/contracts/test/invariants/SubnetRegistryInvariants.t.sol
+++ b/contracts/test/invariants/SubnetRegistryInvariants.t.sol
@@ -99,7 +99,7 @@ contract SubnetRegistryInvariants is StdInvariant, Test, TestRegistry, Integrati
             address owner = owners[i];
             uint64 nonce = registryHandler.getUserLastNonce(owner);
 
-            assertNotEq(nonce, 0);
+            require(nonce != 0, "nonce should not be 0");
             assertEq(
                 registryHandler.getSubnetDeployedBy(owner),
                 registryHandler.getSubnetDeployedWithNonce(owner, nonce)

--- a/demos/axelar-token/foundry.toml
+++ b/demos/axelar-token/foundry.toml
@@ -4,6 +4,7 @@ out = "out"
 libs = ["node_modules", "lib"]
 fs_permissions = [{ access = "read-write", path = "./out"}]
 remappings = [
-    "@consensus-shipyard/=node_modules/@consensus-shipyard/"
+    "@consensus-shipyard/=node_modules/@consensus-shipyard/",
+    "ExcessivelySafeCall/=node_modules/@consensus-shipyard/ipc-contracts/lib/ExcessivelySafeCall/src/",
 ]
 allow_paths = ["../../contracts"]

--- a/demos/linked-token/foundry.toml
+++ b/demos/linked-token/foundry.toml
@@ -7,4 +7,5 @@ remappings = [
     "@ipc/=node_modules/@consensus-shipyard/ipc-contracts/",
     ## this murky remapping is only needed transitively for testing; we should try to get rid of this.
     "murky/=node_modules/@consensus-shipyard/ipc-contracts/lib/murky/src/",
+    "ExcessivelySafeCall/=node_modules/@consensus-shipyard/ipc-contracts/lib/ExcessivelySafeCall/src/",
 ]


### PR DESCRIPTION
This PR adds `ExcessivelySafeCall` to limit the amount of bytes that will be loaded to memory. The gas however is forwarded fully.