### PR TITLE
fix: deployer fixes

### DIFF
--- a/scripts/ipc-subnet-manager/ipc-subnet-config.yml
+++ b/scripts/ipc-subnet-manager/ipc-subnet-config.yml
@@ -50,6 +50,9 @@ paths:
   ipc_repo: "/home/ipc/ipc"
   # Path to ipc-cli binary on remote hosts
   ipc_binary: "/home/ipc/ipc/target/release/ipc-cli"
+  # Path to IPC repo for local builds (update-binaries --compile local)
+  # Default: auto-detect from script location (parent of scripts/ipc-subnet-manager)
+  # local_ipc_repo: "/path/to/ipc"
   # Node home directory (will be created)
   node_home: "/home/ipc/.ipc-node"
   # Node init config path

--- a/scripts/ipc-subnet-manager/ipc-subnet-manager.sh
+++ b/scripts/ipc-subnet-manager/ipc-subnet-manager.sh
@@ -462,7 +462,7 @@ Compile modes:
           Rust, Foundry on each host.
   local   Build on this machine and SCP binaries to validators. If you're on
           macOS and validators are Linux, cross-compiles to x86_64-unknown-linux-gnu.
-          Requires: cross (cargo install cross) for macOS->Linux.
+          Requires: cargo-zigbuild + zig (recommended) or cross (needs Docker).
 
 Examples:
     $0 update-binaries --branch main

--- a/scripts/ipc-subnet-manager/ipc-subnet-manager.sh
+++ b/scripts/ipc-subnet-manager/ipc-subnet-manager.sh
@@ -71,6 +71,7 @@ Options:
     --yes                Skip confirmation prompts
     --debug              Show verbose debug output
     --branch NAME        For bootstrap/update-binaries: git branch to pull from (default: main)
+    --compile MODE       For update-binaries: 'local' or 'remote' (default: remote)
     --duration SECONDS   For block-time: sample duration (default: 10)
     --help               Show this help message
 
@@ -93,6 +94,7 @@ Examples:
     $0 init --debug                            # Initialize with verbose debug output
     $0 check                                   # Run health checks
     $0 update-binaries --branch main           # Update binaries from main branch
+    $0 update-binaries -C local --branch main  # Build locally, deploy to validators
     $0 watch-finality                          # Monitor parent finality progress
     $0 watch-blocks                            # Monitor block production
     $0 logs validator-1                        # View logs from validator-1
@@ -426,12 +428,21 @@ cmd_init() {
 # Update binaries on all validators
 cmd_update_binaries() {
     local branch="main"
+    local compile_mode="remote"
 
     # Parse options
     while [[ $# -gt 0 ]]; do
         case $1 in
             --branch)
                 branch="$2"
+                shift 2
+                ;;
+            --compile|-C)
+                compile_mode="$2"
+                if [[ "$compile_mode" != "local" && "$compile_mode" != "remote" ]]; then
+                    log_error "Invalid --compile value: $compile_mode (use 'local' or 'remote')"
+                    exit 1
+                fi
                 shift 2
                 ;;
             --help|-h)
@@ -441,25 +452,28 @@ Update IPC binaries on all validators
 Usage: $0 update-binaries [options]
 
 Options:
-    --branch NAME    Git branch to pull from (default: main)
-    --help           Show this help message
+    --branch NAME       Git branch to pull from (default: main)
+    --compile MODE      Where to build: 'local' or 'remote' (default: remote)
+    -C MODE             Short for --compile
+    --help              Show this help message
 
-This command will:
-  1. SSH to each validator (in parallel)
-  2. Pull latest changes from the specified branch
-  3. Build binaries using 'make' in the repo root
-  4. Copy ipc-cli and fendermint binaries to /usr/local/bin
+Compile modes:
+  remote  Build on each validator via SSH (current behavior). Requires pnpm,
+          Rust, Foundry on each host.
+  local   Build on this machine and SCP binaries to validators. If you're on
+          macOS and validators are Linux, cross-compiles to x86_64-unknown-linux-gnu.
+          Requires: cross (cargo install cross) for macOS->Linux.
 
 Examples:
     $0 update-binaries --branch main
-    $0 update-binaries --branch dev
-    $0 update-binaries --branch feature-xyz
+    $0 update-binaries --branch main --compile local
+    $0 update-binaries -C local --branch main
 EOF
                 exit 0
                 ;;
             *)
                 log_error "Unknown option: $1"
-                echo "Usage: $0 update-binaries --branch <branch-name>"
+                echo "Usage: $0 update-binaries [options] (use --help for details)"
                 exit 1
                 ;;
         esac
@@ -469,7 +483,7 @@ EOF
     load_config
 
     # Update binaries
-    update_all_binaries "$branch"
+    update_all_binaries "$branch" "$compile_mode"
 }
 
 # Update existing node configs

--- a/scripts/ipc-subnet-manager/ipc-subnet-manager.sh
+++ b/scripts/ipc-subnet-manager/ipc-subnet-manager.sh
@@ -48,6 +48,7 @@ Commands:
     init --resume     Continue init from where it left off (after deploy failure)
     update-config     Update existing node configs without wiping data
     update-binaries   Pull latest code, build, and install binaries on all validators
+    deploy-binaries   Copy existing binaries to validators (no build)
     check             Comprehensive health check on all nodes
     diagnose [name]   Detailed diagnostics for troubleshooting (all or one validator)
     restart           Graceful restart of all nodes
@@ -95,6 +96,7 @@ Examples:
     $0 check                                   # Run health checks
     $0 update-binaries --branch main           # Update binaries from main branch
     $0 update-binaries -C local --branch main  # Build locally, deploy to validators
+    $0 deploy-binaries --path ./target/release # Copy binaries to all validators
     $0 watch-finality                          # Monitor parent finality progress
     $0 watch-blocks                            # Monitor block production
     $0 logs validator-1                        # View logs from validator-1
@@ -486,6 +488,81 @@ EOF
     update_all_binaries "$branch" "$compile_mode"
 }
 
+# Deploy binaries to validators (copy only, no build)
+cmd_deploy_binaries() {
+    local binary_path=""
+    local target_validator=""
+
+    # Parse options
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --path)
+                binary_path="$2"
+                shift 2
+                ;;
+            --help|-h)
+                cat << EOF
+Copy ipc-cli and fendermint binaries to validators (no build)
+
+Usage: $0 deploy-binaries [options] [validator-name]
+
+Options:
+    --path DIR    Path to directory containing ipc-cli and fendermint
+    --help        Show this help message
+
+If --path is omitted, auto-detects from local IPC repo:
+  - target/release/ (native build)
+  - target/x86_64-unknown-linux-gnu/release/ (cross-compiled)
+
+Examples:
+    $0 deploy-binaries --path ./target/release
+    $0 deploy-binaries --path ./target/x86_64-unknown-linux-gnu/release
+    $0 deploy-binaries validator-2   # Deploy to single validator (uses auto-detect path)
+EOF
+                exit 0
+                ;;
+            -*)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+            *)
+                target_validator="$1"
+                shift
+                ;;
+        esac
+    done
+
+    load_config
+
+    # Auto-detect path if not specified
+    if [ -z "$binary_path" ]; then
+        local local_repo
+        local_repo=$(get_config_value "paths.local_ipc_repo" 2>/dev/null || true)
+        if [ -z "$local_repo" ] || [ "$local_repo" = "null" ]; then
+            local_repo=$(cd "${SCRIPT_DIR}/../.." && pwd)
+        fi
+        if [ -f "$local_repo/target/release/ipc-cli" ]; then
+            binary_path="$local_repo/target/release"
+        elif [ -f "$local_repo/target/x86_64-unknown-linux-gnu/release/ipc-cli" ]; then
+            binary_path="$local_repo/target/x86_64-unknown-linux-gnu/release"
+        else
+            log_error "Binaries not found. Specify --path or run from IPC repo with built binaries."
+            log_info "Expected: target/release/ or target/x86_64-unknown-linux-gnu/release/"
+            exit 1
+        fi
+        log_info "Using binaries from: $binary_path"
+    fi
+
+    binary_path=$(cd "$binary_path" 2>/dev/null && pwd)
+    if [ -z "$binary_path" ]; then
+        log_error "Invalid path"
+        exit 1
+    fi
+
+    log_header "Deploying Binaries"
+    deploy_binaries_only "$binary_path" "$target_validator"
+}
+
 # Update existing node configs
 cmd_update_config() {
     log_header "Updating Node Configurations"
@@ -868,7 +945,7 @@ main() {
 
     # Acquire lock for destructive operations
     case $command in
-        init|restart|update-binaries)
+        init|restart|update-binaries|deploy-binaries)
             acquire_lock
             ;;
     esac
@@ -886,6 +963,9 @@ main() {
             ;;
         update-binaries)
             cmd_update_binaries "$@"
+            ;;
+        deploy-binaries)
+            cmd_deploy_binaries "$@"
             ;;
         check)
             cmd_check "$@"

--- a/scripts/ipc-subnet-manager/lib/health.sh
+++ b/scripts/ipc-subnet-manager/lib/health.sh
@@ -1788,6 +1788,9 @@ update_validator_binaries() {
     log_info "[$name] Updating binaries from branch '$branch'..."
 
     local update_cmd="cd $ipc_repo && \
+        source ~/.cargo/env 2>/dev/null; \
+        source ~/.bashrc 2>/dev/null; \
+        export PATH=\"\$HOME/.cargo/bin:\$HOME/.foundry/bin:\$HOME/.npm-global/bin:\$PATH\" && \
         git fetch origin && \
         git checkout $branch && \
         git pull origin $branch && \
@@ -1814,15 +1817,159 @@ update_validator_binaries() {
     return 0
 }
 
+# Build IPC binaries locally (with cross-compilation for macOS->Linux)
+# On success, writes binary directory path to $3 (result file). Returns 0/1.
+build_ipc_locally() {
+    local branch="${1:-main}"
+    local local_repo="$2"
+    local result_file="$3"
+
+    log_info "Building IPC locally (branch: $branch)..."
+    log_info "Repository: $local_repo"
+
+    # Git fetch and checkout
+    if ! (cd "$local_repo" && git fetch origin && git checkout "$branch" && git pull origin "$branch"); then
+        log_error "Failed to update git repository"
+        return 1
+    fi
+
+    # Contracts codegen (requires pnpm)
+    log_info "Running contracts codegen..."
+    if ! (cd "$local_repo/contracts" && make gen 2>&1); then
+        log_error "Contracts codegen failed (ensure pnpm is installed)"
+        return 1
+    fi
+
+    local target_triple=""
+    local binary_dir=""
+    local os_name
+    os_name=$(uname -s)
+
+    if [ "$os_name" = "Darwin" ]; then
+        # Cross-compile for Linux (validators are typically x86_64 Linux)
+        target_triple="x86_64-unknown-linux-gnu"
+        binary_dir="$local_repo/target/$target_triple/release"
+
+        if ! command -v cross &>/dev/null; then
+            log_error "cross not found. Install with: cargo install cross"
+            log_info "Required for macOS->Linux cross-compilation"
+            return 1
+        fi
+
+        log_info "Cross-compiling for $target_triple (macOS -> Linux)..."
+        if ! (cd "$local_repo" && cross build --release --target "$target_triple" 2>&1); then
+            log_error "Cross-compilation failed"
+            return 1
+        fi
+    else
+        # Native build (Linux or same-arch)
+        binary_dir="$local_repo/target/release"
+        log_info "Building natively..."
+        if ! (cd "$local_repo" && cargo build --release 2>&1); then
+            log_error "Build failed"
+            return 1
+        fi
+    fi
+
+    if [ ! -f "$binary_dir/ipc-cli" ] || [ ! -f "$binary_dir/fendermint" ]; then
+        log_error "Binaries not found in $binary_dir"
+        return 1
+    fi
+
+    echo "$binary_dir" > "$result_file"
+    return 0
+}
+
+# Deploy locally-built binaries to a single validator
+deploy_binaries_to_validator() {
+    local validator_idx="$1"
+    local binary_dir="$2"
+
+    local name="${VALIDATORS[$validator_idx]}"
+    local ip=$(get_config_value "validators[$validator_idx].ip")
+    local ssh_user=$(get_config_value "validators[$validator_idx].ssh_user")
+    local ipc_user=$(get_config_value "validators[$validator_idx].ipc_user")
+    local ipc_repo=$(get_config_value "paths.ipc_repo")
+    local remote_release="$ipc_repo/target/release"
+
+    log_info "[$name] Deploying binaries..."
+
+    # Ensure remote directory exists
+    ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 "$ssh_user@$ip" \
+        "sudo mkdir -p $remote_release && sudo chown $ipc_user:$ipc_user $remote_release" 2>/dev/null || true
+
+    if ! scp_to_host "$ip" "$ssh_user" "$ipc_user" "$binary_dir/ipc-cli" "$remote_release/ipc-cli"; then
+        log_error "[$name] Failed to copy ipc-cli"
+        return 1
+    fi
+    if ! scp_to_host "$ip" "$ssh_user" "$ipc_user" "$binary_dir/fendermint" "$remote_release/fendermint"; then
+        log_error "[$name] Failed to copy fendermint"
+        return 1
+    fi
+
+    log_success "[$name] Binaries deployed"
+    return 0
+}
+
 # Update binaries on all validators
 update_all_binaries() {
     local branch="${1:-main}"
+    local compile_mode="${2:-remote}"
 
     log_header "Updating IPC Binaries"
     log_info "Branch: $branch"
+    log_info "Compile mode: $compile_mode"
     log_info "Validators: ${#VALIDATORS[@]}"
     echo ""
 
+    if [ "$compile_mode" = "local" ]; then
+        # Build once locally, deploy to all validators
+        local local_repo
+        local_repo=$(get_config_value "paths.local_ipc_repo" 2>/dev/null || true)
+        if [ -z "$local_repo" ] || [ "$local_repo" = "null" ]; then
+            # Default: repo root (script is in scripts/ipc-subnet-manager/)
+            local_repo=$(cd "${SCRIPT_DIR}/../.." && pwd)
+        fi
+        if [ ! -d "$local_repo/.git" ]; then
+            log_error "Not a git repository: $local_repo"
+            log_info "Set paths.local_ipc_repo in config to point to IPC repo"
+            return 1
+        fi
+
+        local result_file="/tmp/ipc-manager-build-result.$$"
+        trap "rm -f $result_file" EXIT
+        if ! build_ipc_locally "$branch" "$local_repo" "$result_file"; then
+            rm -f "$result_file"
+            return 1
+        fi
+        local binary_dir
+        binary_dir=$(cat "$result_file")
+        rm -f "$result_file"
+
+        log_success "Build complete. Deploying to validators..."
+        echo ""
+
+        local all_success=true
+        for idx in "${!VALIDATORS[@]}"; do
+            if ! deploy_binaries_to_validator "$idx" "$binary_dir"; then
+                all_success=false
+            fi
+        done
+
+        if [ "$all_success" = true ]; then
+            echo ""
+            log_success "✓ All validators updated successfully"
+            log_info "You may need to restart nodes for changes to take effect:"
+            log_info "  $0 restart"
+            return 0
+        else
+            echo ""
+            log_error "✗ Some validators failed to update"
+            return 1
+        fi
+    fi
+
+    # Remote compile (original behavior)
     local all_success=true
     local results=()
 

--- a/scripts/ipc-subnet-manager/lib/health.sh
+++ b/scripts/ipc-subnet-manager/lib/health.sh
@@ -1850,15 +1850,33 @@ build_ipc_locally() {
         target_triple="x86_64-unknown-linux-gnu"
         binary_dir="$local_repo/target/$target_triple/release"
 
-        if ! command -v cross &>/dev/null; then
-            log_error "cross not found. Install with: cargo install cross"
-            log_info "Required for macOS->Linux cross-compilation"
-            return 1
-        fi
-
-        log_info "Cross-compiling for $target_triple (macOS -> Linux)..."
-        if ! (cd "$local_repo" && cross build --release --target "$target_triple" 2>&1); then
-            log_error "Cross-compilation failed"
+        # Prefer cargo-zigbuild (no Docker needed); fall back to cross
+        if command -v cargo-zigbuild &>/dev/null && command -v zig &>/dev/null; then
+            log_info "Cross-compiling for $target_triple using cargo-zigbuild (macOS -> Linux)..."
+            rustup target add "$target_triple" 2>/dev/null || true
+            if ! (cd "$local_repo" && cargo zigbuild --release --target "$target_triple" 2>&1); then
+                log_error "cargo-zigbuild failed"
+                return 1
+            fi
+        elif command -v cross &>/dev/null; then
+            log_info "Cross-compiling for $target_triple using cross (macOS -> Linux)..."
+            local cross_output
+            cross_output=$(cd "$local_repo" && cross build --release --target "$target_triple" 2>&1)
+            local cross_exit=$?
+            if [ $cross_exit -ne 0 ]; then
+                echo "$cross_output" | tail -20
+                log_error "Cross-compilation failed"
+                if echo "$cross_output" | grep -q "couldn't install toolchain"; then
+                    log_info "Tip: cross 0.2.5 has a bug on macOS. Try one of:"
+                    log_info "  1. cargo install cross --git https://github.com/cross-rs/cross"
+                    log_info "  2. cargo install cargo-zigbuild && brew install zig  (no Docker needed)"
+                fi
+                return 1
+            fi
+        else
+            log_error "No cross-compiler found. Install one of:"
+            log_info "  cargo-zigbuild (recommended, no Docker): cargo install cargo-zigbuild && brew install zig"
+            log_info "  cross (needs Docker): cargo install cross --git https://github.com/cross-rs/cross"
             return 1
         fi
     else

--- a/scripts/ipc-subnet-manager/lib/health.sh
+++ b/scripts/ipc-subnet-manager/lib/health.sh
@@ -1904,23 +1904,19 @@ deploy_binaries_to_validator() {
     local binary_dir="$2"
 
     local name="${VALIDATORS[$validator_idx]}"
-    local ip=$(get_config_value "validators[$validator_idx].ip")
-    local ssh_user=$(get_config_value "validators[$validator_idx].ssh_user")
-    local ipc_user=$(get_config_value "validators[$validator_idx].ipc_user")
     local ipc_repo=$(get_config_value "paths.ipc_repo")
     local remote_release="$ipc_repo/target/release"
 
     log_info "[$name] Deploying binaries..."
 
-    # Ensure remote directory exists
-    ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 "$ssh_user@$ip" \
-        "sudo mkdir -p $remote_release && sudo chown $ipc_user:$ipc_user $remote_release" 2>/dev/null || true
+    # Ensure directory exists (exec_on_host handles local/remote via is_local_mode)
+    exec_on_host "$validator_idx" "mkdir -p $remote_release" >/dev/null 2>&1 || true
 
-    if ! scp_to_host "$ip" "$ssh_user" "$ipc_user" "$binary_dir/ipc-cli" "$remote_release/ipc-cli"; then
+    if ! copy_to_host "$validator_idx" "$binary_dir/ipc-cli" "$remote_release/ipc-cli"; then
         log_error "[$name] Failed to copy ipc-cli"
         return 1
     fi
-    if ! scp_to_host "$ip" "$ssh_user" "$ipc_user" "$binary_dir/fendermint" "$remote_release/fendermint"; then
+    if ! copy_to_host "$validator_idx" "$binary_dir/fendermint" "$remote_release/fendermint"; then
         log_error "[$name] Failed to copy fendermint"
         return 1
     fi

--- a/scripts/ipc-subnet-manager/lib/health.sh
+++ b/scripts/ipc-subnet-manager/lib/health.sh
@@ -1898,7 +1898,7 @@ build_ipc_locally() {
     return 0
 }
 
-# Deploy locally-built binaries to a single validator
+# Deploy binaries to a single validator (used by update-binaries --compile local and deploy-binaries)
 deploy_binaries_to_validator() {
     local validator_idx="$1"
     local binary_dir="$2"
@@ -1927,6 +1927,57 @@ deploy_binaries_to_validator() {
 
     log_success "[$name] Binaries deployed"
     return 0
+}
+
+# Deploy binaries to validators (copy only, no build)
+# Usage: deploy_binaries_only <binary_dir> [validator_name]
+deploy_binaries_only() {
+    local binary_dir="$1"
+    local target_validator="${2:-}"
+
+    if [ ! -f "$binary_dir/ipc-cli" ] || [ ! -f "$binary_dir/fendermint" ]; then
+        log_error "Binaries not found in $binary_dir (need ipc-cli and fendermint)"
+        return 1
+    fi
+
+    if [ -n "$target_validator" ]; then
+        local found=false
+        for name in "${VALIDATORS[@]}"; do
+            [ "$name" = "$target_validator" ] && found=true && break
+        done
+        if [ "$found" != true ]; then
+            log_error "Unknown validator: $target_validator"
+            log_info "Valid: ${VALIDATORS[*]}"
+            return 1
+        fi
+    fi
+
+    local all_success=true
+    local deployed=0
+    for idx in "${!VALIDATORS[@]}"; do
+        local name="${VALIDATORS[$idx]}"
+        if [ -n "$target_validator" ] && [ "$name" != "$target_validator" ]; then
+            continue
+        fi
+        deployed=1
+        if ! deploy_binaries_to_validator "$idx" "$binary_dir"; then
+            all_success=false
+        fi
+    done
+
+    if [ "$deployed" -eq 0 ]; then
+        log_error "No validators matched"
+        return 1
+    fi
+
+    if [ "$all_success" = true ]; then
+        log_success "✓ All binaries deployed successfully"
+        log_info "You may need to restart nodes: $0 restart"
+        return 0
+    else
+        log_error "✗ Some validators failed to receive binaries"
+        return 1
+    fi
 }
 
 # Update binaries on all validators


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new binary deployment paths (local build + SCP, and copy-only deploy) that change how validator executables get updated; mistakes could roll out wrong/arch-incompatible binaries across the fleet. Remote build behavior is mostly preserved but now depends on sourcing shell env and PATH setup during SSH builds.
> 
> **Overview**
> Adds a new `deploy-binaries` command to copy prebuilt `ipc-cli`/`fendermint` to validators (optionally targeting a single validator) with auto-detection of the local `target/*/release` output path.
> 
> Extends `update-binaries` with `--compile {local|remote}` so updates can either build on each validator (default) or build once locally (including macOS→Linux cross-compile support) and then deploy the resulting binaries to all validators.
> 
> Updates the YAML config template to document `paths.local_ipc_repo`, and tweaks remote build execution to source common shell env files and set PATH before running `make`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9de9cd0aa2250b2c4de352cc8424ae58c1bb63dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->