### PR TITLE
fix: prevent xnet call messages with non-zero value from inflating child subnet circulating supply

### DIFF
--- a/contracts/contracts/gateway/router/CheckpointingFacet.sol
+++ b/contracts/contracts/gateway/router/CheckpointingFacet.sol
@@ -116,9 +116,7 @@ contract CheckpointingFacet is GatewayActorModifiers {
         uint256 crossMsgLength = msgs.length;
 
         for (uint256 i; i < crossMsgLength; ) {
-            if (msgs[i].kind != IpcMsgKind.Call) {
-                totalValue += msgs[i].value;
-            }
+            totalValue += msgs[i].value;
             unchecked {
                 ++i;
             }

--- a/contracts/test/integration/GatewayDiamond.t.sol
+++ b/contracts/test/integration/GatewayDiamond.t.sol
@@ -1163,6 +1163,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase, SubnetWithNativeT
         (, subnetInfo) = gatewayDiamond.getter().getSubnet(subnetId);
         require(subnetInfo.circSupply == DEFAULT_COLLATERAL_AMOUNT, "unexpected circulation supply after funding");
 
+        uint256 totalAmount = 0;
         IpcEnvelope[] memory msgs = new IpcEnvelope[](10);
         for (uint64 i = 0; i < 10; i++) {
             msgs[i] = TestUtils.newXnetCallMsg(
@@ -1174,6 +1175,8 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase, SubnetWithNativeT
                 amount,
                 i
             );
+
+            totalAmount += amount;
         }
 
         BottomUpCheckpoint memory checkpoint = BottomUpCheckpoint({
@@ -1189,8 +1192,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase, SubnetWithNativeT
         gatewayDiamond.checkpointer().commitCheckpoint(checkpoint);
 
         (, subnetInfo) = gatewayDiamond.getter().getSubnet(subnetId);
-        // cross net messages with Call kind does not affect the circulating supply
-        require(subnetInfo.circSupply == DEFAULT_COLLATERAL_AMOUNT, "unexpected circulating supply");
+        require(subnetInfo.circSupply == DEFAULT_COLLATERAL_AMOUNT - totalAmount, "unexpected circulating supply");
     }
 
     function testGatewayDiamond_listIncompleteCheckpoints() public {


### PR DESCRIPTION
Prevent xnet call messages with non-zero value from inflating child subnet circulating supply