### PR TITLE
refactor: keystore sanity

### DIFF
--- a/fendermint/testing/materializer/src/docker/mod.rs
+++ b/fendermint/testing/materializer/src/docker/mod.rs
@@ -318,6 +318,7 @@ impl DockerMaterializer {
         let mut config = if !file_name.exists() {
             IpcCliConfig {
                 keystore_path: Some("~/.ipc".to_string()),
+                password: None,
                 subnets: Default::default(),
             }
         } else {

--- a/fendermint/testing/materializer/src/docker/mod.rs
+++ b/fendermint/testing/materializer/src/docker/mod.rs
@@ -531,9 +531,9 @@ impl DockerMaterializer {
 
     /// Run some kind of command with the `ipc-cli` that needs to be executed as
     /// transaction by an account on a given subnet.
-    async fn ipc_cli_run_cmd<'a>(
+    async fn ipc_cli_run_cmd(
         &mut self,
-        submit_config: &SubmitConfig<'a, DockerMaterials>,
+        submit_config: &SubmitConfig<'_, DockerMaterials>,
         account: &DefaultAccount,
         cmd: String,
     ) -> anyhow::Result<Vec<String>> {

--- a/fendermint/testing/materializer/src/docker/node.rs
+++ b/fendermint/testing/materializer/src/docker/node.rs
@@ -85,13 +85,13 @@ impl Display for DockerNode {
 }
 
 impl DockerNode {
-    pub async fn get_or_create<'a>(
+    pub async fn get_or_create(
         root: impl AsRef<Path>,
         docker: Docker,
         dropper: DropChute,
         drop_policy: &DropPolicy,
         node_name: &NodeName,
-        node_config: &NodeConfig<'a, DockerMaterials>,
+        node_config: &NodeConfig<'_, DockerMaterials>,
         port_range: DockerPortRange,
     ) -> anyhow::Result<Self> {
         let fendermint_name = container_name(node_name, "fendermint");

--- a/fendermint/testing/materializer/src/docker/relayer.rs
+++ b/fendermint/testing/materializer/src/docker/relayer.rs
@@ -35,7 +35,7 @@ impl DockerRelayer {
     /// This assumes that the submitter and the involved parent and child
     /// subnets have been added to the `ipc-cli` config.
     #[allow(clippy::too_many_arguments)]
-    pub async fn get_or_create<'a>(
+    pub async fn get_or_create(
         root: impl AsRef<Path>,
         docker: Docker,
         dropper: DropChute,

--- a/ipc/provider/src/config/mod.rs
+++ b/ipc/provider/src/config/mod.rs
@@ -56,6 +56,11 @@ registry_addr = "0x0b4e239FF21b40120cDa817fba77bD1B366c1bcD"
 pub struct Config {
     /// Directory of the keystore that wants to be made available by the provider.
     pub keystore_path: Option<String>,
+
+    /// The password used
+    // TODO wrap in a type that uses `zeroize` on `Drop`, only used for on-disk keystores.
+    pub password: Option<String>,
+
     #[serde(deserialize_with = "deserialize_subnets_from_vec", default)]
     #[serde(serialize_with = "serialize_subnets_to_str")]
     pub subnets: HashMap<SubnetID, Subnet>,
@@ -66,6 +71,7 @@ impl Config {
     pub fn new() -> Self {
         Config {
             keystore_path: None,
+            password: None,
             subnets: Default::default(),
         }
     }

--- a/ipc/provider/src/config/serialize.rs
+++ b/ipc/provider/src/config/serialize.rs
@@ -121,6 +121,7 @@ mod tests {
     fn test_serialization() {
         let mut config = Config {
             keystore_path: Some(String::from("~/.ipc")),
+            password: None,
             subnets: Default::default(),
         };
 

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -893,7 +893,9 @@ pub fn new_evm_keystore_from_path(
     repo_str: &str,
     password: Option<String>,
 ) -> anyhow::Result<PlainKeyStore<EthKeyAddress>> {
-    let name = password.map(|_| ipc_wallet::ENCRYPTED_KEYSTORE_NAME).unwrap_or_else(|| ipc_wallet::PLAIN_JSON_KEYSTORE_NAME);
+    let name = password
+        .map(|_| ipc_wallet::ENCRYPTED_KEYSTORE_NAME)
+        .unwrap_or_else(|| ipc_wallet::PLAIN_KEYSTORE_NAME);
     let repo = Path::new(&repo_str).join(name);
     let repo = expand_tilde(repo);
     let keystore_config = if let Some(pass) = password {
@@ -904,7 +906,10 @@ pub fn new_evm_keystore_from_path(
     KeyStore::new(keystore_config).map_err(|e| anyhow!("Failed to create evm keystore: {}", e))
 }
 
-pub fn new_fvm_keystore_from_path(repo_str: &str, password: Option<&str>) -> anyhow::Result<KeyStore> {
+pub fn new_fvm_keystore_from_path(
+    repo_str: &str,
+    password: Option<&str>,
+) -> anyhow::Result<KeyStore> {
     let repo = Path::new(&repo_str);
     let repo = expand_tilde(repo);
     let keystore_config = if let Some(password) = password {

--- a/ipc/wallet/Cargo.toml
+++ b/ipc/wallet/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license-file.workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 ahash = "0.8"

--- a/ipc/wallet/src/evm/persistent.rs
+++ b/ipc/wallet/src/evm/persistent.rs
@@ -88,6 +88,7 @@ impl<T: Clone + Eq + Hash + TryFrom<KeyInfo> + Default + ToString> KeyStore
 }
 
 impl<T: Clone + Eq + Hash + TryFrom<KeyInfo> + Default + ToString> PersistentKeyStore<T> {
+    // TODO handle encryption
     pub fn new(path: PathBuf) -> Result<Self> {
         if let Some(p) = path.parent() {
             if !p.exists() {

--- a/ipc/wallet/src/fvm/keystore/encryption_overlay.rs
+++ b/ipc/wallet/src/fvm/keystore/encryption_overlay.rs
@@ -1,0 +1,92 @@
+use super::*;
+
+use anyhow::{bail, Result};
+
+/// Encrypted overlay for the `KeyStore` in [`ENCRYPTED_KEYSTORE_LOCATION`]
+///
+/// Uses `Argon2id` as hash key derivation
+/// and algorithm `XSalsa20Poly1305` authenticated encryption
+/// and CBOR as data format encoding.
+#[derive(Clone, PartialEq, Debug, Eq)]
+pub(crate) struct EncryptionOverlay {
+    pub(crate) salt: SaltByteArray,
+    // pre-hashed key
+    pub(crate) encryption_key: Vec<u8>,
+}
+
+impl EncryptionOverlay {
+    /// Derive the actual encryption key utilizing a random salt value
+    pub fn with_random_salt(passphrase: &str) -> Result<Self> {
+        Self::derive_key(passphrase.as_ref(), None)
+    }
+
+    /// Derive the actual encryption key utlizing the provided "salt" value
+    pub fn from_salt(passphrase: impl AsRef<str>, salt: impl Into<SaltByteArray>) -> Result<Self> {
+        Self::derive_key(passphrase.as_ref(), Some(salt.into()))
+    }
+
+    fn derive_key(passphrase: &str, prev_salt: Option<SaltByteArray>) -> Result<Self> {
+        let salt = match prev_salt {
+            Some(prev_salt) => prev_salt,
+            None => {
+                let mut salt = [0; RECOMMENDED_SALT_LEN];
+                OsRng.fill_bytes(&mut salt);
+                salt
+            }
+        };
+
+        let mut param_builder = ParamsBuilder::new();
+        // #define crypto_pwhash_argon2id_MEMLIMIT_INTERACTIVE 67108864U
+        // see <https://github.com/jedisct1/libsodium/blob/089f850608737f9d969157092988cb274fe7f8d4/src/libsodium/include/sodium/crypto_pwhash_argon2id.h#L70>
+        const CRYPTO_PWHASH_ARGON2ID_MEMLIMIT_INTERACTIVE: u32 = 67108864;
+        // #define crypto_pwhash_argon2id_OPSLIMIT_INTERACTIVE 2U
+        // see <https://github.com/jedisct1/libsodium/blob/089f850608737f9d969157092988cb274fe7f8d4/src/libsodium/include/sodium/crypto_pwhash_argon2id.h#L66>
+        const CRYPTO_PWHASH_ARGON2ID_OPSLIMIT_INTERACTIVE: u32 = 2;
+        param_builder
+            .m_cost(CRYPTO_PWHASH_ARGON2ID_MEMLIMIT_INTERACTIVE / 1024)
+            .t_cost(CRYPTO_PWHASH_ARGON2ID_OPSLIMIT_INTERACTIVE);
+        // https://docs.rs/sodiumoxide/latest/sodiumoxide/crypto/secretbox/xsalsa20poly1305/constant.KEYBYTES.html
+        // KEYBYTES = 0x20
+        // param_builder.output_len(32)?;
+        let hasher = Argon2::new(
+            argon2::Algorithm::Argon2id,
+            argon2::Version::V0x13,
+            param_builder.build().map_err(map_err_to_anyhow)?,
+        );
+        let salt_string = SaltString::encode_b64(&salt).map_err(map_err_to_anyhow)?;
+        let pw_hash = hasher
+            .hash_password(passphrase.as_bytes(), &salt_string)
+            .map_err(map_err_to_anyhow)?;
+        if let Some(hash) = pw_hash.hash {
+            Ok(Self {
+                salt,
+                encryption_key: hash.as_bytes().to_vec(),
+            })
+        } else {
+            bail!(EncryptedKeyStoreError::EncryptionError)
+        }
+    }
+
+    pub(crate) fn encrypt(&self, msg: &[u8]) -> Result<Vec<u8>> {
+        let mut nonce = [0; NONCE_SIZE];
+        OsRng.fill_bytes(&mut nonce);
+        let nonce = GenericArray::from_slice(&nonce);
+        let key = GenericArray::from_slice(&self.encryption_key);
+        let cipher = XSalsa20Poly1305::new(key);
+        let mut ciphertext = cipher.encrypt(nonce, msg).map_err(map_err_to_anyhow)?;
+        ciphertext.extend(nonce.iter());
+        Ok(ciphertext)
+    }
+
+    pub(crate) fn decrypt(&self, msg: &[u8]) -> Result<Vec<u8>> {
+        let cyphertext_len = msg.len() - NONCE_SIZE;
+        let ciphertext = &msg[..cyphertext_len];
+        let nonce = GenericArray::from_slice(&msg[cyphertext_len..]);
+        let key = GenericArray::from_slice(&self.encryption_key);
+        let cipher = XSalsa20Poly1305::new(key);
+        let plaintext = cipher
+            .decrypt(nonce, ciphertext)
+            .map_err(map_err_to_anyhow)?;
+        Ok(plaintext)
+    }
+}

--- a/ipc/wallet/src/fvm/keystore/encryption_overlay.rs
+++ b/ipc/wallet/src/fvm/keystore/encryption_overlay.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use super::*;
 
 use anyhow::{bail, Result};

--- a/ipc/wallet/src/fvm/keystore/json.rs
+++ b/ipc/wallet/src/fvm/keystore/json.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use crate::fvm::serialization::json::signature_type::SignatureTypeJson;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 

--- a/ipc/wallet/src/fvm/keystore/json.rs
+++ b/ipc/wallet/src/fvm/keystore/json.rs
@@ -1,0 +1,54 @@
+use crate::fvm::serialization::json::signature_type::SignatureTypeJson;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use super::*;
+
+/// Wrapper for serializing and de-serializing a `KeyInfo` from JSON.
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct KeyInfoJson(#[serde(with = "self")] pub KeyInfo);
+
+/// Wrapper for serializing a `KeyInfo` reference to JSON.
+#[derive(Serialize)]
+#[serde(transparent)]
+pub struct KeyInfoJsonRef<'a>(#[serde(with = "self")] pub &'a KeyInfo);
+
+impl From<KeyInfoJson> for KeyInfo {
+    fn from(key: KeyInfoJson) -> KeyInfo {
+        key.0
+    }
+}
+#[derive(Serialize, Deserialize)]
+struct JsonHelper {
+    #[serde(rename = "Type")]
+    sig_type: SignatureTypeJson,
+    #[serde(rename = "PrivateKey")]
+    private_key: String,
+}
+
+pub fn serialize<S>(k: &KeyInfo, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    JsonHelper {
+        sig_type: SignatureTypeJson(k.key_type),
+        private_key: BASE64_STANDARD.encode(&k.private_key),
+    }
+    .serialize(serializer)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<KeyInfo, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let JsonHelper {
+        sig_type,
+        private_key,
+    } = Deserialize::deserialize(deserializer)?;
+    Ok(KeyInfo {
+        key_type: sig_type.0,
+        private_key: BASE64_STANDARD
+            .decode(private_key)
+            .map_err(de::Error::custom)?,
+    })
+}

--- a/ipc/wallet/src/fvm/keystore/mod.rs
+++ b/ipc/wallet/src/fvm/keystore/mod.rs
@@ -67,10 +67,10 @@ impl KeyStoreConfig {
             path: path.as_ref().to_path_buf(),
         }
     }
-    pub fn encrypted(path: impl AsRef<Path>, password: impl Into<String>) -> Self {
+    pub fn encrypted(path: impl AsRef<Path>, password: impl ToString) -> Self {
         Self::Encrypted {
             location: path.as_ref().to_path_buf(),
-            password: password.into(),
+            password: password.to_string(),
         }
     }
 }

--- a/ipc/wallet/src/fvm/keystore/mod.rs
+++ b/ipc/wallet/src/fvm/keystore/mod.rs
@@ -28,162 +28,78 @@ use xsalsa20poly1305::{
 
 use super::errors::Error;
 
-pub const KEYSTORE_NAME: &str = "keystore.json";
+pub const PLAIN_JSON_KEYSTORE_NAME: &str = "keystore.json";
 pub const ENCRYPTED_KEYSTORE_NAME: &str = "keystore";
 
 /// Environmental variable which holds the `KeyStore` encryption phrase.
 pub const FOREST_KEYSTORE_PHRASE_ENV: &str = "FOREST_KEYSTORE_PHRASE";
 
-type SaltByteArray = [u8; RECOMMENDED_SALT_LEN];
 
-// TODO need to update keyinfo to not use SignatureType, use string instead to
-// save keys like jwt secret
-/// `KeyInfo` structure, this contains the type of key (stored as a string) and
-/// the private key. Note how the private key is stored as a byte vector
-#[derive(Clone, PartialEq, Debug, Eq, Serialize, Deserialize)]
-pub struct KeyInfo {
-    key_type: SignatureType,
-    // Vec<u8> is used because The private keys for BLS and SECP256K1 are not of the same type
-    private_key: Vec<u8>,
-}
+#[cfg(test)]
+mod tests;
 
-#[derive(Clone, PartialEq, Debug, Eq, Serialize, Deserialize)]
-pub struct PersistentKeyInfo {
-    key_type: SignatureType,
-    private_key: String,
-}
+pub mod types;
+pub mod json;
 
-impl KeyInfo {
-    /// Return a new `KeyInfo` given the key type and private key
-    pub fn new(key_type: SignatureType, private_key: Vec<u8>) -> Self {
-        KeyInfo {
-            key_type,
-            private_key,
-        }
-    }
-
-    /// Return a reference to the key's signature type
-    pub fn key_type(&self) -> &SignatureType {
-        &self.key_type
-    }
-
-    /// Return a reference to the private key
-    pub fn private_key(&self) -> &Vec<u8> {
-        &self.private_key
-    }
-}
-
-pub mod json {
-    use crate::fvm::serialization::json::signature_type::SignatureTypeJson;
-    use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-
-    use super::*;
-
-    /// Wrapper for serializing and de-serializing a `KeyInfo` from JSON.
-    #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
-    #[serde(transparent)]
-    pub struct KeyInfoJson(#[serde(with = "self")] pub KeyInfo);
-
-    /// Wrapper for serializing a `KeyInfo` reference to JSON.
-    #[derive(Serialize)]
-    #[serde(transparent)]
-    pub struct KeyInfoJsonRef<'a>(#[serde(with = "self")] pub &'a KeyInfo);
-
-    impl From<KeyInfoJson> for KeyInfo {
-        fn from(key: KeyInfoJson) -> KeyInfo {
-            key.0
-        }
-    }
-    #[derive(Serialize, Deserialize)]
-    struct JsonHelper {
-        #[serde(rename = "Type")]
-        sig_type: SignatureTypeJson,
-        #[serde(rename = "PrivateKey")]
-        private_key: String,
-    }
-
-    pub fn serialize<S>(k: &KeyInfo, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        JsonHelper {
-            sig_type: SignatureTypeJson(k.key_type),
-            private_key: BASE64_STANDARD.encode(&k.private_key),
-        }
-        .serialize(serializer)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<KeyInfo, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let JsonHelper {
-            sig_type,
-            private_key,
-        } = Deserialize::deserialize(deserializer)?;
-        Ok(KeyInfo {
-            key_type: sig_type.0,
-            private_key: BASE64_STANDARD
-                .decode(private_key)
-                .map_err(de::Error::custom)?,
-        })
-    }
-}
+pub use types::*;
 
 /// `KeyStore` structure, this contains a set of `KeyInfos` indexed by address.
 #[derive(Clone, PartialEq, Debug, Eq)]
 pub struct KeyStore {
     key_info: HashMap<String, KeyInfo>,
-    persistence: Option<PersistentKeyStore>,
-    encryption: Option<EncryptedKeyStore>,
+    plain: Option<PlainPersistentKeyStore>,
+    encryption: Option<EncryptionOverlay>,
 }
 
+/// Configuration type for constructing a `KeyStore`
 pub enum KeyStoreConfig {
-    Memory,
-    Persistent(PathBuf),
-    Encrypted(PathBuf, String),
+    /// Create an in-memory only, empty keystore
+    InMemory,
+    /// Create a plain, un-encrypted keystore, not recommended outside of integration tests
+    Plain{path: PathBuf },
+    /// Create a encrypted keystore, using the given password
+    Encrypted{ location: PathBuf, password: String},
+}
+impl KeyStoreConfig {
+    pub fn plain(path: impl AsRef<Path>) -> Self {
+        Self::Plain{ path : path.as_ref().to_path_buf() }
+    }
+    pub fn encrypted(path: impl AsRef<Path>, password: impl Into<String>) -> Self {
+        Self::Encrypted { location : path.as_ref().to_path_buf(), password: password.into() }
+    }
 }
 
-/// Persistent `KeyStore` in JSON clear text in `KEYSTORE_LOCATION`
+
+
+/// Plain persistent `KeyStore` in JSON clear text in [`PLAIN_KEYSTORE_LOCATION`]
 #[derive(Clone, PartialEq, Debug, Eq)]
-struct PersistentKeyStore {
-    file_path: PathBuf,
+struct PlainPersistentKeyStore {
+    /// Path of the keystore on the filesystem.
+    path: PathBuf,
 }
 
-/// Encrypted `KeyStore`
-/// `Argon2id` hash key derivation
-/// `XSalsa20Poly1305` authenticated encryption
-/// CBOR encoding
+/// Encrypted overlay for the `KeyStore` in [`ENCRYPTED_KEYSTORE_LOCATION`]
+/// 
+/// Uses `Argon2id` as hash key derivation
+/// and algorithm `XSalsa20Poly1305` authenticated encryption
+/// and CBOR as data format encoding.
 #[derive(Clone, PartialEq, Debug, Eq)]
-struct EncryptedKeyStore {
+struct EncryptionOverlay {
     salt: SaltByteArray,
+    // pre-hashed key
     encryption_key: Vec<u8>,
-}
-
-#[derive(Debug, Error)]
-pub enum EncryptedKeyStoreError {
-    /// Possibly indicates incorrect passphrase
-    #[error("Error decrypting data")]
-    DecryptionError,
-    /// An error occurred while encrypting keys
-    #[error("Error encrypting data")]
-    EncryptionError,
-    /// Unlock called without `encrypted_keystore` being enabled in
-    /// `config.toml`
-    #[error("Error with forest configuration")]
-    ConfigurationError,
 }
 
 impl KeyStore {
     pub fn new(config: KeyStoreConfig) -> Result<Self, Error> {
         match config {
-            KeyStoreConfig::Memory => Ok(Self {
+            KeyStoreConfig::InMemory => Ok(Self {
                 key_info: HashMap::new(),
-                persistence: None,
+                plain: None,
                 encryption: None,
             }),
-            KeyStoreConfig::Persistent(location) => {
-                let file_path = location.join(KEYSTORE_NAME);
+            KeyStoreConfig::Plain{path: location} => {
+                let file_path = location.join(PLAIN_JSON_KEYSTORE_NAME);
 
                 match File::open(&file_path) {
                     Ok(file) => {
@@ -215,7 +131,7 @@ impl KeyStore {
 
                         Ok(Self {
                             key_info,
-                            persistence: Some(PersistentKeyStore { file_path }),
+                            plain: Some(PlainPersistentKeyStore { path: file_path }),
                             encryption: None,
                         })
                     }
@@ -227,7 +143,7 @@ impl KeyStore {
                             );
                             Ok(Self {
                                 key_info: HashMap::new(),
-                                persistence: Some(PersistentKeyStore { file_path }),
+                                plain: Some(PlainPersistentKeyStore { path: file_path }),
                                 encryption: None,
                             })
                         } else {
@@ -236,7 +152,8 @@ impl KeyStore {
                     }
                 }
             }
-            KeyStoreConfig::Encrypted(location, passphrase) => {
+            KeyStoreConfig::Encrypted{location, password
+            } => {
                 if !location.exists() {
                     create_dir(location.clone())?;
                 }
@@ -261,7 +178,7 @@ impl KeyStore {
                             );
 
                             let (salt, encryption_key) =
-                                EncryptedKeyStore::derive_key(&passphrase, None).map_err(
+                                EncryptionOverlay::derive_key(&password, None).map_err(
                                     |error| {
                                         error!("Failed to create key from passphrase");
                                         Error::Other(error.to_string())
@@ -269,8 +186,8 @@ impl KeyStore {
                                 )?;
                             Ok(Self {
                                 key_info: HashMap::new(),
-                                persistence: Some(PersistentKeyStore { file_path }),
-                                encryption: Some(EncryptedKeyStore {
+                                plain: Some(PlainPersistentKeyStore { path: file_path }),
+                                encryption: Some(EncryptionOverlay {
                                     salt,
                                     encryption_key,
                                 }),
@@ -282,13 +199,13 @@ impl KeyStore {
                             let mut prev_salt = [0; RECOMMENDED_SALT_LEN];
                             prev_salt.copy_from_slice(&buf);
                             let (salt, encryption_key) =
-                                EncryptedKeyStore::derive_key(&passphrase, Some(prev_salt))
+                                EncryptionOverlay::derive_key(&password, Some(prev_salt))
                                     .map_err(|error| {
                                         error!("Failed to create key from passphrase");
                                         Error::Other(error.to_string())
                                     })?;
 
-                            let decrypted_data = EncryptedKeyStore::decrypt(&encryption_key, &data)
+                            let decrypted_data = EncryptionOverlay::decrypt(&encryption_key, &data)
                                 .map_err(|error| Error::Other(error.to_string()))?;
 
                             let key_info = serde_ipld_dagcbor::from_slice(&decrypted_data)
@@ -299,8 +216,8 @@ impl KeyStore {
 
                             Ok(Self {
                                 key_info,
-                                persistence: Some(PersistentKeyStore { file_path }),
-                                encryption: Some(EncryptedKeyStore {
+                                plain: Some(PlainPersistentKeyStore { path: file_path }),
+                                encryption: Some(EncryptionOverlay {
                                     salt,
                                     encryption_key,
                                 }),
@@ -311,15 +228,15 @@ impl KeyStore {
                         debug!("Encrypted keystore does not exist, initializing new keystore");
 
                         let (salt, encryption_key) =
-                            EncryptedKeyStore::derive_key(&passphrase, None).map_err(|error| {
+                            EncryptionOverlay::derive_key(&password, None).map_err(|error| {
                                 error!("Failed to create key from passphrase");
                                 Error::Other(error.to_string())
                             })?;
 
                         Ok(Self {
                             key_info: HashMap::new(),
-                            persistence: Some(PersistentKeyStore { file_path }),
-                            encryption: Some(EncryptedKeyStore {
+                            plain: Some(PlainPersistentKeyStore { path: file_path }),
+                            encryption: Some(EncryptionOverlay {
                                 salt,
                                 encryption_key,
                             }),
@@ -330,15 +247,16 @@ impl KeyStore {
         }
     }
 
+    /// Write an updated version of the keystore to disk
     pub fn flush(&self) -> anyhow::Result<()> {
-        match &self.persistence {
+        match &self.plain {
             Some(persistent_keystore) => {
                 let dir = persistent_keystore
-                    .file_path
+                    .path
                     .parent()
                     .ok_or_else(|| Error::Other("Invalid Path".to_string()))?;
                 fs::create_dir_all(dir)?;
-                let file = File::create(&persistent_keystore.file_path)?;
+                let file = File::create(&persistent_keystore.path)?;
 
                 // Restrict permissions on files containing private keys
                 #[cfg(unix)]
@@ -354,7 +272,7 @@ impl KeyStore {
                         })?;
 
                         let encrypted_data =
-                            EncryptedKeyStore::encrypt(&encrypted_keystore.encryption_key, &data)?;
+                            EncryptionOverlay::encrypt(&encrypted_keystore.encryption_key, &data)?;
                         let mut salt_vec = encrypted_keystore.salt.to_vec();
                         salt_vec.extend(encrypted_data);
                         writer.write_all(&salt_vec)?;
@@ -406,7 +324,7 @@ impl KeyStore {
         }
         self.key_info.insert(key, key_info);
 
-        if self.persistence.is_some() {
+        if self.plain.is_some() {
             self.flush().map_err(|err| Error::Other(err.to_string()))?;
         }
 
@@ -417,7 +335,7 @@ impl KeyStore {
     pub fn remove(&mut self, key: String) -> anyhow::Result<KeyInfo> {
         let key_out = self.key_info.remove(&key).ok_or(Error::KeyInfo)?;
 
-        if self.persistence.is_some() {
+        if self.plain.is_some() {
             self.flush()?;
         }
 
@@ -425,7 +343,7 @@ impl KeyStore {
     }
 }
 
-impl EncryptedKeyStore {
+impl EncryptionOverlay {
     fn derive_key(
         passphrase: &str,
         prev_salt: Option<SaltByteArray>,
@@ -494,139 +412,4 @@ impl EncryptedKeyStore {
 
 fn map_err_to_anyhow<T: Display>(e: T) -> anyhow::Error {
     anyhow::Error::msg(e.to_string())
-}
-
-#[cfg(test)]
-mod test {
-    use anyhow::*;
-    use base64::{prelude::BASE64_STANDARD, Engine};
-    use quickcheck_macros::quickcheck;
-
-    use super::*;
-    use crate::{
-        json::{KeyInfoJson, KeyInfoJsonRef},
-        wallet,
-    };
-
-    const PASSPHRASE: &str = "foobarbaz";
-
-    #[test]
-    fn test_generate_key() {
-        let (salt, encryption_key) = EncryptedKeyStore::derive_key(PASSPHRASE, None).unwrap();
-        let (second_salt, second_key) =
-            EncryptedKeyStore::derive_key(PASSPHRASE, Some(salt)).unwrap();
-
-        assert_eq!(
-            encryption_key, second_key,
-            "Derived key must be deterministic"
-        );
-        assert_eq!(salt, second_salt, "Salts must match");
-    }
-
-    #[test]
-    fn test_encrypt_message() -> Result<()> {
-        let (_, private_key) = EncryptedKeyStore::derive_key(PASSPHRASE, None)?;
-        let message = "foo is coming";
-        let ciphertext = EncryptedKeyStore::encrypt(&private_key, message.as_bytes())?;
-        let second_pass = EncryptedKeyStore::encrypt(&private_key, message.as_bytes())?;
-        ensure!(
-            ciphertext != second_pass,
-            "Ciphertexts use secure initialization vectors"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_decrypt_message() -> Result<()> {
-        let (_, private_key) = EncryptedKeyStore::derive_key(PASSPHRASE, None)?;
-        let message = "foo is coming";
-        let ciphertext = EncryptedKeyStore::encrypt(&private_key, message.as_bytes())?;
-        let plaintext = EncryptedKeyStore::decrypt(&private_key, &ciphertext)?;
-        ensure!(plaintext == message.as_bytes());
-        Ok(())
-    }
-
-    #[test]
-    fn test_read_old_encrypted_keystore() -> Result<()> {
-        let dir: PathBuf = "tests/keystore_encrypted_old".into();
-        ensure!(dir.exists());
-        let ks = KeyStore::new(KeyStoreConfig::Encrypted(dir, PASSPHRASE.to_string()))?;
-        ensure!(ks.persistence.is_some());
-        Ok(())
-    }
-
-    #[test]
-    fn test_read_write_encrypted_keystore() -> Result<()> {
-        let keystore_location = tempfile::tempdir()?.into_path();
-        let ks = KeyStore::new(KeyStoreConfig::Encrypted(
-            keystore_location.clone(),
-            PASSPHRASE.to_string(),
-        ))?;
-        ks.flush()?;
-
-        let ks_read = KeyStore::new(KeyStoreConfig::Encrypted(
-            keystore_location,
-            PASSPHRASE.to_string(),
-        ))?;
-
-        ensure!(ks == ks_read);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_read_write_keystore() -> Result<()> {
-        let keystore_location = tempfile::tempdir()?.into_path();
-        let mut ks = KeyStore::new(KeyStoreConfig::Persistent(keystore_location.clone()))?;
-
-        let key = wallet::generate_key(SignatureType::BLS)?;
-
-        let addr = format!("wallet-{}", key.address);
-        ks.put(addr.clone(), key.key_info)?;
-        ks.flush().unwrap();
-
-        let default = ks.get(&addr).unwrap();
-
-        // Manually parse keystore.json
-        let keystore_file = keystore_location.join(KEYSTORE_NAME);
-        let reader = BufReader::new(File::open(keystore_file)?);
-        let persisted_keystore: HashMap<String, PersistentKeyInfo> =
-            serde_json::from_reader(reader)?;
-
-        let default_key_info = persisted_keystore.get(&addr).unwrap();
-        let actual = BASE64_STANDARD.decode(default_key_info.private_key.clone())?;
-
-        assert_eq!(
-            default.private_key, actual,
-            "persisted key matches key from key store"
-        );
-
-        // Read existing keystore.json
-        let ks_read = KeyStore::new(KeyStoreConfig::Persistent(keystore_location))?;
-        ensure!(ks == ks_read);
-
-        Ok(())
-    }
-
-    impl quickcheck::Arbitrary for KeyInfo {
-        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-            let sigtype = g
-                .choose(&[
-                    fvm_shared::crypto::signature::SignatureType::BLS,
-                    fvm_shared::crypto::signature::SignatureType::Secp256k1,
-                ])
-                .unwrap();
-            KeyInfo {
-                key_type: *sigtype,
-                private_key: Vec::arbitrary(g),
-            }
-        }
-    }
-
-    #[quickcheck]
-    fn keyinfo_roundtrip(keyinfo: KeyInfo) {
-        let serialized: String = serde_json::to_string(&KeyInfoJsonRef(&keyinfo)).unwrap();
-        let parsed: KeyInfoJson = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(keyinfo, parsed.0);
-    }
 }

--- a/ipc/wallet/src/fvm/keystore/tests.rs
+++ b/ipc/wallet/src/fvm/keystore/tests.rs
@@ -1,0 +1,131 @@
+use anyhow::*;
+use base64::{prelude::BASE64_STANDARD, Engine};
+use quickcheck_macros::quickcheck;
+
+use super::*;
+use crate::{
+    json::{KeyInfoJson, KeyInfoJsonRef},
+    wallet,
+};
+
+const PASSPHRASE: &str = "foobarbaz";
+
+#[test]
+fn test_generate_key() {
+    let (salt, encryption_key) = EncryptionOverlay::derive_key(PASSPHRASE, None).unwrap();
+    let (second_salt, second_key) =
+        EncryptionOverlay::derive_key(PASSPHRASE, Some(salt)).unwrap();
+
+    assert_eq!(
+        encryption_key, second_key,
+        "Derived key must be deterministic"
+    );
+    assert_eq!(salt, second_salt, "Salts must match");
+}
+
+#[test]
+fn test_encrypt_message() -> Result<()> {
+    let (_, private_key) = EncryptionOverlay::derive_key(PASSPHRASE, None)?;
+    let message = "foo is coming";
+    let ciphertext = EncryptionOverlay::encrypt(&private_key, message.as_bytes())?;
+    let second_pass = EncryptionOverlay::encrypt(&private_key, message.as_bytes())?;
+    ensure!(
+        ciphertext != second_pass,
+        "Ciphertexts use secure initialization vectors"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_decrypt_message() -> Result<()> {
+    let (_, private_key) = EncryptionOverlay::derive_key(PASSPHRASE, None)?;
+    let message = "foo is coming";
+    let ciphertext = EncryptionOverlay::encrypt(&private_key, message.as_bytes())?;
+    let plaintext = EncryptionOverlay::decrypt(&private_key, &ciphertext)?;
+    ensure!(plaintext == message.as_bytes());
+    Ok(())
+}
+
+#[test]
+fn test_read_old_encrypted_keystore() -> Result<()> {
+    let dir: PathBuf = "tests/keystore_encrypted_old".into();
+    ensure!(dir.exists());
+    let ks = KeyStore::new(KeyStoreConfig::encrypted(dir, PASSPHRASE))?;
+    ensure!(ks.plain.is_some());
+    Ok(())
+}
+
+#[test]
+fn test_read_write_encrypted_keystore() -> Result<()> {
+    let keystore_location = tempfile::tempdir()?.into_path();
+    let ks = KeyStore::new(KeyStoreConfig::encrypted(
+        &keystore_location,
+        PASSPHRASE,
+    ))?;
+    ks.flush()?;
+
+    let ks_read = KeyStore::new(KeyStoreConfig::encrypted(
+        &keystore_location,
+        PASSPHRASE,
+    ))?;
+
+    ensure!(ks == ks_read);
+
+    Ok(())
+}
+
+#[test]
+fn test_read_write_keystore() -> Result<()> {
+    let keystore_location = tempfile::tempdir()?.into_path();
+    let mut ks = KeyStore::new(KeyStoreConfig::plain(&keystore_location))?;
+
+    let key = wallet::generate_key(SignatureType::BLS)?;
+
+    let addr = format!("wallet-{}", key.address);
+    ks.put(addr.clone(), key.key_info)?;
+    ks.flush().unwrap();
+
+    let default = ks.get(&addr).unwrap();
+
+    // Manually parse keystore.json
+    let keystore_file = keystore_location.join(PLAIN_JSON_KEYSTORE_NAME);
+    let reader = BufReader::new(File::open(keystore_file)?);
+    let persisted_keystore: HashMap<String, PersistentKeyInfo> =
+        serde_json::from_reader(reader)?;
+
+    let default_key_info = persisted_keystore.get(&addr).unwrap();
+    let actual = BASE64_STANDARD.decode(default_key_info.private_key.clone())?;
+
+    assert_eq!(
+        default.private_key, actual,
+        "persisted key matches key from key store"
+    );
+
+    // Read existing keystore.json
+    let ks_read = KeyStore::new(KeyStoreConfig::plain(keystore_location))?;
+    ensure!(ks == ks_read);
+
+    Ok(())
+}
+
+impl quickcheck::Arbitrary for KeyInfo {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        let sigtype = g
+            .choose(&[
+                fvm_shared::crypto::signature::SignatureType::BLS,
+                fvm_shared::crypto::signature::SignatureType::Secp256k1,
+            ])
+            .unwrap();
+        KeyInfo {
+            key_type: *sigtype,
+            private_key: Vec::arbitrary(g),
+        }
+    }
+}
+
+#[quickcheck]
+fn keyinfo_roundtrip(keyinfo: KeyInfo) {
+    let serialized: String = serde_json::to_string(&KeyInfoJsonRef(&keyinfo)).unwrap();
+    let parsed: KeyInfoJson = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(keyinfo, parsed.0);
+}

--- a/ipc/wallet/src/fvm/keystore/tests.rs
+++ b/ipc/wallet/src/fvm/keystore/tests.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::*;
 use base64::{prelude::BASE64_STANDARD, Engine};
 use quickcheck_macros::quickcheck;

--- a/ipc/wallet/src/fvm/keystore/types.rs
+++ b/ipc/wallet/src/fvm/keystore/types.rs
@@ -2,7 +2,6 @@ use super::*;
 
 pub(crate) type SaltByteArray = [u8; RECOMMENDED_SALT_LEN];
 
-
 #[allow(missing_docs)]
 #[derive(Debug, Error)]
 pub enum EncryptedKeyStoreError {

--- a/ipc/wallet/src/fvm/keystore/types.rs
+++ b/ipc/wallet/src/fvm/keystore/types.rs
@@ -1,0 +1,56 @@
+use super::*;
+
+pub(crate) type SaltByteArray = [u8; RECOMMENDED_SALT_LEN];
+
+
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum EncryptedKeyStoreError {
+    /// Possibly indicates incorrect passphrase
+    #[error("Error decrypting data, is the password correct?")]
+    DecryptionError,
+    /// An error occurred while encrypting keys
+    #[error("Error encrypting data")]
+    EncryptionError,
+    /// Unlock called without `encrypted_keystore` being enabled in
+    /// `config.toml`
+    #[error("Error with forest configuration")]
+    ConfigurationError,
+}
+
+// TODO need to update keyinfo to not use SignatureType, use string instead to
+// save keys like jwt secret
+/// `KeyInfo` structure, this contains the type of key (stored as a string) and
+/// the private key. Note how the private key is stored as a byte vector
+#[derive(Clone, PartialEq, Debug, Eq, Serialize, Deserialize)]
+pub struct KeyInfo {
+    pub(crate) key_type: SignatureType,
+    // Vec<u8> is used because The private keys for BLS and SECP256K1 are not of the same type
+    pub(crate) private_key: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Debug, Eq, Serialize, Deserialize)]
+pub struct PersistentKeyInfo {
+    pub(crate) key_type: SignatureType,
+    pub(crate) private_key: String,
+}
+
+impl KeyInfo {
+    /// Return a new `KeyInfo` given the key type and private key
+    pub fn new(key_type: SignatureType, private_key: Vec<u8>) -> Self {
+        KeyInfo {
+            key_type,
+            private_key,
+        }
+    }
+
+    /// Return a reference to the key's signature type
+    pub fn key_type(&self) -> &SignatureType {
+        &self.key_type
+    }
+
+    /// Return a reference to the private key
+    pub fn private_key(&self) -> &Vec<u8> {
+        &self.private_key
+    }
+}

--- a/ipc/wallet/src/fvm/keystore/types.rs
+++ b/ipc/wallet/src/fvm/keystore/types.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
 use super::*;
 
 pub(crate) type SaltByteArray = [u8; RECOMMENDED_SALT_LEN];

--- a/ipc/wallet/src/fvm/wallet.rs
+++ b/ipc/wallet/src/fvm/wallet.rs
@@ -271,7 +271,7 @@ mod tests {
 
     fn generate_wallet() -> Wallet {
         let key_vec = construct_priv_keys();
-        Wallet::new_from_keys(KeyStore::new(KeyStoreConfig::Memory).unwrap(), key_vec)
+        Wallet::new_from_keys(KeyStore::new(KeyStoreConfig::InMemory).unwrap(), key_vec)
     }
 
     #[test]
@@ -281,7 +281,7 @@ mod tests {
         let addr = key_vec[0].address;
 
         let mut wallet =
-            Wallet::new_from_keys(KeyStore::new(KeyStoreConfig::Memory).unwrap(), key_vec);
+            Wallet::new_from_keys(KeyStore::new(KeyStoreConfig::InMemory).unwrap(), key_vec);
 
         // make sure that this address resolves to the right key
         assert_eq!(wallet.find_key(&addr).unwrap(), found_key);
@@ -308,7 +308,7 @@ mod tests {
         let priv_key_bytes = key_vec[2].key_info.private_key().clone();
         let addr = key_vec[2].address;
 
-        let keystore = KeyStore::new(KeyStoreConfig::Memory).unwrap();
+        let keystore = KeyStore::new(KeyStoreConfig::InMemory).unwrap();
         let mut wallet = Wallet::new_from_keys(keystore, key_vec);
         let msg = [0u8; 64];
 
@@ -329,7 +329,7 @@ mod tests {
     fn import_export() -> anyhow::Result<()> {
         let key_vec = construct_priv_keys();
         let key = key_vec[0].clone();
-        let keystore = KeyStore::new(KeyStoreConfig::Memory).unwrap();
+        let keystore = KeyStore::new(KeyStoreConfig::InMemory).unwrap();
         let mut wallet = Wallet::new_from_keys(keystore, key_vec);
 
         let key_info = wallet.export(&key.address).unwrap();
@@ -360,7 +360,7 @@ mod tests {
         let key_vec = construct_priv_keys();
         let mut addr_string_vec = Vec::new();
 
-        let mut key_store = KeyStore::new(KeyStoreConfig::Memory).unwrap();
+        let mut key_store = KeyStore::new(KeyStoreConfig::InMemory).unwrap();
 
         for i in &key_vec {
             addr_string_vec.push(i.address.to_string());
@@ -408,7 +408,7 @@ mod tests {
 
     #[test]
     fn get_set_default() {
-        let key_store = KeyStore::new(KeyStoreConfig::Memory).unwrap();
+        let key_store = KeyStore::new(KeyStoreConfig::InMemory).unwrap();
         let mut wallet = Wallet::new(key_store);
         // check to make sure that there is no default
         assert_eq!(wallet.get_default().unwrap_err(), Error::KeyInfo);
@@ -437,7 +437,7 @@ mod tests {
         let secp_key_info = KeyInfo::new(SignatureType::Secp256k1, secp_priv_key);
         let secp_key = Key::try_from(secp_key_info).unwrap();
         let addr = secp_key.address;
-        let key_store = KeyStore::new(KeyStoreConfig::Memory).unwrap();
+        let key_store = KeyStore::new(KeyStoreConfig::InMemory).unwrap();
         let mut wallet = Wallet::new_from_keys(key_store, vec![secp_key]);
 
         let msg = [0u8; 64];
@@ -456,7 +456,7 @@ mod tests {
         let bls_key_info = KeyInfo::new(SignatureType::BLS, bls_priv_key);
         let bls_key = Key::try_from(bls_key_info).unwrap();
         let addr = bls_key.address;
-        let key_store = KeyStore::new(KeyStoreConfig::Memory).unwrap();
+        let key_store = KeyStore::new(KeyStoreConfig::InMemory).unwrap();
         let mut wallet = Wallet::new_from_keys(key_store, vec![bls_key]);
 
         let msg = [0u8; 64];


### PR DESCRIPTION
Currently only the `fvm` keystore implements an encrypted variant, but we'd want encryption as an abstract overlay so it can also be utilized for the `evm` implementation.

This PR refactors the _`fvm`_ keystore implementation such that the now renamed `EncryptionOverlay` is re-usable for the `evm` as well (pending impl in a follow up PR).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/consensus-shipyard/ipc/1346)
<!-- Reviewable:end -->
