### PR TITLE
fix: use rust `1.83.0` and avoid artifact version mismatches and fixes `docker-build` target

### DIFF
--- a/fendermint/docker/builder.ci.Dockerfile
+++ b/fendermint/docker/builder.ci.Dockerfile
@@ -48,7 +48,7 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
 WORKDIR /app
 
 # Update the version here if our `rust-toolchain.toml` would cause something new to be fetched every time.
-ARG RUST_VERSION=1.78
+ARG RUST_VERSION=1.83.0
 RUN rustup install ${RUST_VERSION} && rustup target add wasm32-unknown-unknown
 
 # Defined here so anything above it can be cached as a common dependency.

--- a/fendermint/docker/builder.local.Dockerfile
+++ b/fendermint/docker/builder.local.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Builder
-FROM rust:bookworm as builder
+FROM rust:1.83.0-bookworm as builder
 
 RUN apt-get update && \
   apt-get install -y build-essential clang cmake protobuf-compiler && \


### PR DESCRIPTION
… errors

Must be kept in sync with `rust-toolchain.toml`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/consensus-shipyard/ipc/1385)
<!-- Reviewable:end -->
