### PR TITLE
fix(node): patch call create contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3742,6 +3742,7 @@ dependencies = [
  "fendermint_vm_message",
  "fendermint_vm_resolver",
  "fendermint_vm_topdown",
+ "fil_actor_eam",
  "futures-core",
  "futures-util",
  "fvm",

--- a/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/eth/api/src/apis/eth.rs
@@ -722,14 +722,7 @@ where
         };
         error_with_revert(ExitCode::new(deliver_tx.code.value()), msg, data)
     } else if is_create {
-        // It's not clear why some tools like Remix call this with deployment transaction, but they do.
-        // We could parse the deployed contract address, but it would be of very limited use;
-        // the call effect isn't persisted, so one would have to send an actual transaction
-        // and then run a call on `pending` state with this address to have a chance to hit
-        // that contract before the transaction is included in a block, assuming address
-        // creation is deterministic.
-        // Lotus returns empty: https://github.com/filecoin-project/lotus/blob/v1.23.1-rc2/node/impl/full/eth.go#L1091-L1094
-        Ok(Default::default())
+        Ok(deliver_tx.data.into())
     } else {
         let return_data = decode_fevm_invoke(&deliver_tx)
             .context("error decoding data from deliver_tx in query")?;

--- a/fendermint/vm/interpreter/Cargo.toml
+++ b/fendermint/vm/interpreter/Cargo.toml
@@ -30,7 +30,7 @@ fendermint_actor_gas_market_eip1559 = { path = "../../actors/gas_market/eip1559"
 fendermint_actor_eam = { path = "../../actors/eam" }
 fendermint_testing = { path = "../../testing", optional = true }
 ipc_actors_abis = { path = "../../../contract-bindings" }
-
+fil_actor_eam = { workspace = true }
 ipc-api = { path = "../../../ipc/api" }
 ipc-observability = { path = "../../../ipc/observability" }
 


### PR DESCRIPTION
A simple patch to fendermint query that creates a contract. Currently it returns the addresses, but to align with eth rpc that returns the actual deployed code.