### PR TITLE
Add demos created during offsite

### DIFF
--- a/demos/.gitignore
+++ b/demos/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,20 @@
+# IPC JSX Demos (Local)
+
+This folder now has a tiny Vite + React host so both JSX demos can run locally.
+
+## Run
+
+```bash
+cd demos
+pnpm install --ignore-workspace
+pnpm --ignore-workspace dev
+```
+
+Open [http://127.0.0.1:5173](http://127.0.0.1:5173).
+
+## Demo URLs
+
+- `/?demo=reputation` for `dev-reputation-mock`
+- `/?demo=sp` for `sp-analysis`
+
+You can also switch between both demos using the top-right toggle in the UI.

--- a/demos/dev-reputation-mock/ipc_reputation_demo.jsx
+++ b/demos/dev-reputation-mock/ipc_reputation_demo.jsx
@@ -1,0 +1,594 @@
+import { useState, useEffect, useRef } from "react";
+
+const FONTS = `
+  @import url('https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=DM+Sans:wght@300;400;500&family=DM+Mono:wght@400;500&display=swap');
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  @keyframes fadeUp   { from { opacity:0; transform:translateY(10px); } to { opacity:1; transform:translateY(0); } }
+  @keyframes pulse    { 0%,100%{opacity:1;} 50%{opacity:0.4;} }
+  @keyframes flowDash { to { stroke-dashoffset: -24; } }
+  @keyframes flowDashFast { to { stroke-dashoffset: -16; } }
+  @keyframes nodePulse { 0%,100%{box-shadow:0 0 0 0 rgba(0,201,167,0.0);} 60%{box-shadow:0 0 0 6px rgba(0,201,167,0.10);} }
+  .fa  { animation: fadeUp 0.35s ease both; }
+  .np  { animation: nodePulse 2s ease-in-out infinite; }
+`;
+
+const C = {
+  bg:"#070810", surf:"#0d0f1a", surf2:"#111421", surf3:"#161b2e",
+  bdr:"#1c2138", bdrHi:"#2a3258",
+  teal:"#00c9a7", tealDim:"rgba(0,201,167,0.08)", tealBdr:"rgba(0,201,167,0.22)", tealGlow:"rgba(0,201,167,0.14)",
+  amber:"#f5a623", amberDim:"rgba(245,166,35,0.08)", amberBdr:"rgba(245,166,35,0.22)",
+  red:"#e05252", redDim:"rgba(224,82,82,0.08)", redBdr:"rgba(224,82,82,0.22)",
+  blue:"#4d9de0", blueDim:"rgba(77,157,224,0.08)", blueBdr:"rgba(77,157,224,0.22)",
+  violet:"#9b8cf8", violetDim:"rgba(155,140,248,0.08)", violetBdr:"rgba(155,140,248,0.22)",
+  txt:"#dde3f0", txt2:"#6b7a99", txt3:"#323c58",
+  mono:'"DM Mono","JetBrains Mono",monospace',
+  display:'"Syne",sans-serif',
+  sans:'"DM Sans",system-ui,sans-serif',
+};
+
+const sc  = v => v >= 75 ? C.teal : v >= 50 ? C.amber : C.red;
+const sbg = v => v >= 75 ? C.tealDim : v >= 50 ? C.amberDim : C.redDim;
+const sbd = v => v >= 75 ? C.tealBdr : v >= 50 ? C.amberBdr : C.redBdr;
+
+const DEV = {
+  name:"Karel van Troost", handle:"karelvantroost", role:"Engineering Coordinator · IPC", av:"KV",
+  score:84, tier:"senior", period:"2026-Q1",
+  effPRs:11, totalPRs:14, rawCommits:83, wCommits:51,
+  rawLines:4821, effLines:2190, infPct:55,
+  cid:"bafybeig7xq2m...r4p9wk", block:412847,
+  dims:[["Problem-solving depth",91],["Code quality signals",87],["Review responsiveness",82],["Consistency over time",79],["Scope of contribution",74],["Documentation habit",61]],
+  prs:[
+    { t:"Refactor auth middleware to JWT RS256", s:91, w:1.0, a:312, d:287,
+      verdict:"Identified a security vulnerability in the existing symmetric JWT implementation and migrated to asymmetric RS256. Demonstrates threat modelling and backward compatibility constraints. Net line reduction despite new test coverage is a strong positive signal." },
+    { t:"Retry logic with exponential backoff", s:78, w:1.0, a:94, d:12,
+      verdict:"Implements exponential backoff with jitter for transient failures. Solid handling of idempotency edge cases. Somewhat narrow scope but well-executed. Review feedback addressed thoughtfully." },
+    { t:"Move helpers to lib/ directory", s:4, w:0.05, a:340, d:340, flagged:true,
+      flag:"94% token overlap between source and destination",
+      verdict:"Pure relocation without modification. 94% token similarity detected. No tests added, no interfaces changed. Weight: 0.05×" },
+    { t:"Fix race condition in queue worker", s:85, w:1.0, a:61, d:44,
+      verdict:"Resolved a subtle race condition where concurrent workers could process the same job twice. Correct use of optimistic locking with appropriate TTL handling." },
+  ],
+};
+
+const BOARD = [
+  { h:"0xGameMaster", av:"GM", c:847, s:23, bad:true },
+  { h:"CodeSpammer99", av:"CS", c:612, s:31, bad:true },
+  { h:"linefiller_dev", av:"LF", c:441, s:18, bad:true },
+  { h:"karelvantroost", av:"KV", c:83, s:84, bad:false },
+  { h:"sergeyp_dev",   av:"SP", c:71,  s:89, bad:false },
+];
+
+const STEPS = [
+  { id:"fetch",  label:"Fetching GitHub data",           ms:1800, layer:0,
+    out:"GET /users/karelvantroost/repos\nGET .../commits?author=karelvantroost&since=90d\nGET .../pulls?state=closed&creator=karelvantroost\nGET .../pulls/{n}/files   ×14\nGET .../pulls/{n}/reviews ×14\n\n→ 5 repos  83 commits  14 merged PRs\n→ 31 review threads received" },
+  { id:"p0",     label:"Analysing: JWT RS256 refactor",  ms:2600, layer:0, pr:0 },
+  { id:"p1",     label:"Analysing: Retry + backoff",     ms:1800, layer:0, pr:1 },
+  { id:"p2",     label:"Analysing: Move helpers to lib/",ms:2000, layer:0, pr:2 },
+  { id:"p3",     label:"Analysing: Fix race condition",  ms:1600, layer:0, pr:3 },
+  { id:"gaming", label:"Anti-gaming detection pass",     ms:1600, layer:0,
+    out:"Scanning 14 PRs...\n\n[FLAG] PR #41: 94% token overlap → 0.05×\n[FLAG] 6 commits: formatter-only → excluded\n[FLAG] PR #38: generated schema → 0.1×\n\nRaw lines:      4,821\nEffective:      2,190\nInflation:     -55%" },
+  { id:"score",  label:"Computing weighted score",       ms:1200, layer:0,
+    out:"Weighted PR score:   81.4\nConsistency score:   79.0\n\n(0.82 × 81.4) + (0.18 × 79.0)\n= 66.7 + 14.2\n= 84   tier: senior" },
+  { id:"storage",label:"Writing evidence to IPC Storage",ms:1000, layer:1,
+    out:"POST reputation_evidence_karelvantroost_2026Q1.json\nSize: 68.4 KB   Replicas: 3/3\n\nCID: bafybeig7xq2m...r4p9wk\nStatus: confirmed ✓" },
+  { id:"chain",  label:"WASM actor: on-chain commit",    ms:2600, layer:2, f3:true },
+];
+
+const LAYERS = [
+  { id:0, label:"Off-chain agent",  sub:"GitHub API · Claude AI",       color:C.blue,   dimColor:C.blueDim,   bdrColor:C.blueBdr,
+    items:["Fetches GitHub data","Analyses PR diffs","Detects gaming patterns","Computes score"] },
+  { id:1, label:"IPC Storage",      sub:"Content-addressed · Replicated", color:C.violet, dimColor:C.violetDim, bdrColor:C.violetBdr,
+    items:["Stores evidence doc (68 KB)","Returns CID","3× replicated","Permanently retrievable"] },
+  { id:2, label:"IPC Chain",         sub:"WASM actor · F3 finality",      color:C.teal,   dimColor:C.tealDim,   bdrColor:C.tealBdr,
+    items:["Validates agent signature","Writes on-chain record","F3 consensus","Registry queryable"] },
+];
+
+const APPS = [
+  { title:"DAO governance", badge:"voting weight = score/100",
+    desc:"Contribution replaces capital as the basis for influence. Voting power proportional to verified reputation.",
+    code:"Proposal #47  quorum: 60%\nkarelvantroost  0.84× weight\nsergeyp_dev     0.89× weight\n0xGameMaster    0.23× weight",
+    q:"How would IPC reputation scores work for weighted DAO governance voting?" },
+  { title:"Bounty platform", badge:"score gates eligibility",
+    desc:"Bounties gated by minimum reputation. No KYC — the on-chain record is the credential.",
+    code:"Bounty #447 — 500 FIL\nRequired score: 70+\n\nkarelvantroost  84 → eligible\n0xGameMaster    23 → blocked",
+    q:"How would IPC reputation scores work as a gating mechanism for a web3 bounty platform?" },
+  { title:"Grant allocation", badge:"score-weighted distribution",
+    desc:"Weight FIL+ grants by contribution quality, not first-come-first-served.",
+    code:"Round 12 — 10,000 FIL pool\nAllocation = (score/total) × pool\n\nkarelvantroost  84 → 840 FIL\nsergeyp_dev     89 → 890 FIL",
+    q:"How could IPC reputation scores weight grant allocation in the Filecoin ecosystem?" },
+  { title:"Hiring credential", badge:"verifiable on-chain",
+    desc:"A portable, tamper-proof developer profile. The IPC Storage CID lets anyone audit every verdict.",
+    code:"karelvantroost  senior  84/100\nPeriod: 2026-Q1\nVerified: IPC Chain · Filecoin Calibration\nEvidence: bafybeig7xq2m...r4p9wk",
+    q:"What makes an IPC on-chain reputation score better than a GitHub profile for hiring?" },
+];
+
+const CHECKS = [
+  { l:"Content integrity", e:"keccak256(fetch(output_cid)) == result_hash", r:"0x9c3a88f2...f291a3 == 0x9c3a88f2...f291a3  ✓" },
+  { l:"Agent identity",    e:"ecrecover(result_hash, signature) == agent_address", r:"recovered 0xd8e2...9f1c == registered agent  ✓" },
+  { l:"Block timestamp",   e:"block.timestamp verified at block 412,847", r:"2026-03-17T11:24:07Z confirmed  ✓" },
+];
+
+const NAV = ["The problem","Live pipeline","Reputation profile","Audit trail","Applications"];
+
+function sendPrompt(prompt) {
+  if (typeof window === "undefined" || !prompt) return;
+  const q = encodeURIComponent(prompt);
+  window.open(`https://chatgpt.com/?q=${q}`, "_blank", "noopener,noreferrer");
+}
+
+/* ── IPC LAYER DIAGRAM ─────────────────────────────────── */
+function IPCLayerDiagram({ activeLayer, completedLayers }) {
+  // connector 0->1 flows when layer 0 done or layer 1 active
+  const flow01 = completedLayers.has(0) || activeLayer === 1;
+  const flow12 = completedLayers.has(1) || activeLayer === 2;
+
+  return (
+    <div style={{ marginBottom:14, padding:"14px 16px", background:C.surf, border:`1px solid ${C.bdr}`, borderRadius:12 }}>
+      <div style={{ fontSize:9, fontFamily:C.mono, color:C.txt3, letterSpacing:"0.1em", marginBottom:12 }}>IPC ARCHITECTURE</div>
+      <div style={{ display:"flex", alignItems:"center", gap:0 }}>
+        {LAYERS.map((l, i) => {
+          const isActive    = activeLayer === l.id;
+          const isCompleted = completedLayers.has(l.id);
+          const isLit       = isActive || isCompleted;
+          const col         = isLit ? l.color : C.txt3;
+          const bg          = isLit ? l.dimColor : "transparent";
+          const bdr         = isLit ? l.bdrColor : C.bdr;
+          const isLast      = i === LAYERS.length - 1;
+          const flowActive  = i === 0 ? flow01 : flow12;
+
+          return (
+            <div key={l.id} style={{ display:"flex", alignItems:"center", flex:1 }}>
+              {/* Node */}
+              <div className={isActive ? "np" : ""} style={{
+                flex:1, padding:"10px 12px", borderRadius:10,
+                border:`1px solid ${bdr}`,
+                background: bg,
+                transition:"all 0.5s ease",
+              }}>
+                {/* Header row */}
+                <div style={{ display:"flex", alignItems:"center", gap:7, marginBottom:7 }}>
+                  <LayerIcon id={l.id} color={col} active={isLit} />
+                  <div>
+                    <div style={{ fontSize:11.5, fontWeight:500, color: isLit ? col : C.txt2, transition:"color 0.5s", lineHeight:1.2 }}>{l.label}</div>
+                    <div style={{ fontSize:9.5, fontFamily:C.mono, color: isLit ? col+"99" : C.txt3, marginTop:1, transition:"color 0.5s" }}>{l.sub}</div>
+                  </div>
+                  {isActive && (
+                    <div style={{ marginLeft:"auto", width:6, height:6, borderRadius:"50%", background:col, animation:"pulse 1s ease-in-out infinite", flexShrink:0 }} />
+                  )}
+                  {isCompleted && (
+                    <div style={{ marginLeft:"auto", fontFamily:C.mono, fontSize:9, color:col, flexShrink:0 }}>✓</div>
+                  )}
+                </div>
+                {/* Items */}
+                <div style={{ borderTop:`1px solid ${isLit ? bdr : C.bdr}`, paddingTop:7 }}>
+                  {l.items.map((item, j) => (
+                    <div key={j} style={{ display:"flex", alignItems:"center", gap:5, marginBottom: j < l.items.length-1 ? 3 : 0 }}>
+                      <div style={{ width:4, height:4, borderRadius:"50%", flexShrink:0, background: isLit ? col : C.txt3, opacity: isLit ? 0.6 : 0.3, transition:"all 0.5s" }} />
+                      <span style={{ fontSize:10, color: isLit ? C.txt2 : C.txt3, transition:"color 0.5s" }}>{item}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Connector arrow (between nodes) */}
+              {!isLast && (
+                <div style={{ width:32, flexShrink:0, display:"flex", flexDirection:"column", alignItems:"center", gap:3 }}>
+                  <svg width="32" height="18" style={{ overflow:"visible" }}>
+                    <line x1="2" y1="9" x2="28" y2="9"
+                      stroke={flowActive ? LAYERS[i+1].color : C.bdr}
+                      strokeWidth={flowActive ? 1.5 : 1}
+                      strokeDasharray={flowActive ? "4 4" : "3 4"}
+                      style={{ transition:"stroke 0.5s",
+                        animation: flowActive ? `flowDash 0.6s linear infinite` : "none" }}
+                    />
+                    <polygon points="24,5 30,9 24,13"
+                      fill={flowActive ? LAYERS[i+1].color : C.bdr}
+                      style={{ transition:"fill 0.5s" }}
+                    />
+                  </svg>
+                  <span style={{ fontSize:8.5, fontFamily:C.mono, color: flowActive ? LAYERS[i+1].color+"88" : C.txt3, transition:"color 0.5s", letterSpacing:"0.02em" }}>
+                    {i === 0 ? "signed doc" : "CID + sig"}
+                  </span>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function LayerIcon({ id, color, active }) {
+  const dim = 24;
+  const c = active ? color : C.txt3;
+  const bg = active ? `${color}18` : C.surf2;
+  const bd = active ? `${color}40` : C.bdr;
+
+  return (
+    <div style={{ width:dim, height:dim, borderRadius:6, background:bg, border:`1px solid ${bd}`, display:"flex", alignItems:"center", justifyContent:"center", flexShrink:0, transition:"all 0.5s" }}>
+      {id === 0 && (
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+          <circle cx="6" cy="4" r="2.5" stroke={c} strokeWidth="1.2"/>
+          <path d="M1 11c0-2.76 2.24-5 5-5s5 2.24 5 5" stroke={c} strokeWidth="1.2" strokeLinecap="round"/>
+        </svg>
+      )}
+      {id === 1 && (
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+          <rect x="1.5" y="2.5" width="9" height="7" rx="1.5" stroke={c} strokeWidth="1.2"/>
+          <path d="M1.5 5h9" stroke={c} strokeWidth="1.2"/>
+          <circle cx="4" cy="3.75" r="0.6" fill={c}/>
+          <circle cx="6" cy="3.75" r="0.6" fill={c}/>
+        </svg>
+      )}
+      {id === 2 && (
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+          <polygon points="6,1 11,4 11,8 6,11 1,8 1,4" stroke={c} strokeWidth="1.2" fill="none"/>
+          <circle cx="6" cy="6" r="1.5" fill={c} opacity="0.7"/>
+        </svg>
+      )}
+    </div>
+  );
+}
+
+/* ── SHARED ───────────────────────────────────────────── */
+function Card({ children, style, glow }) {
+  return (
+    <div style={{ background:C.surf, border:`1px solid ${glow ? C.tealBdr : C.bdr}`, borderRadius:12, padding:"1rem 1.25rem", boxShadow: glow ? `0 0 28px ${C.tealGlow}` : "none", ...style }}>{children}</div>
+  );
+}
+function Badge({ children, color=C.teal, style }) {
+  return <span style={{ fontFamily:C.mono, fontSize:10, padding:"2px 7px", borderRadius:4, border:`1px solid ${color}40`, background:`${color}12`, color, letterSpacing:"0.03em", ...style }}>{children}</span>;
+}
+function ScoreChip({ score }) {
+  return <span style={{ fontFamily:C.mono, fontSize:11, fontWeight:500, padding:"2px 8px", borderRadius:4, background:sbg(score), border:`1px solid ${sbd(score)}`, color:sc(score) }}>{score}</span>;
+}
+function Btn({ children, onClick, style }) {
+  const [h, setH] = useState(false);
+  return (
+    <button onClick={onClick} onMouseEnter={() => setH(true)} onMouseLeave={() => setH(false)} style={{ fontFamily:C.sans, fontSize:12, padding:"7px 16px", borderRadius:8, border:`1px solid ${C.tealBdr}`, background: h ? C.tealDim : "transparent", color:C.teal, cursor:"pointer", transition:"background 0.15s", ...style }}>{children}</button>
+  );
+}
+
+/* ── APP ──────────────────────────────────────────────── */
+export default function App() {
+  const [scene, setScene] = useState(0);
+  const [k, setK] = useState(0);
+  function go(i) { setScene(i); setK(n => n+1); }
+  return (
+    <div style={{ background:C.bg, minHeight:"100vh", fontFamily:C.sans, color:C.txt, padding:"1.25rem" }}>
+      <style>{FONTS}</style>
+      <div style={{ display:"flex", gap:4, marginBottom:"1.5rem", flexWrap:"wrap" }}>
+        {NAV.map((l,i) => {
+          const active = scene===i, done = scene>i;
+          return <button key={i} onClick={() => go(i)} style={{ padding:"5px 14px", fontSize:11, fontFamily:C.sans, borderRadius:20, cursor:"pointer", transition:"all 0.2s", border: active ? `1px solid ${C.teal}` : done ? `1px solid ${C.tealBdr}` : `1px solid ${C.bdr}`, background: active ? C.tealDim : "transparent", color: active ? C.teal : done ? C.teal+"88" : C.txt2 }}>{done?"✓ ":`${i+1}. `}{l}</button>;
+        })}
+      </div>
+      <div key={k} className="fa">
+        {scene===0 && <Problem next={() => go(1)} />}
+        {scene===1 && <Pipeline next={() => go(2)} />}
+        {scene===2 && <Profile next={() => go(3)} />}
+        {scene===3 && <Audit next={() => go(4)} />}
+        {scene===4 && <Applications />}
+      </div>
+    </div>
+  );
+}
+
+/* ── SCENE 1: PROBLEM ─────────────────────────────────── */
+function Problem({ next }) {
+  const [show, setShow] = useState(false);
+  useEffect(() => { const t = setTimeout(() => setShow(true), 900); return () => clearTimeout(t); }, []);
+  const ipc = [...BOARD].sort((a,b) => b.s - a.s);
+  return (
+    <div>
+      <div style={{ textAlign:"center", marginBottom:"1.5rem" }}>
+        <div style={{ fontFamily:C.display, fontSize:26, color:C.txt, marginBottom:6, letterSpacing:"-0.02em" }}>The commit leaderboard is broken</div>
+        <div style={{ fontSize:13, color:C.txt2, maxWidth:480, margin:"0 auto" }}>Volume beats quality. Developers who game the system outrank developers who do real work.</div>
+      </div>
+      <div style={{ display:"grid", gridTemplateColumns:"1fr 1fr", gap:12, marginBottom:14 }}>
+        <div style={{ borderRadius:12, overflow:"hidden", border:`1px solid ${C.redBdr}` }}>
+          <div style={{ padding:"9px 14px", background:C.redDim, borderBottom:`1px solid ${C.redBdr}`, fontSize:10, fontWeight:500, color:C.red, fontFamily:C.mono, letterSpacing:"0.08em" }}>GITHUB — RANKED BY RAW COMMITS</div>
+          {BOARD.map((d,i) => (
+            <div key={d.h} style={{ display:"flex", alignItems:"center", gap:9, padding:"9px 14px", borderBottom:i<BOARD.length-1?`1px solid ${C.bdr}`:"none", background:d.bad?C.redDim:"transparent" }}>
+              <span style={{ fontSize:10, color:C.txt3, fontFamily:C.mono, width:14, flexShrink:0 }}>#{i+1}</span>
+              <div style={{ width:28, height:28, borderRadius:"50%", flexShrink:0, background:d.bad?C.redDim:C.tealDim, display:"flex", alignItems:"center", justifyContent:"center", fontSize:9, fontWeight:500, color:d.bad?C.red:C.teal, border:`1px solid ${d.bad?C.redBdr:C.tealBdr}`, fontFamily:C.mono }}>{d.av}</div>
+              <span style={{ flex:1, fontSize:11.5, color:d.bad?C.red:C.txt }}>@{d.h}</span>
+              <span style={{ fontFamily:C.mono, fontSize:12, color:d.bad?C.red:C.txt }}>{d.c}</span>
+              {d.bad && <Badge color={C.red}>GAMED</Badge>}
+            </div>
+          ))}
+        </div>
+        <div style={{ borderRadius:12, overflow:"hidden", border:`1px solid ${show?C.tealBdr:C.bdr}`, opacity:show?1:0.1, transition:"all 1s ease", boxShadow:show?`0 0 32px ${C.tealGlow}`:"none" }}>
+          <div style={{ padding:"9px 14px", background:show?C.tealDim:C.surf2, borderBottom:`1px solid ${show?C.tealBdr:C.bdr}`, fontSize:10, fontWeight:500, color:show?C.teal:C.txt2, fontFamily:C.mono, letterSpacing:"0.08em", transition:"all 1s" }}>IPC REPUTATION — VERIFIED AI SCORE</div>
+          {ipc.map((d,i) => (
+            <div key={d.h} style={{ display:"flex", alignItems:"center", gap:9, padding:"9px 14px", borderBottom:i<ipc.length-1?`1px solid ${C.bdr}`:"none" }}>
+              <span style={{ fontSize:10, color:C.txt3, fontFamily:C.mono, width:14, flexShrink:0 }}>#{i+1}</span>
+              <div style={{ width:28, height:28, borderRadius:"50%", flexShrink:0, background:C.tealDim, display:"flex", alignItems:"center", justifyContent:"center", fontSize:9, fontWeight:500, color:C.teal, border:`1px solid ${C.tealBdr}`, fontFamily:C.mono }}>{d.av}</div>
+              <span style={{ flex:1, fontSize:11.5 }}>@{d.h}</span>
+              <span style={{ fontFamily:C.mono, fontSize:14, fontWeight:500, color:sc(d.s) }}>{d.s}</span>
+              <span style={{ fontSize:10, color:C.txt3 }}>/100</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      {show && (
+        <div style={{ padding:"11px 16px", background:C.surf2, borderRadius:10, borderLeft:`3px solid ${C.teal}`, marginBottom:14, fontSize:12.5, color:C.txt2, lineHeight:1.7 }} className="fa">
+          <span style={{ color:C.red, fontFamily:C.mono }}>0xGameMaster</span> has 847 commits and an IPC score of <span style={{ color:C.red, fontFamily:C.mono }}>23</span>.&nbsp;
+          <span style={{ color:C.teal, fontFamily:C.mono }}>karelvantroost</span> has 83 commits and a score of <span style={{ color:C.teal, fontFamily:C.mono }}>84</span>. The IPC agent reads the actual diff — it can tell the difference between moving files around and writing real code.
+        </div>
+      )}
+      <div style={{ display:"flex", justifyContent:"flex-end" }}><Btn onClick={next}>Watch IPC score a developer →</Btn></div>
+    </div>
+  );
+}
+
+/* ── SCENE 2: PIPELINE ────────────────────────────────── */
+function Pipeline({ next }) {
+  const [step, setStep]     = useState(-1);
+  const [done, setDone]     = useState(new Set());
+  const [running, setRun]   = useState(false);
+  const [f3t, setF3t]       = useState(0);
+  const [f3fin, setF3fin]   = useState(false);
+  const tm  = useRef(null);
+  const f3r = useRef(null);
+  const allDone = done.has(STEPS.length - 1);
+
+  // Derive which layer is currently active and which are completed
+  const curLayer = step >= 0 && step < STEPS.length ? STEPS[step].layer : -1;
+  const completedLayers = new Set();
+  STEPS.forEach((s, i) => { if (done.has(i)) completedLayers.add(s.layer); });
+  // A layer is only "completed" if ALL its steps are done
+  const layerComplete = new Set();
+  [0,1,2].forEach(lid => {
+    const layerSteps = STEPS.map((s,i) => ({s,i})).filter(({s}) => s.layer === lid);
+    if (layerSteps.every(({i}) => done.has(i))) layerComplete.add(lid);
+  });
+
+  function start() { setRun(true); setStep(0); }
+
+  useEffect(() => {
+    if (!running || step < 0 || step >= STEPS.length) return;
+    tm.current = setTimeout(() => {
+      setDone(p => new Set([...p, step]));
+      if (step + 1 < STEPS.length) setStep(step + 1); else setRun(false);
+    }, STEPS[step].ms);
+    return () => clearTimeout(tm.current);
+  }, [step, running]);
+
+  useEffect(() => {
+    if (!running || step !== STEPS.length - 1) return;
+    let t = 0;
+    f3r.current = setInterval(() => {
+      t = parseFloat(Math.min(t + 0.1, 2.4).toFixed(1));
+      setF3t(t);
+      if (t >= 2.4) { clearInterval(f3r.current); setF3fin(true); }
+    }, 70);
+    return () => clearInterval(f3r.current);
+  }, [step, running]);
+
+  const curS  = step >= 0 && step < STEPS.length ? STEPS[step] : null;
+  const curPR = curS && curS.pr !== undefined ? DEV.prs[curS.pr] : null;
+  const activeLayer = running || allDone ? curLayer : -1;
+
+  return (
+    <div>
+      {/* IPC Architecture diagram — always visible, lights up as pipeline progresses */}
+      <IPCLayerDiagram activeLayer={activeLayer} completedLayers={layerComplete} />
+
+      {/* Stepper + output */}
+      <div style={{ display:"grid", gridTemplateColumns:"200px 1fr", gap:14 }}>
+        <div>
+          <div style={{ fontSize:9, color:C.txt3, fontFamily:C.mono, letterSpacing:"0.06em", padding:"0 4px", marginBottom:10 }}>@KARELVANTROOST</div>
+          {STEPS.map((s,i) => {
+            const isDone = done.has(i), isActive = i===step && !isDone && running;
+            const layerCol = LAYERS[s.layer].color;
+            return (
+              <div key={s.id} style={{ display:"flex", alignItems:"center", gap:8, padding:"5px 8px", borderRadius:8, background:isActive ? `${layerCol}10` : "transparent", marginBottom:1, border:isActive ? `1px solid ${layerCol}30` : "1px solid transparent" }}>
+                <div style={{ width:15, height:15, borderRadius:"50%", flexShrink:0, border:`1px solid ${isDone ? layerCol : isActive ? layerCol : C.bdrHi}`, background:isDone ? layerCol : "transparent", display:"flex", alignItems:"center", justifyContent:"center", fontSize:8, color:isDone ? C.bg : layerCol, fontFamily:C.mono, animation:isActive ? "pulse 1s ease-in-out infinite" : "none" }}>
+                  {isDone ? "✓" : ""}
+                </div>
+                <span style={{ fontSize:10, lineHeight:1.35, color:isDone ? layerCol : isActive ? layerCol : C.txt3 }}>{s.label}</span>
+              </div>
+            );
+          })}
+        </div>
+
+        <div>
+          <div style={{ background:C.surf, border:`1px solid ${C.bdr}`, borderRadius:12, padding:14, minHeight:200, display:"flex", flexDirection:"column" }}>
+            {!running && step < 0 ? (
+              <div style={{ flex:1, display:"flex", flexDirection:"column", alignItems:"center", justifyContent:"center", gap:12 }}>
+                <div style={{ fontFamily:C.mono, fontSize:11, color:C.txt2 }}>Ready to analyse @karelvantroost</div>
+                <Btn onClick={start}>Run pipeline →</Btn>
+              </div>
+            ) : curS ? <StepOut step={curS} pr={curPR} f3t={f3t} f3fin={f3fin} /> : null}
+          </div>
+          {allDone && (
+            <div style={{ display:"flex", justifyContent:"flex-end", marginTop:10 }} className="fa">
+              <Btn onClick={next}>View reputation profile →</Btn>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StepOut({ step, pr, f3t, f3fin }) {
+  if (step.f3) return (
+    <div style={{ display:"flex", flexDirection:"column" }}>
+      <pre style={{ fontFamily:C.mono, fontSize:10.5, lineHeight:1.9, color:C.txt2, whiteSpace:"pre-wrap", marginBottom:16 }}>{`ReputationRegistry.setScore({\n  developer:    "0xd8e2...9f1c",\n  score:        84,\n  tier:         "senior",\n  evidence_cid: "bafybeig7xq2m...r4p9wk",\n  period:       "2026-Q1"\n})`}</pre>
+      <div style={{ textAlign:"center", padding:"10px 0" }}>
+        <div style={{ fontFamily:C.mono, fontSize:9, color:C.txt3, letterSpacing:"0.1em", marginBottom:8 }}>F3 FAST FINALITY</div>
+        <div style={{ fontFamily:C.display, fontSize:60, lineHeight:1, color:f3fin ? C.teal : C.txt, transition:"color 0.5s", marginBottom:12 }}>{f3t.toFixed(1)}s</div>
+        {f3fin
+          ? <Badge>FINALIZED ✓</Badge>
+          : <span style={{ fontSize:11, color:C.txt3, fontFamily:C.mono }}>waiting for F3 consensus...</span>}
+      </div>
+    </div>
+  );
+  if (pr) return (
+    <div style={{ border:`1px solid ${pr.flagged ? C.amberBdr : C.bdrHi}`, borderRadius:10, padding:"12px 14px", background:pr.flagged ? C.amberDim : C.surf2 }}>
+      <div style={{ display:"flex", justifyContent:"space-between", alignItems:"flex-start", gap:10, marginBottom:6 }}>
+        <span style={{ fontSize:13, fontWeight:500, lineHeight:1.35, color:C.txt }}>{pr.t}</span>
+        <ScoreChip score={pr.s} />
+      </div>
+      <div style={{ fontFamily:C.mono, fontSize:10, color:C.txt2, marginBottom:pr.flagged ? 8 : 10 }}>+{pr.a} −{pr.d} &nbsp;·&nbsp; weight {pr.w}×</div>
+      {pr.flagged && <div style={{ fontFamily:C.mono, fontSize:10.5, color:C.amber, background:C.amberDim, border:`1px solid ${C.amberBdr}`, borderRadius:6, padding:"5px 10px", marginBottom:10 }}>⚠ FLAGGED: {pr.flag}</div>}
+      <div style={{ fontSize:11.5, color:C.txt2, lineHeight:1.6, borderLeft:`2px solid ${pr.flagged ? C.amberBdr : C.tealBdr}`, paddingLeft:10, fontStyle:"italic" }}>{pr.verdict}</div>
+    </div>
+  );
+  return <pre style={{ fontFamily:C.mono, fontSize:10.5, lineHeight:1.9, color:C.txt2, whiteSpace:"pre-wrap" }}>{step.out}</pre>;
+}
+
+/* ── SCENE 3: PROFILE ─────────────────────────────────── */
+function Profile({ next }) {
+  const [disp, setDisp] = useState(0);
+  const [bars, setBars] = useState(false);
+  const size=140, stroke=8, r=(size-stroke)/2, circ=2*Math.PI*r;
+  useEffect(() => {
+    let n = 0;
+    const id = setInterval(() => {
+      n = Math.min(n+1.6, DEV.score); setDisp(Math.round(n));
+      if (n >= DEV.score) { clearInterval(id); setTimeout(() => setBars(true), 200); }
+    }, 18);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div>
+      <Card style={{ marginBottom:12 }}>
+        <div style={{ display:"flex", alignItems:"center", gap:16, paddingBottom:16, marginBottom:16, borderBottom:`1px solid ${C.bdr}` }}>
+          <div style={{ position:"relative", flexShrink:0 }}>
+            <svg width={size} height={size} style={{ transform:"rotate(-90deg)" }}>
+              <circle cx={size/2} cy={size/2} r={r} fill="none" stroke={C.bdr} strokeWidth={stroke} />
+              <circle cx={size/2} cy={size/2} r={r} fill="none" stroke={sc(disp)} strokeWidth={stroke} strokeDasharray={circ} strokeDashoffset={circ*(1-disp/100)} strokeLinecap="round" style={{ transition:"stroke-dashoffset 0.05s linear, stroke 0.5s" }} />
+            </svg>
+            <div style={{ position:"absolute", inset:0, display:"flex", flexDirection:"column", alignItems:"center", justifyContent:"center" }}>
+              <div style={{ fontFamily:C.display, fontSize:36, lineHeight:1, color:sc(disp) }}>{disp}</div>
+              <div style={{ fontSize:9, color:C.txt2, fontFamily:C.mono, marginTop:2 }}>/ 100</div>
+            </div>
+          </div>
+          <div style={{ flex:1 }}>
+            <div style={{ fontFamily:C.display, fontSize:22, color:C.txt, letterSpacing:"-0.02em", marginBottom:2 }}>{DEV.name}</div>
+            <div style={{ fontSize:12, color:C.txt2, marginBottom:10 }}>{DEV.role}</div>
+            <div style={{ display:"flex", gap:6, flexWrap:"wrap" }}>
+              <Badge>{DEV.tier}</Badge>
+              <Badge color={C.txt2}>{DEV.period}</Badge>
+              <Badge color={C.txt2}>block {DEV.block.toLocaleString()}</Badge>
+            </div>
+          </div>
+        </div>
+        <div style={{ display:"grid", gridTemplateColumns:"repeat(4,minmax(0,1fr))", gap:8, marginBottom:16 }}>
+          {[["Effective PRs",`${DEV.effPRs}/${DEV.totalPRs}`],["Weighted commits",`${DEV.wCommits}/${DEV.rawCommits}`],["Inflation removed",`${DEV.infPct}%`],["IPC Storage CID",DEV.cid]].map(([l,v]) => (
+            <div key={l} style={{ background:C.surf2, borderRadius:8, padding:"9px 11px", border:`1px solid ${C.bdr}` }}>
+              <div style={{ fontSize:10, color:C.txt2, marginBottom:5 }}>{l}</div>
+              <div style={{ fontFamily:C.mono, fontSize:11.5, fontWeight:500, wordBreak:"break-all", color:C.txt }}>{v}</div>
+            </div>
+          ))}
+        </div>
+        <div style={{ marginBottom:16 }}>
+          {DEV.dims.map(([l,s]) => (
+            <div key={l} style={{ display:"flex", alignItems:"center", gap:10, marginBottom:7 }}>
+              <span style={{ fontSize:11, color:C.txt2, width:188, flexShrink:0 }}>{l}</span>
+              <div style={{ flex:1, height:4, background:C.surf3, borderRadius:2, overflow:"hidden" }}>
+                <div style={{ height:"100%", borderRadius:2, background:sc(s), width:bars?s+"%":"0%", transition:"width 1.1s cubic-bezier(0.16,1,0.3,1)" }} />
+              </div>
+              <span style={{ fontFamily:C.mono, fontSize:11, fontWeight:500, color:sc(s), width:24, textAlign:"right" }}>{s}</span>
+            </div>
+          ))}
+        </div>
+        <div style={{ borderTop:`1px solid ${C.bdr}`, paddingTop:12 }}>
+          {DEV.prs.map((pr,i) => (
+            <div key={i} style={{ display:"flex", justifyContent:"space-between", alignItems:"center", padding:"7px 0", borderBottom:i<DEV.prs.length-1?`1px solid ${C.bdr}`:"none" }}>
+              <span style={{ fontSize:11.5, color:pr.flagged?C.amber:C.txt, flex:1, overflow:"hidden", textOverflow:"ellipsis", whiteSpace:"nowrap", marginRight:12 }}>{pr.flagged?"⚠ ":""}{pr.t}</span>
+              <div style={{ display:"flex", alignItems:"center", gap:8, flexShrink:0 }}>
+                <span style={{ fontFamily:C.mono, fontSize:10, color:C.txt3 }}>+{pr.a}/−{pr.d}</span>
+                <ScoreChip score={pr.s} />
+                <span style={{ fontFamily:C.mono, fontSize:9.5, color:C.txt3 }}>{pr.w}×</span>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div style={{ marginTop:12, paddingTop:12, borderTop:`1px solid ${C.bdr}`, display:"flex", justifyContent:"space-between", alignItems:"center" }}>
+          <span style={{ fontFamily:C.mono, fontSize:10, color:C.txt3 }}>F3 finalized · IPC Chain · Filecoin Calibration</span>
+          <span style={{ fontFamily:C.mono, fontSize:10, color:C.teal+"88" }}>{DEV.cid}</span>
+        </div>
+      </Card>
+      <div style={{ display:"flex", justifyContent:"flex-end" }}><Btn onClick={next}>Verify the evidence →</Btn></div>
+    </div>
+  );
+}
+
+/* ── SCENE 4: AUDIT ───────────────────────────────────── */
+function Audit({ next }) {
+  const [states, setStates] = useState(["idle","idle","idle"]);
+  const [done, setDone]     = useState(false);
+  function run() {
+    if (done || states[0] !== "idle") return;
+    CHECKS.forEach((_,i) => {
+      setTimeout(() => {
+        setStates(p => { const n=[...p]; n[i]="run"; return n; });
+        setTimeout(() => {
+          setStates(p => { const n=[...p]; n[i]="ok"; return n; });
+          if (i===2) setDone(true);
+        }, 700 + Math.random()*300);
+      }, i*1000);
+    });
+  }
+  return (
+    <div>
+      <div style={{ fontSize:12.5, color:C.txt2, lineHeight:1.75, marginBottom:14 }}>Three independent cryptographic checks. Anyone can run them — no trusted party required. The math either checks out or it doesn't.</div>
+      {states[0]==="idle" && <Btn onClick={run} style={{ width:"100%", marginBottom:14, textAlign:"center" }}>Run verification →</Btn>}
+      {CHECKS.map((c,i) => {
+        const st = states[i];
+        return (
+          <div key={i} style={{ display:"flex", alignItems:"flex-start", gap:12, padding:"12px 14px", marginBottom:8, borderRadius:10, border:`1px solid ${st==="ok"?C.tealBdr:st==="run"?C.amberBdr:C.bdr}`, background:st==="ok"?C.tealDim:st==="run"?C.amberDim:C.surf, transition:"all 0.35s" }}>
+            <div style={{ width:20, height:20, borderRadius:"50%", flexShrink:0, marginTop:1, border:`1px solid ${st==="ok"?C.teal:st==="run"?C.amber:C.bdrHi}`, background:st==="ok"?C.teal:"transparent", display:"flex", alignItems:"center", justifyContent:"center", fontSize:10, color:st==="ok"?C.bg:C.txt3, animation:st==="run"?"pulse 0.8s ease-in-out infinite":"none" }}>
+              {st==="ok"?"✓":""}
+            </div>
+            <div>
+              <div style={{ fontSize:13.5, fontWeight:500, marginBottom:4, color:C.txt }}>{c.l}</div>
+              <div style={{ fontFamily:C.mono, fontSize:10.5, color:st==="ok"?C.teal:C.txt2, lineHeight:1.5 }}>{st==="ok"?c.r:c.e}</div>
+            </div>
+          </div>
+        );
+      })}
+      {done && (
+        <div className="fa">
+          <div style={{ padding:"12px 16px", background:C.tealDim, border:`1px solid ${C.tealBdr}`, borderRadius:10, textAlign:"center", fontFamily:C.mono, fontSize:12, color:C.teal, marginBottom:12, letterSpacing:"0.03em" }}>ALL CHECKS PASSED — RECORD CRYPTOGRAPHICALLY VERIFIED</div>
+          <div style={{ display:"flex", justifyContent:"flex-end" }}><Btn onClick={next}>See what this enables →</Btn></div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── SCENE 5: APPLICATIONS ────────────────────────────── */
+function Applications() {
+  return (
+    <div>
+      <div style={{ fontSize:12.5, color:C.txt2, lineHeight:1.75, marginBottom:14 }}>
+        Any contract on IPC can now call <span style={{ fontFamily:C.mono, fontSize:11, color:C.teal }}>ReputationRegistry.getScore(address)</span> and get a trustless, auditable developer score. Four things that become immediately possible:
+      </div>
+      <div style={{ display:"grid", gridTemplateColumns:"1fr 1fr", gap:10 }}>
+        {APPS.map((a,i) => (
+          <div key={i} style={{ background:C.surf, border:`1px solid ${C.bdr}`, borderRadius:12, padding:"14px 16px", display:"flex", flexDirection:"column", gap:10, transition:"border-color 0.2s" }}
+            onMouseEnter={e => e.currentTarget.style.borderColor=C.tealBdr}
+            onMouseLeave={e => e.currentTarget.style.borderColor=C.bdr}>
+            <div>
+              <div style={{ fontFamily:C.display, fontSize:16, color:C.txt, letterSpacing:"-0.01em", marginBottom:5 }}>{a.title}</div>
+              <div style={{ fontSize:12, color:C.txt2, lineHeight:1.6 }}>{a.desc}</div>
+            </div>
+            <pre style={{ fontFamily:C.mono, fontSize:10, color:C.txt2, background:C.surf2, borderRadius:8, padding:"9px 11px", lineHeight:1.85, border:`1px solid ${C.bdr}`, whiteSpace:"pre-wrap" }}>{a.code}</pre>
+            <div style={{ display:"flex", justifyContent:"space-between", alignItems:"center" }}>
+              <Badge>{a.badge}</Badge>
+              <button onClick={() => sendPrompt(a.q)} style={{ fontFamily:C.sans, fontSize:11, padding:"4px 10px", borderRadius:6, border:`1px solid ${C.tealBdr}`, background:"transparent", color:C.teal, cursor:"pointer", transition:"all 0.15s" }}
+                onMouseEnter={e => e.currentTarget.style.background=C.tealDim}
+                onMouseLeave={e => e.currentTarget.style.background="transparent"}>Explore this ↗</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/demos/index.html
+++ b/demos/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>IPC Demos</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/demos/package.json
+++ b/demos/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ipc-demos",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "vite": "^5.4.10"
+  }
+}

--- a/demos/pnpm-lock.yaml
+++ b/demos/pnpm-lock.yaml
@@ -1,0 +1,1026 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@vitejs/plugin-react':
+        specifier: ^4.3.1
+        version: 4.7.0(vite@5.4.21)
+      vite:
+        specifier: ^5.4.10
+        version: 5.4.21
+
+packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.0':
+    resolution: {integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.0':
+    resolution: {integrity: sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.0':
+    resolution: {integrity: sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.0':
+    resolution: {integrity: sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.0':
+    resolution: {integrity: sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.0':
+    resolution: {integrity: sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
+    resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
+    resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.0':
+    resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.0':
+    resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.0':
+    resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.0':
+    resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
+    resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.0':
+    resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
+    resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.0':
+    resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.0':
+    resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.0':
+    resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.0':
+    resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.0':
+    resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.0':
+    resolution: {integrity: sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.0':
+    resolution: {integrity: sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.0':
+    resolution: {integrity: sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.0':
+    resolution: {integrity: sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.0':
+    resolution: {integrity: sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  baseline-browser-mapping@2.10.11:
+    resolution: {integrity: sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.1:
+    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001781:
+    resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  electron-to-chromium@1.5.328:
+    resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.36:
+    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.60.0:
+    resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.1
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.0':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/estree@1.0.8': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 5.4.21
+    transitivePeerDependencies:
+      - supports-color
+
+  baseline-browser-mapping@2.10.11: {}
+
+  browserslist@4.28.1:
+    dependencies:
+      baseline-browser-mapping: 2.10.11
+      caniuse-lite: 1.0.30001781
+      electron-to-chromium: 1.5.328
+      node-releases: 2.0.36
+      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  caniuse-lite@1.0.30001781: {}
+
+  convert-source-map@2.0.0: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  electron-to-chromium@1.5.328: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  escalade@3.2.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  node-releases@2.0.36: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-refresh@0.17.0: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  rollup@4.60.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.0
+      '@rollup/rollup-android-arm64': 4.60.0
+      '@rollup/rollup-darwin-arm64': 4.60.0
+      '@rollup/rollup-darwin-x64': 4.60.0
+      '@rollup/rollup-freebsd-arm64': 4.60.0
+      '@rollup/rollup-freebsd-x64': 4.60.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.0
+      '@rollup/rollup-linux-arm64-gnu': 4.60.0
+      '@rollup/rollup-linux-arm64-musl': 4.60.0
+      '@rollup/rollup-linux-loong64-gnu': 4.60.0
+      '@rollup/rollup-linux-loong64-musl': 4.60.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.0
+      '@rollup/rollup-linux-ppc64-musl': 4.60.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.0
+      '@rollup/rollup-linux-riscv64-musl': 4.60.0
+      '@rollup/rollup-linux-s390x-gnu': 4.60.0
+      '@rollup/rollup-linux-x64-gnu': 4.60.0
+      '@rollup/rollup-linux-x64-musl': 4.60.0
+      '@rollup/rollup-openbsd-x64': 4.60.0
+      '@rollup/rollup-openharmony-arm64': 4.60.0
+      '@rollup/rollup-win32-arm64-msvc': 4.60.0
+      '@rollup/rollup-win32-ia32-msvc': 4.60.0
+      '@rollup/rollup-win32-x64-gnu': 4.60.0
+      '@rollup/rollup-win32-x64-msvc': 4.60.0
+      fsevents: 2.3.3
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  semver@6.3.1: {}
+
+  source-map-js@1.2.1: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.1):
+    dependencies:
+      browserslist: 4.28.1
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite@5.4.21:
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.8
+      rollup: 4.60.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  yallist@3.1.1: {}

--- a/demos/sp-analysis-web/ipc_compute.html
+++ b/demos/sp-analysis-web/ipc_compute.html
@@ -1,0 +1,809 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+<title>IPC Compute</title>
+<script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=DM+Sans:wght@300;400;500&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet"/>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body, #root { height: 100%; font-family: 'DM Sans', system-ui, sans-serif; }
+  body { background: #070810; color: #dde3f0; }
+  @keyframes fadeUp   { from{opacity:0;transform:translateY(6px)} to{opacity:1;transform:translateY(0)} }
+  @keyframes fadeIn   { from{opacity:0} to{opacity:1} }
+  @keyframes pulse    { 0%,100%{opacity:1} 50%{opacity:0.3} }
+  @keyframes spin     { to{transform:rotate(360deg)} }
+  @keyframes slideIn  { from{opacity:0;transform:translateX(10px)} to{opacity:1;transform:translateX(0)} }
+  @keyframes ticker   { 0%{opacity:1} 50%{opacity:0.4} 100%{opacity:1} }
+  .fa { animation: fadeUp 0.25s ease both; }
+  .fi { animation: fadeIn 0.2s ease both; }
+  .si { animation: slideIn 0.25s ease both; }
+  input, textarea, select { font-family: inherit; background: transparent; border: none; outline: none; color: inherit; }
+  input[type=range] { cursor: pointer; accent-color: #00c9a7; }
+  textarea { resize: vertical; }
+  button { font-family: inherit; cursor: pointer; }
+  ::-webkit-scrollbar { width: 4px; height: 4px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: #1c2138; border-radius: 2px; }
+  ::selection { background: rgba(0,201,167,0.25); }
+  select option { background: #0d0f1a; color: #dde3f0; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+const { useState, useEffect, useRef, useCallback } = React;
+
+const C = {
+  bg:"#070810", surf:"#0d0f1a", surf2:"#111421", surf3:"#161b2e",
+  bdr:"#1c2138", bdrHi:"#2a3258",
+  teal:"#00c9a7", tealDim:"rgba(0,201,167,0.08)", tealBdr:"rgba(0,201,167,0.22)", tealGlow:"rgba(0,201,167,0.14)",
+  amber:"#f5a623", amberDim:"rgba(245,166,35,0.08)", amberBdr:"rgba(245,166,35,0.22)", amberGlow:"rgba(245,166,35,0.10)",
+  violet:"#9b8cf8", violetDim:"rgba(155,140,248,0.08)", violetBdr:"rgba(155,140,248,0.22)",
+  red:"#e05252", redDim:"rgba(224,82,82,0.08)", redBdr:"rgba(224,82,82,0.22)",
+  txt:"#dde3f0", txt2:"#6b7a99", txt3:"#323c58",
+  mono:'"DM Mono","Fira Code",monospace',
+  display:'"Syne",sans-serif',
+  sans:'"DM Sans",system-ui,sans-serif',
+};
+
+const MODELS = [
+  { id:"meta-llama/Llama-3.1-8B-Instruct", label:"Llama 3.1 8B Instruct", ppt:0.0002 },
+  { id:"mistralai/Mistral-7B-Instruct",    label:"Mistral 7B Instruct",    ppt:0.00015 },
+  { id:"microsoft/Phi-3-mini-4k",          label:"Phi-3 Mini 4k",          ppt:0.00010 },
+];
+
+const DEFAULT_PROMPT = `You are a data analyst. Your goal is to identify the most reliable Filecoin Storage Providers — those with a strong track record of consistent uptime, sector maintenance, and deal fulfilment.
+
+Save your final report to report.md containing:
+- Brief methodology note (which APIs, which signals, how scored)
+- Ranked table of top 15 most reliable SPs
+- 2–3 paragraph summary of what distinguishes the top performers`;
+
+const CHAIN_ID = 314159;
+const MOCK_BALANCE = 2.40;
+
+// ── WALLET MODE ──────────────────────────────────────────────────────────
+// Set to false to use a mock wallet (no MetaMask required) — good for demos.
+// Set to true to require real MetaMask connection + EIP-712 signing.
+const USE_REAL_WALLET = false;
+const MOCK_ADDRESS = "0xd8e29f1c3a5b7e4c2a1b9f3d7e5c8a2b4f6d9e1c";
+// ────────────────────────────────────────────────────────────────────────
+
+const REPORT_TABLE = [
+  { rank:1,  id:"f0116628",  score:106.99, uptime:96.2, deals:106,  power:"6.69 PiB" },
+  { rank:2,  id:"f0149768",  score:105.92, uptime:95.8, deals:83,   power:"2.00 PiB" },
+  { rank:3,  id:"f01393827", score:104.93, uptime:100,  deals:7,    power:"0.98 PiB" },
+  { rank:4,  id:"f0134991",  score:104.55, uptime:89.2, deals:47,   power:"6.63 PiB" },
+  { rank:5,  id:"f03339",    score:103.57, uptime:89.6, deals:941,  power:"1.08 PiB" },
+  { rank:6,  id:"f065103",   score:103.50, uptime:88.8, deals:86,   power:"2.16 PiB" },
+  { rank:7,  id:"f0230200",  score:103.46, uptime:92.3, deals:39,   power:"0.72 PiB" },
+  { rank:8,  id:"f01690643", score:103.03, uptime:100,  deals:675,  power:"0.34 PiB" },
+  { rank:9,  id:"f01694564", score:102.92, uptime:100,  deals:212,  power:"0.31 PiB" },
+  { rank:10, id:"f044160",   score:102.84, uptime:93.8, deals:1268, power:"0.34 PiB" },
+  { rank:11, id:"f01690774", score:102.82, uptime:100,  deals:706,  power:"0.27 PiB" },
+  { rank:12, id:"f018501",   score:102.80, uptime:94.9, deals:461,  power:"0.19 PiB" },
+  { rank:13, id:"f01652952", score:102.70, uptime:100,  deals:757,  power:"0.23 PiB" },
+  { rank:14, id:"f01690781", score:102.69, uptime:100,  deals:953,  power:"0.23 PiB" },
+  { rank:15, id:"f0121768",  score:102.66, uptime:90.4, deals:14,   power:"5.05 PiB" },
+];
+
+const MOCK_JOBS_INIT = [
+  { id:"job_8f2a1c", prompt:DEFAULT_PROMPT, model:"meta-llama/Llama-3.1-8B-Instruct", maxTokens:2048, temperature:0.3, status:"completed", submittedAt:Date.now()-1000*60*47, completedAt:Date.now()-1000*60*46, worker:"val-2.ipc-fil.io", txHash:"0x4a3f8b2e1c9d7e5f3a2b1c8d4e9f7a3b", resultTxHash:"0x9c1b7d3a4e8f2c5b1a9d7e3f8b4a2c6d", cid:"bafybeig7xq2m...r4p9wk", block:412847, tokensUsed:1842, cost:0.368, hasReport:true, sig:"0x7f3c8a...d4a21d" },
+  { id:"job_3d9e7f", prompt:"Summarise Filecoin network storage statistics for Q1 2026. Include total network capacity, active deals, average deal duration, and top storage regions.", model:"mistralai/Mistral-7B-Instruct", maxTokens:1024, temperature:0.5, status:"completed", submittedAt:Date.now()-1000*60*60*3, completedAt:Date.now()-1000*60*60*3+14000, worker:"val-1.ipc-fil.io", txHash:"0x2e8c4a1b9f7d3e5c2a8b4f9d7e1c3a5b", resultTxHash:"0x5b1a9c7e3f2d8b4a1e9f7c3b5d2a8e4c", cid:"bafybeid9m3kx7p...w2n5vq", block:411203, tokensUsed:891, cost:0.134, hasReport:false, sig:"0x3a1b...e82c" },
+  { id:"job_1a4b8c", prompt:"Analyse the top 10 Filecoin miners by sector count and compute a reliability composite score based on WindowPoSt success rate.", model:"meta-llama/Llama-3.1-8B-Instruct", maxTokens:4096, temperature:0.2, status:"failed", submittedAt:Date.now()-1000*60*60*8, worker:"val-3.ipc-fil.io", txHash:"0x7f3c8a2e4b1d9f5c7a3b2e8d4c1f9a5b", resultTxHash:null, cid:null, block:408991, tokensUsed:0, cost:0, error:"Container timeout after 300s", hasReport:false, sig:"0x9d2e...f14b" },
+];
+
+function timeAgo(ts) {
+  if (!ts) return "—";
+  const m = Math.floor((Date.now()-ts)/60000);
+  const h = Math.floor(m/60);
+  if (m<1) return "just now";
+  if (m<60) return m+"m ago";
+  if (h<24) return h+"h ago";
+  return Math.floor(h/24)+"d ago";
+}
+function trunc(s, n=6) { if(!s)return"—"; return s.length>n*2+3?s.slice(0,n)+"..."+s.slice(-n):s; }
+function jobId() { return "job_"+Math.random().toString(36).slice(2,8); }
+function mockTx() { return "0x"+Array.from({length:32},()=>Math.floor(Math.random()*16).toString(16)).join(""); }
+function estimateCost(tokens, modelId) {
+  const m = MODELS.find(x=>x.id===modelId)||MODELS[0];
+  return (tokens*m.ppt).toFixed(3);
+}
+
+/* ── SHARED ───────────────────────── */
+function Badge({ children, color=C.teal, style={} }) {
+  return <span style={{ fontFamily:C.mono, fontSize:10, padding:"2px 7px", borderRadius:4, border:`1px solid ${color}40`, background:`${color}12`, color, letterSpacing:"0.03em", ...style }}>{children}</span>;
+}
+
+function Btn({ children, onClick, disabled, variant="default", size="md", style={} }) {
+  const [h,setH]=useState(false);
+  const col = variant==="primary"?C.teal:variant==="amber"?C.amber:variant==="danger"?C.red:C.teal;
+  const sz = size==="sm"?{fontSize:11,padding:"5px 11px"}:size==="lg"?{fontSize:13,padding:"10px 22px"}:{fontSize:12,padding:"7px 15px"};
+  return (
+    <button onClick={onClick} disabled={disabled}
+      onMouseEnter={()=>setH(true)} onMouseLeave={()=>setH(false)}
+      style={{ fontFamily:C.sans, borderRadius:8, border:`1px solid ${col}44`, background:disabled?"transparent":h?`${col}18`:"transparent", color:disabled?C.txt3:col, cursor:disabled?"not-allowed":"pointer", transition:"all 0.15s", ...sz, ...style }}>
+      {children}
+    </button>
+  );
+}
+
+function Spinner({ size=14, color=C.teal }) {
+  return <div style={{ width:size, height:size, borderRadius:"50%", border:`1.5px solid ${color}30`, borderTop:`1.5px solid ${color}`, animation:"spin 0.7s linear infinite", flexShrink:0, display:"inline-block" }}/>;
+}
+
+function StatusChip({ status }) {
+  const map = { queued:{label:"queued",color:C.txt2}, picked_up:{label:"picked up",color:C.amber}, running:{label:"running",color:C.amber}, completed:{label:"completed",color:C.teal}, failed:{label:"failed",color:C.red} };
+  const {label,color} = map[status]||map.queued;
+  const pulsing = status==="picked_up"||status==="running";
+  return (
+    <div style={{ display:"flex", alignItems:"center", gap:5 }}>
+      <div style={{ width:6,height:6,borderRadius:"50%",background:color,flexShrink:0,animation:pulsing?"pulse 1s ease-in-out infinite":"none" }}/>
+      <span style={{ fontFamily:C.mono,fontSize:10,color,letterSpacing:"0.03em" }}>{label}</span>
+    </div>
+  );
+}
+
+function Field({ label, children, style={} }) {
+  return (
+    <div style={style}>
+      <div style={{ fontSize:10,fontFamily:C.mono,color:C.txt3,letterSpacing:"0.06em",marginBottom:6 }}>{label}</div>
+      {children}
+    </div>
+  );
+}
+
+function CopyRow({ label, value }) {
+  const [copied,setCopied]=useState(false);
+  function copy(){ try{navigator.clipboard.writeText(value);}catch(e){} setCopied(true); setTimeout(()=>setCopied(false),1500); }
+  return (
+    <div style={{ padding:"11px 14px", background:C.surf, border:`1px solid ${C.bdr}`, borderRadius:10 }}>
+      <div style={{ fontSize:9.5,fontFamily:C.mono,color:C.txt3,letterSpacing:"0.06em",marginBottom:4 }}>{label}</div>
+      <div style={{ display:"flex",alignItems:"center",gap:8 }}>
+        <span style={{ fontFamily:C.mono,fontSize:11,color:C.txt2,flex:1,wordBreak:"break-all",lineHeight:1.5 }}>{value||"—"}</span>
+        {value&&<button onClick={copy} style={{ fontFamily:C.mono,fontSize:9,color:copied?C.teal:C.txt3,background:"transparent",border:"none",cursor:"pointer",flexShrink:0 }}>{copied?"copied!":"copy"}</button>}
+      </div>
+    </div>
+  );
+}
+
+/* ── WALLET ───────────────────────── */
+function useWallet() {
+  const [state,setState]=useState({ connected:false,address:null,balance:MOCK_BALANCE,provider:null,signer:null,connecting:false,error:null });
+
+  // ── MOCK connect ──────────────────
+  async function connectMock() {
+    setState(s=>({...s,connecting:true,error:null}));
+    await new Promise(r=>setTimeout(r,700)); // feel like a real handshake
+    setState({ connected:true,address:MOCK_ADDRESS,balance:MOCK_BALANCE,provider:null,signer:"mock",connecting:false,error:null });
+  }
+
+  // ── REAL connect (MetaMask) ───────
+  async function connectReal() {
+    setState(s=>({...s,connecting:true,error:null}));
+    try {
+      const eth = await new Promise(resolve=>{
+        if (window.ethereum) return resolve(window.ethereum);
+        const t = setTimeout(()=>resolve(null),3000);
+        window.addEventListener("ethereum#initialized",()=>{clearTimeout(t);resolve(window.ethereum);},{once:true});
+      });
+      if (!eth) {
+        setState(s=>({...s,connecting:false,error:"MetaMask not detected. Serve via localhost: npx serve . then open http://localhost:3000"}));
+        return;
+      }
+      const provider = new ethers.providers.Web3Provider(eth);
+      await provider.send("eth_requestAccounts",[]);
+      const signer = provider.getSigner();
+      const address = await signer.getAddress();
+      setState({ connected:true,address,balance:MOCK_BALANCE,provider,signer,connecting:false,error:null });
+    } catch(e) {
+      setState(s=>({...s,connecting:false,error:e.code===4001?"Rejected.":e.message||"Failed to connect."}));
+    }
+  }
+
+  async function connect() { USE_REAL_WALLET ? connectReal() : connectMock(); }
+
+  function disconnect() { setState({ connected:false,address:null,balance:MOCK_BALANCE,provider:null,signer:null,connecting:false,error:null }); }
+  function addBalance(amt) { setState(s=>({...s,balance:parseFloat((s.balance+amt).toFixed(2))})); }
+
+  async function signJob(data) {
+    if (!USE_REAL_WALLET) {
+      // Mock: pause briefly to simulate signing delay, return a fake signature
+      await new Promise(r=>setTimeout(r,1200));
+      return "0x" + Array.from({length:65},()=>Math.floor(Math.random()*256).toString(16).padStart(2,"0")).join("");
+    }
+    if (!state.signer || state.signer==="mock") throw new Error("Real signer not available");
+    const domain = { name:"IPC Compute",version:"1",chainId:CHAIN_ID };
+    const types  = { Job:[{name:"prompt",type:"string"},{name:"model",type:"string"},{name:"maxTokens",type:"uint256"},{name:"temperature",type:"uint256"},{name:"nonce",type:"uint256"},{name:"deadline",type:"uint256"}] };
+    const value  = { prompt:data.prompt,model:data.model,maxTokens:data.maxTokens,temperature:Math.round(data.temperature*100),nonce:Math.floor(Math.random()*1e6),deadline:Math.floor(Date.now()/1000)+3600 };
+    return await state.signer._signTypedData(domain,types,value);
+  }
+
+  return {...state, connect, disconnect, addBalance, signJob};
+}
+
+/* ── JOB STORE ────────────────────── */
+function useJobs() {
+  const [jobs,setJobs]=useState(()=>{
+    try { const s=JSON.parse(localStorage.getItem("ipc_jobs")||"[]"); return s.length?s:MOCK_JOBS_INIT; }
+    catch { return MOCK_JOBS_INIT; }
+  });
+  useEffect(()=>{ try{localStorage.setItem("ipc_jobs",JSON.stringify(jobs));}catch(e){} },[jobs]);
+  function addJob(j) { setJobs(p=>[j,...p]); }
+  function updateJob(id,u) { setJobs(p=>p.map(j=>j.id===id?{...j,...u}:j)); }
+  return {jobs,addJob,updateJob};
+}
+
+/* ── BLOCK TICKER ─────────────────── */
+function useBlock(start=412850) {
+  const [b,setB]=useState(start);
+  useEffect(()=>{ const id=setInterval(()=>setB(x=>x+Math.floor(Math.random()*2)),2000); return ()=>clearInterval(id); },[]);
+  return b;
+}
+
+/* ══════════════════════════════════════
+   APP
+══════════════════════════════════════ */
+function App() {
+  const wallet = useWallet();
+  const {jobs,addJob,updateJob} = useJobs();
+  const block = useBlock();
+  const [view,setView] = useState("new-job");
+  const [selectedId,setSelectedId] = useState(null);
+  const [topUpOpen,setTopUpOpen] = useState(false);
+  const [activeId,setActiveId] = useState(null);
+
+  function openResults(id) { setSelectedId(id); setView("results"); }
+
+  function simulateJob(job) {
+    setActiveId(job.id);
+    const blk = block+2;
+    setTimeout(()=>updateJob(job.id,{status:"picked_up",worker:"val-2.ipc-fil.io"}),900);
+    setTimeout(()=>updateJob(job.id,{status:"running"}),3500);
+    setTimeout(()=>{
+      const used=Math.floor(job.maxTokens*0.7+Math.random()*150);
+      updateJob(job.id,{ status:"completed", completedAt:Date.now(), txHash:mockTx(), resultTxHash:mockTx(),
+        cid:"bafybeig7xq2m...r4p9wk", block:blk, tokensUsed:used,
+        cost:parseFloat(estimateCost(used,job.model)), hasReport:true });
+      setActiveId(null);
+    },12000);
+  }
+
+  const activeJob = jobs.find(j=>j.id===activeId);
+  const selectedJob = jobs.find(j=>j.id===selectedId);
+
+  return (
+    <div style={{ display:"flex",height:"100vh",background:C.bg,overflow:"hidden" }}>
+
+      {/* SIDEBAR */}
+      <aside style={{ width:228,background:C.surf,borderRight:`1px solid ${C.bdr}`,display:"flex",flexDirection:"column",flexShrink:0 }}>
+        {/* Logo */}
+        <div style={{ padding:"18px 16px 14px",borderBottom:`1px solid ${C.bdr}` }}>
+          <div style={{ display:"flex",alignItems:"center",gap:9 }}>
+            <div style={{ width:26,height:26,borderRadius:7,background:C.tealDim,border:`1px solid ${C.tealBdr}`,display:"flex",alignItems:"center",justifyContent:"center",flexShrink:0 }}>
+              <svg width="13" height="13" viewBox="0 0 13 13" fill="none"><polygon points="6.5,1 12,4 12,9 6.5,12 1,9 1,4" stroke={C.teal} strokeWidth="1.2" fill="none"/><circle cx="6.5" cy="6.5" r="1.8" fill={C.teal} opacity="0.7"/></svg>
+            </div>
+            <div>
+              <div style={{ fontFamily:C.display,fontSize:14,color:C.txt,letterSpacing:"-0.01em" }}>IPC Compute</div>
+              <div style={{ fontSize:9,fontFamily:C.mono,color:C.txt3,marginTop:1 }}>powered by IPC Chain</div>
+            </div>
+          </div>
+        </div>
+
+        {/* Wallet */}
+        <div style={{ padding:"12px 14px",borderBottom:`1px solid ${C.bdr}` }}>
+          {!wallet.connected ? (
+            <button onClick={wallet.connect} disabled={wallet.connecting}
+              style={{ width:"100%",padding:"8px 12px",borderRadius:8,border:`1px solid ${C.bdr}`,background:"transparent",color:C.txt2,fontSize:12,fontFamily:C.sans,cursor:"pointer",display:"flex",alignItems:"center",gap:7,transition:"all 0.15s" }}
+              onMouseEnter={e=>{e.currentTarget.style.borderColor=C.tealBdr;e.currentTarget.style.color=C.teal;}}
+              onMouseLeave={e=>{e.currentTarget.style.borderColor=C.bdr;e.currentTarget.style.color=C.txt2;}}>
+              {wallet.connecting?<Spinner size={12}/>:<svg width="12" height="12" viewBox="0 0 12 12" fill="none"><rect x="1" y="3" width="10" height="7" rx="1.5" stroke="currentColor" strokeWidth="1.2"/><path d="M4 3V2.5a2 2 0 014 0V3" stroke="currentColor" strokeWidth="1.2"/><circle cx="8.5" cy="6.5" r="1" fill="currentColor"/></svg>}
+              {wallet.connecting?"Connecting...":"Connect wallet"}
+            </button>
+          ) : (
+            <div>
+              <div style={{ display:"flex",alignItems:"center",gap:7,marginBottom:8 }}>
+                <div style={{ width:7,height:7,borderRadius:"50%",background:C.teal,flexShrink:0 }}/>
+                <span style={{ fontFamily:C.mono,fontSize:11,color:C.txt }}>{trunc(wallet.address,5)}</span>
+                <button onClick={wallet.disconnect} style={{ marginLeft:"auto",fontSize:9,fontFamily:C.mono,color:C.txt3,background:"transparent",border:"none",cursor:"pointer" }}>disconnect</button>
+              </div>
+              <div style={{ display:"flex",alignItems:"center",justifyContent:"space-between",padding:"8px 10px",background:C.surf2,borderRadius:8,border:`1px solid ${C.bdr}` }}>
+                <div>
+                  <div style={{ fontSize:9.5,fontFamily:C.mono,color:C.txt3,marginBottom:2 }}>USDFC balance</div>
+                  <div style={{ fontFamily:C.mono,fontSize:15,fontWeight:500,color:wallet.balance<1?C.amber:C.txt }}>${wallet.balance.toFixed(2)}</div>
+                </div>
+                <button onClick={()=>setTopUpOpen(true)} style={{ fontSize:10,fontFamily:C.mono,color:C.teal,background:C.tealDim,border:`1px solid ${C.tealBdr}`,borderRadius:5,padding:"3px 8px",cursor:"pointer" }}>top up</button>
+              </div>
+            </div>
+          )}
+          {wallet.error&&<div style={{ fontSize:10,color:C.amber,marginTop:8,fontFamily:C.sans,lineHeight:1.6,padding:"8px 10px",background:"rgba(245,166,35,0.07)",borderRadius:6,border:"1px solid rgba(245,166,35,0.2)" }}>{wallet.error}</div>}
+        </div>
+
+        {/* Nav */}
+        <nav style={{ padding:"10px",flex:1 }}>
+          {[{id:"new-job",label:"New job"},{id:"jobs",label:"Jobs",badge:jobs.filter(j=>j.status==="completed").length}].map(item=>{
+            const active=view===item.id;
+            return (
+              <button key={item.id} onClick={()=>setView(item.id)}
+                style={{ width:"100%",display:"flex",alignItems:"center",gap:9,padding:"8px 10px",borderRadius:8,border:"none",background:active?C.tealDim:"transparent",color:active?C.teal:C.txt2,fontSize:13,cursor:"pointer",transition:"all 0.15s",marginBottom:1 }}
+                onMouseEnter={e=>{if(!active){e.currentTarget.style.background=C.surf2;e.currentTarget.style.color=C.txt;}}}
+                onMouseLeave={e=>{if(!active){e.currentTarget.style.background="transparent";e.currentTarget.style.color=C.txt2;}}}>
+                <span style={{ flex:1,textAlign:"left" }}>{item.label}</span>
+                {item.badge>0&&<span style={{ fontFamily:C.mono,fontSize:9.5,padding:"1px 6px",borderRadius:10,background:C.surf3,color:C.txt3 }}>{item.badge}</span>}
+              </button>
+            );
+          })}
+        </nav>
+
+        {/* Active job */}
+        {activeJob&&(
+          <div style={{ margin:"0 10px 10px",padding:"9px 10px",background:C.amberDim,border:`1px solid ${C.amberBdr}`,borderRadius:8 }}>
+            <div style={{ display:"flex",alignItems:"center",gap:6,marginBottom:3 }}>
+              <Spinner size={10} color={C.amber}/>
+              <span style={{ fontSize:10,fontFamily:C.mono,color:C.amber }}>job running</span>
+            </div>
+            <div style={{ fontFamily:C.mono,fontSize:10,color:C.txt2 }}>{activeJob.id} · {activeJob.status}</div>
+          </div>
+        )}
+
+        {/* Network */}
+        <div style={{ padding:"10px 14px",borderTop:`1px solid ${C.bdr}` }}>
+          <div style={{ display:"flex",alignItems:"center",gap:6 }}>
+            <div style={{ width:5,height:5,borderRadius:"50%",background:C.teal,animation:"ticker 2s ease-in-out infinite",flexShrink:0 }}/>
+            <span style={{ fontFamily:C.mono,fontSize:9.5,color:C.txt3 }}>IPC Filecoin Calibration</span>
+          </div>
+          <div style={{ fontFamily:C.mono,fontSize:9.5,color:C.txt3,marginTop:3 }}>block <span style={{ color:C.txt2 }}>{block.toLocaleString()}</span></div>
+        </div>
+      </aside>
+
+      {/* MAIN */}
+      <main style={{ flex:1,overflow:"auto",padding:"28px 32px" }}>
+        {view==="new-job"&&<NewJobView wallet={wallet} addJob={addJob} simulateJob={simulateJob} onTopUp={()=>setTopUpOpen(true)} onViewJobs={()=>setView("jobs")} block={block}/>}
+        {view==="jobs"&&<JobsView jobs={jobs} onSelect={openResults} activeId={activeId} onRerun={j=>{setView("new-job");}}/>}
+        {view==="results"&&selectedJob&&<ResultsView job={selectedJob} onNewJob={()=>setView("new-job")} onBack={()=>setView("jobs")}/>}
+      </main>
+
+      {topUpOpen&&<TopUpModal wallet={wallet} onClose={()=>setTopUpOpen(false)}/>}
+    </div>
+  );
+}
+
+/* ── NEW JOB ──────────────────────── */
+function NewJobView({ wallet, addJob, simulateJob, onTopUp, onViewJobs, block }) {
+  const [prompt,setPrompt]=useState(DEFAULT_PROMPT);
+  const [model,setModel]=useState(MODELS[0].id);
+  const [maxTokens,setMaxTokens]=useState(2048);
+  const [temperature,setTemperature]=useState(0.3);
+  const [signing,setSigning]=useState(false);
+  const [signError,setSignError]=useState(null);
+  const [submitted,setSubmitted]=useState(null);
+
+  const estCost = parseFloat(estimateCost(maxTokens,model));
+  const lowBalance = wallet.connected&&wallet.balance<estCost;
+  const canSubmit = wallet.connected&&!lowBalance&&prompt.trim().length>10&&!signing;
+  const tokenCount = Math.floor(prompt.length/4);
+  const selectedModel = MODELS.find(m=>m.id===model)||MODELS[0];
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+    setSigning(true); setSignError(null);
+    try {
+      const sig = await wallet.signJob({prompt,model,maxTokens,temperature});
+      const job = { id:jobId(),prompt,model,maxTokens,temperature,status:"queued",submittedAt:Date.now(),sig:sig.slice(0,18)+"...",txHash:mockTx(),resultTxHash:null,cid:null,block:null,tokensUsed:0,cost:0,hasReport:false,worker:null };
+      addJob(job); simulateJob(job); setSubmitted(job.id); setSigning(false);
+    } catch(e) {
+      setSignError(e.code===4001?"Signature rejected.":"Signing failed."); setSigning(false);
+    }
+  }
+
+  if (submitted) return (
+    <div className="fa" style={{ maxWidth:580 }}>
+      <div style={{ padding:"20px 22px",background:C.tealDim,border:`1px solid ${C.tealBdr}`,borderRadius:12,marginBottom:16 }}>
+        <div style={{ fontFamily:C.display,fontSize:20,color:C.teal,marginBottom:6 }}>Job submitted</div>
+        <div style={{ fontSize:13,color:C.txt2,marginBottom:14 }}>Transaction signed and committed to IPC Chain. Your job is queued for execution.</div>
+        <div style={{ display:"grid",gridTemplateColumns:"1fr 1fr",gap:8 }}>
+          <div style={{ padding:"9px 11px",background:C.surf2,borderRadius:8,border:`1px solid ${C.bdr}` }}>
+            <div style={{ fontSize:9.5,fontFamily:C.mono,color:C.txt3,marginBottom:3 }}>JOB ID</div>
+            <div style={{ fontFamily:C.mono,fontSize:11,color:C.teal }}>{submitted}</div>
+          </div>
+          <div style={{ padding:"9px 11px",background:C.surf2,borderRadius:8,border:`1px solid ${C.bdr}` }}>
+            <div style={{ fontSize:9.5,fontFamily:C.mono,color:C.txt3,marginBottom:3 }}>EST. COST</div>
+            <div style={{ fontFamily:C.mono,fontSize:11,color:C.txt }}>${estCost} USDFC</div>
+          </div>
+        </div>
+      </div>
+      <div style={{ display:"flex",gap:10 }}>
+        <Btn onClick={onViewJobs} variant="primary">Watch execution →</Btn>
+        <Btn onClick={()=>setSubmitted(null)}>New job</Btn>
+      </div>
+    </div>
+  );
+
+  return (
+    <div style={{ maxWidth:660 }}>
+      <div style={{ marginBottom:22 }}>
+        <h1 style={{ fontFamily:C.display,fontSize:22,color:C.txt,letterSpacing:"-0.02em",marginBottom:4 }}>New job</h1>
+        <p style={{ fontSize:13,color:C.txt2 }}>Configure and submit a compute task to the IPC chain.</p>
+      </div>
+      <div style={{ display:"grid",gap:14 }}>
+
+        {/* Model + params */}
+        <div style={{ background:C.surf,border:`1px solid ${C.bdr}`,borderRadius:12,padding:"16px 18px" }}>
+          <div style={{ fontSize:10,fontFamily:C.mono,color:C.txt3,letterSpacing:"0.06em",marginBottom:14 }}>MODEL & PARAMETERS</div>
+          <Field label="MODEL" style={{ marginBottom:14 }}>
+            <div style={{ position:"relative" }}>
+              <select value={model} onChange={e=>setModel(e.target.value)} style={{ width:"100%",padding:"8px 10px",background:C.surf2,border:`1px solid ${C.bdr}`,borderRadius:8,color:C.txt,fontSize:12,fontFamily:C.sans,cursor:"pointer",appearance:"none" }}>
+                {MODELS.map(m=><option key={m.id} value={m.id}>{m.label}</option>)}
+              </select>
+              <div style={{ position:"absolute",right:10,top:"50%",transform:"translateY(-50%)",pointerEvents:"none",color:C.txt3,fontSize:10 }}>▾</div>
+            </div>
+          </Field>
+          <div style={{ display:"grid",gridTemplateColumns:"1fr 1fr",gap:14 }}>
+            <Field label={`MAX TOKENS — ${maxTokens.toLocaleString()}`}>
+              <input type="range" min={256} max={4096} step={128} value={maxTokens} onChange={e=>setMaxTokens(+e.target.value)} style={{ width:"100%",marginTop:4 }}/>
+              <div style={{ display:"flex",justifyContent:"space-between",marginTop:3 }}>
+                <span style={{ fontFamily:C.mono,fontSize:9,color:C.txt3 }}>256</span>
+                <span style={{ fontFamily:C.mono,fontSize:9,color:C.txt3 }}>4096</span>
+              </div>
+            </Field>
+            <Field label={`TEMPERATURE — ${temperature.toFixed(1)}`}>
+              <input type="range" min={0} max={10} step={1} value={Math.round(temperature*10)} onChange={e=>setTemperature(e.target.value/10)} style={{ width:"100%",marginTop:4 }}/>
+              <div style={{ display:"flex",justifyContent:"space-between",marginTop:3 }}>
+                <span style={{ fontFamily:C.mono,fontSize:9,color:C.txt3 }}>0.0</span>
+                <span style={{ fontFamily:C.mono,fontSize:9,color:C.txt3 }}>1.0</span>
+              </div>
+            </Field>
+          </div>
+        </div>
+
+        {/* Prompt */}
+        <div style={{ background:C.surf,border:`1px solid ${C.bdr}`,borderRadius:12,padding:"16px 18px" }}>
+          <div style={{ display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:10 }}>
+            <div style={{ fontSize:10,fontFamily:C.mono,color:C.txt3,letterSpacing:"0.06em" }}>PROMPT</div>
+            <span style={{ fontFamily:C.mono,fontSize:9.5,color:C.txt3 }}>~{tokenCount} tokens</span>
+          </div>
+          <textarea value={prompt} onChange={e=>setPrompt(e.target.value)} rows={9}
+            style={{ width:"100%",fontFamily:C.mono,fontSize:11.5,color:C.txt,lineHeight:1.75,background:C.surf2,border:`1px solid ${C.bdr}`,borderRadius:8,padding:"10px 12px" }}
+            placeholder="Enter your prompt..."/>
+        </div>
+
+        {/* Submit */}
+        <div style={{ background:C.surf,border:`1px solid ${lowBalance?C.amberBdr:C.bdr}`,borderRadius:12,padding:"14px 18px" }}>
+          {lowBalance&&(
+            <div style={{ display:"flex",alignItems:"center",gap:9,padding:"9px 12px",background:C.amberDim,border:`1px solid ${C.amberBdr}`,borderRadius:8,marginBottom:12 }} className="fa">
+              <div style={{ width:7,height:7,borderRadius:"50%",background:C.amber,flexShrink:0 }}/>
+              <span style={{ fontSize:12,color:C.amber,flex:1 }}>Insufficient balance. Job costs ${estCost} — balance is ${wallet.balance.toFixed(2)} USDFC.</span>
+              <button onClick={onTopUp} style={{ fontFamily:C.sans,fontSize:11,color:C.amber,background:C.amberDim,border:`1px solid ${C.amberBdr}`,borderRadius:6,padding:"4px 10px",cursor:"pointer",flexShrink:0 }}>Top up →</button>
+            </div>
+          )}
+          <div style={{ display:"flex",alignItems:"center",justifyContent:"space-between",flexWrap:"wrap",gap:10 }}>
+            <div style={{ display:"flex",gap:16 }}>
+              <div><div style={{ fontSize:9.5,fontFamily:C.mono,color:C.txt3,marginBottom:2 }}>EST. COST</div><div style={{ fontFamily:C.mono,fontSize:14,color:C.txt }}>${estCost} USDFC</div></div>
+              <div><div style={{ fontSize:9.5,fontFamily:C.mono,color:C.txt3,marginBottom:2 }}>MODEL</div><div style={{ fontFamily:C.mono,fontSize:11,color:C.txt2 }}>{selectedModel.label}</div></div>
+            </div>
+            <div style={{ display:"flex",gap:8,alignItems:"center" }}>
+              {signError&&<span style={{ fontFamily:C.mono,fontSize:11,color:C.red }}>{signError}</span>}
+              {!wallet.connected
+                ?<Btn onClick={wallet.connect} variant="primary" size="lg">{wallet.connecting?"Connecting...":"Connect wallet to submit"}</Btn>
+                :lowBalance
+                ?<Btn onClick={onTopUp} variant="amber" size="lg">Top up USDFC →</Btn>
+                :<Btn onClick={handleSubmit} disabled={!canSubmit||signing} variant="primary" size="lg">
+                  {signing?<span style={{ display:"flex",alignItems:"center",gap:8 }}><Spinner size={12}/>Waiting for signature...</span>:"Sign & submit →"}
+                </Btn>
+              }
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── JOBS VIEW ────────────────────── */
+function JobsView({ jobs, onSelect, activeId, onRerun }) {
+  return (
+    <div>
+      <div style={{ marginBottom:22 }}>
+        <h1 style={{ fontFamily:C.display,fontSize:22,color:C.txt,letterSpacing:"-0.02em",marginBottom:4 }}>Jobs</h1>
+        <p style={{ fontSize:13,color:C.txt2 }}>{jobs.length} total · {jobs.filter(j=>j.status==="completed").length} completed</p>
+      </div>
+      <div style={{ background:C.surf,border:`1px solid ${C.bdr}`,borderRadius:12,overflow:"hidden" }}>
+        <div style={{ display:"grid",gridTemplateColumns:"110px 1fr 150px 80px 75px 90px",gap:8,padding:"9px 16px",background:C.surf2,borderBottom:`1px solid ${C.bdr}` }}>
+          {["Status","Prompt","Model","Submitted","Cost",""].map(h=>(
+            <span key={h} style={{ fontSize:9.5,fontFamily:C.mono,color:C.txt3,letterSpacing:"0.05em" }}>{h}</span>
+          ))}
+        </div>
+        {jobs.map((job,i)=>(
+          <div key={job.id} className={job.id===activeId?"si":""}
+            style={{ display:"grid",gridTemplateColumns:"110px 1fr 150px 80px 75px 90px",gap:8,padding:"12px 16px",borderBottom:i<jobs.length-1?`1px solid ${C.bdr}`:"none",alignItems:"center",background:job.id===activeId?C.amberDim:"transparent",transition:"background 0.3s",cursor:"default" }}
+            onMouseEnter={e=>{if(job.id!==activeId)e.currentTarget.style.background=C.surf2;}}
+            onMouseLeave={e=>{if(job.id!==activeId)e.currentTarget.style.background="transparent";}}>
+            <StatusChip status={job.status}/>
+            <div>
+              <div style={{ fontFamily:C.mono,fontSize:10,color:C.txt3,marginBottom:2 }}>{job.id}</div>
+              <div style={{ fontSize:12,color:C.txt,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap" }}>{job.prompt.split("\n")[0].slice(0,55)}...</div>
+            </div>
+            <span style={{ fontFamily:C.mono,fontSize:10,color:C.txt2 }}>{(MODELS.find(m=>m.id===job.model)||MODELS[0]).label.split(" ").slice(0,2).join(" ")}</span>
+            <span style={{ fontFamily:C.mono,fontSize:10,color:C.txt3 }}>{timeAgo(job.submittedAt)}</span>
+            <span style={{ fontFamily:C.mono,fontSize:10,color:C.txt2 }}>{job.cost>0?`$${job.cost}`:"—"}</span>
+            <div style={{ display:"flex",gap:5,justifyContent:"flex-end" }}>
+              {job.status==="completed"&&<Btn onClick={()=>onSelect(job.id)} size="sm">View</Btn>}
+              {job.status==="failed"&&<Btn onClick={()=>onRerun(job)} size="sm" variant="amber">Rerun</Btn>}
+              {(job.status==="queued"||job.status==="picked_up"||job.status==="running")&&(
+                <div style={{ display:"flex",alignItems:"center",gap:5 }}>
+                  <Spinner size={11} color={C.amber}/>
+                  <span style={{ fontFamily:C.mono,fontSize:9.5,color:C.amber }}>{job.worker||"queued"}</span>
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ── RESULTS VIEW ─────────────────── */
+function ResultsView({ job, onNewJob, onBack }) {
+  const [tab,setTab]=useState("output");
+  return (
+    <div style={{ maxWidth:780 }}>
+      <div style={{ display:"flex",alignItems:"center",gap:12,marginBottom:22 }}>
+        <button onClick={onBack} style={{ fontFamily:C.mono,fontSize:10,color:C.txt3,background:"transparent",border:"none",cursor:"pointer" }}>← Jobs</button>
+        <div style={{ width:1,height:14,background:C.bdr }}/>
+        <div style={{ fontFamily:C.mono,fontSize:12,color:C.txt2 }}>{job.id}</div>
+        <StatusChip status={job.status}/>
+        {job.cid&&<Badge color={C.violet} style={{ marginLeft:"auto" }}>{trunc(job.cid,8)}</Badge>}
+      </div>
+      <div style={{ display:"flex",gap:2,borderBottom:`1px solid ${C.bdr}`,marginBottom:20 }}>
+        {["output","on-chain","cost","spawn"].map(t=>(
+          <button key={t} onClick={()=>setTab(t)} style={{ fontFamily:C.sans,fontSize:12,padding:"8px 16px",background:"transparent",border:"none",cursor:"pointer",color:tab===t?C.teal:C.txt2,borderBottom:tab===t?`2px solid ${C.teal}`:"2px solid transparent",transition:"all 0.15s",marginBottom:-1 }}>
+            {t==="spawn"?"spawn new job":t}
+          </button>
+        ))}
+      </div>
+      {tab==="output"  &&<OutputTab job={job}/>}
+      {tab==="on-chain"&&<OnChainTab job={job}/>}
+      {tab==="cost"    &&<CostTab job={job}/>}
+      {tab==="spawn"   &&<SpawnTab onNewJob={onNewJob}/>}
+    </div>
+  );
+}
+
+function OutputTab({ job }) {
+  if (!job.hasReport) return <div style={{ padding:"32px 0",textAlign:"center",color:C.txt2,fontSize:13 }}>No output available.</div>;
+  return (
+    <div className="fa" style={{ background:C.surf,border:`1px solid ${C.bdr}`,borderRadius:12,overflow:"hidden" }}>
+      <div style={{ padding:"10px 14px",background:C.surf2,borderBottom:`1px solid ${C.bdr}`,display:"flex",alignItems:"center",gap:8 }}>
+        <svg width="11" height="11" viewBox="0 0 11 11" fill="none"><rect x="1" y="1" width="9" height="9" rx="1.5" stroke={C.violet} strokeWidth="1.2"/><path d="M3 4h5M3 6h5M3 8h3" stroke={C.violet} strokeWidth="1" strokeLinecap="round"/></svg>
+        <span style={{ fontFamily:C.mono,fontSize:10.5,color:C.violet }}>report.md</span>
+        <span style={{ fontFamily:C.mono,fontSize:9,color:C.txt3,marginLeft:"auto" }}>IPC Storage · {job.cid}</span>
+      </div>
+      <div style={{ padding:"20px 24px" }}>
+        <h2 style={{ fontFamily:C.display,fontSize:20,color:C.txt,letterSpacing:"-0.02em",marginBottom:4 }}>Filecoin Storage Provider Reliability Report</h2>
+        <p style={{ fontSize:11,fontFamily:C.mono,color:C.txt3,marginBottom:20 }}>Analysis Date: March 19, 2026 · 597 providers analysed</p>
+        <h3 style={{ fontSize:12,fontWeight:500,color:C.teal,marginBottom:8,letterSpacing:"0.04em" }}>METHODOLOGY</h3>
+        <p style={{ fontSize:13,color:C.txt2,lineHeight:1.75,marginBottom:20 }}>Data sourced from the Filrep API (597 active storage providers). Reliability scoring uses five weighted signals: uptime consistency (35 pts), deal fulfillment (30 pts), sector maintenance (20 pts), network reputation (10 pts), and storage capacity (5 pts).</p>
+        <h3 style={{ fontSize:12,fontWeight:500,color:C.teal,marginBottom:10,letterSpacing:"0.04em" }}>TOP 15 MOST RELIABLE STORAGE PROVIDERS</h3>
+        <div style={{ overflowX:"auto",marginBottom:20 }}>
+          <table style={{ width:"100%",borderCollapse:"collapse",fontSize:11.5,fontFamily:C.mono }}>
+            <thead>
+              <tr style={{ borderBottom:`1px solid ${C.bdr}` }}>
+                {["#","Provider ID","Score","Uptime","Deals","Power"].map(h=>(
+                  <th key={h} style={{ padding:"7px 10px",textAlign:"left",color:C.txt3,fontSize:10,fontWeight:400,letterSpacing:"0.05em",whiteSpace:"nowrap" }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {REPORT_TABLE.map((row,i)=>(
+                <tr key={row.id} style={{ borderBottom:`1px solid ${C.bdr}`,background:i%2===0?"transparent":C.surf2 }}>
+                  <td style={{ padding:"7px 10px",color:C.txt3 }}>#{row.rank}</td>
+                  <td style={{ padding:"7px 10px",color:i<3?C.teal:C.txt }}>{row.id}</td>
+                  <td style={{ padding:"7px 10px",color:i<3?C.teal:C.amber,fontWeight:500 }}>{row.score.toFixed(2)}</td>
+                  <td style={{ padding:"7px 10px",color:C.txt2 }}>{row.uptime.toFixed(1)}%</td>
+                  <td style={{ padding:"7px 10px",color:C.txt2 }}>{row.deals.toLocaleString()}</td>
+                  <td style={{ padding:"7px 10px",color:C.txt3 }}>{row.power}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <h3 style={{ fontSize:12,fontWeight:500,color:C.teal,marginBottom:10,letterSpacing:"0.04em" }}>KEY FINDINGS</h3>
+        {[
+          "The top-tier storage providers demonstrate exceptional operational stability with uptime averages above 88%, significantly above the network mean of 42.2%. The #1 ranked provider f0116628 maintains 96.15% uptime while handling over 100 deals with a perfect success rate.",
+          "All 15 top providers maintain 100% deal success rates with zero slashing events. This is particularly notable for high-volume operators like f044160 which manages 1,268 deals flawlessly — demonstrating sophisticated deal management and proactive monitoring.",
+          "Geographically, all top 15 providers operate from Asia, suggesting a concentration of professional-grade storage infrastructure in this region. The absence of any slashing history across the entire top-15 cohort validates the reliability scoring methodology.",
+        ].map((p,i)=><p key={i} style={{ fontSize:13,color:C.txt2,lineHeight:1.75,marginBottom:12 }}>{p}</p>)}
+      </div>
+    </div>
+  );
+}
+
+function OnChainTab({ job }) {
+  return (
+    <div className="fa" style={{ display:"grid",gap:9 }}>
+      {[["JOB TRANSACTION",job.txHash],["RESULT TRANSACTION",job.resultTxHash],["IPC STORAGE CID",job.cid],["BLOCK HEIGHT",job.block?job.block.toLocaleString():null],["WORKER NODE",job.worker],["EIP-712 SIGNATURE",job.sig]].map(([l,v])=>(
+        <CopyRow key={l} label={l} value={v||"—"}/>
+      ))}
+    </div>
+  );
+}
+
+function CostTab({ job }) {
+  const m = MODELS.find(x=>x.id===job.model)||MODELS[0];
+  const promptTok = Math.floor((job.prompt?.length||0)/4);
+  const compTok   = Math.max(0,(job.tokensUsed||0)-promptTok);
+  return (
+    <div className="fa" style={{ background:C.surf,border:`1px solid ${C.bdr}`,borderRadius:12,overflow:"hidden" }}>
+      <table style={{ width:"100%",borderCollapse:"collapse",fontSize:12 }}>
+        <thead>
+          <tr style={{ borderBottom:`1px solid ${C.bdr}`,background:C.surf2 }}>
+            {["Component","Tokens","Rate","Cost"].map(h=>(
+              <th key={h} style={{ padding:"10px 16px",textAlign:"left",fontFamily:C.mono,fontSize:10,color:C.txt3,fontWeight:400,letterSpacing:"0.05em" }}>{h}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {[["Prompt",promptTok,`$${m.ppt}/token`,`$${(promptTok*m.ppt).toFixed(4)}`],["Completion",compTok,`$${m.ppt}/token`,`$${(compTok*m.ppt).toFixed(4)}`],["Storage write","—","flat rate","$0.001"],["Chain txs (×2)","—","gas","$0.002"]].map(([c,t,r,cost])=>(
+            <tr key={c} style={{ borderBottom:`1px solid ${C.bdr}` }}>
+              <td style={{ padding:"10px 16px",color:C.txt }}>{c}</td>
+              <td style={{ padding:"10px 16px",fontFamily:C.mono,color:C.txt2 }}>{typeof t==="number"?t.toLocaleString():t}</td>
+              <td style={{ padding:"10px 16px",fontFamily:C.mono,fontSize:11,color:C.txt3 }}>{r}</td>
+              <td style={{ padding:"10px 16px",fontFamily:C.mono,color:C.teal }}>{cost}</td>
+            </tr>
+          ))}
+          <tr style={{ background:C.surf2 }}>
+            <td colSpan={3} style={{ padding:"10px 16px",fontWeight:500,color:C.txt }}>Total</td>
+            <td style={{ padding:"10px 16px",fontFamily:C.mono,fontSize:14,fontWeight:500,color:C.teal }}>${job.cost>0?job.cost.toFixed(3):"0.000"} USDFC</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function SpawnTab({ onNewJob }) {
+  return (
+    <div className="fa">
+      <p style={{ fontSize:13,color:C.txt2,lineHeight:1.7,marginBottom:14 }}>Use the output of this job as the basis for a new task — run a deeper analysis, trigger a downstream action, or build on the results.</p>
+      <div style={{ display:"grid",gap:8,marginBottom:16 }}>
+        {["Fetch deal history for top 5 providers and compute month-over-month reliability trends","Generate a Solidity function call to route uploads to the top 3 providers in this report","Cross-reference top providers against the Filecoin Plus verified client dataset"].map((s,i)=>(
+          <div key={i} onClick={onNewJob} style={{ padding:"10px 14px",background:C.surf2,border:`1px solid ${C.bdr}`,borderRadius:9,fontSize:12,color:C.txt2,cursor:"pointer",lineHeight:1.6,transition:"all 0.15s" }}
+            onMouseEnter={e=>{e.currentTarget.style.borderColor=C.tealBdr;e.currentTarget.style.color=C.txt;}}
+            onMouseLeave={e=>{e.currentTarget.style.borderColor=C.bdr;e.currentTarget.style.color=C.txt2;}}>
+            {s}
+          </div>
+        ))}
+      </div>
+      <Btn onClick={onNewJob} variant="primary" size="lg">Open in new job →</Btn>
+    </div>
+  );
+}
+
+/* ── TOP-UP MODAL ─────────────────── */
+function TopUpModal({ wallet, onClose }) {
+  const [amount,setAmount]=useState(10);
+  const [custom,setCustom]=useState("");
+  const [cardNum,setCardNum]=useState("");
+  const [expiry,setExpiry]=useState("");
+  const [cvc,setCvc]=useState("");
+  const [autoOn,setAutoOn]=useState(false);
+  const [threshold,setThreshold]=useState(2);
+  const [autoAmt,setAutoAmt]=useState(10);
+  const [phase,setPhase]=useState("form");
+  const [f3t,setF3t]=useState(0);
+
+  const finalAmt = custom?parseFloat(custom)||0:amount;
+
+  function handlePay() {
+    if (!cardNum||!expiry||!cvc) return;
+    setPhase("processing");
+    let t=0;
+    const id=setInterval(()=>{
+      t=parseFloat(Math.min(t+0.15,0.8).toFixed(2));
+      setF3t(t);
+      if (t>=0.8){ clearInterval(id); setPhase("confirmed"); wallet.addBalance(finalAmt); }
+    },60);
+  }
+
+  function fmtCard(v) { return v.replace(/\D/g,"").slice(0,16).replace(/(.{4})/g,"$1 ").trim(); }
+  function fmtExp(v)  { return v.replace(/\D/g,"").slice(0,4).replace(/(.{2})/,"$1/"); }
+
+  return (
+    <div style={{ position:"fixed",inset:0,background:"rgba(7,8,16,0.9)",display:"flex",alignItems:"center",justifyContent:"center",zIndex:1000,padding:20 }}
+      onClick={e=>{if(e.target===e.currentTarget)onClose();}}>
+      <div style={{ background:C.surf,border:`1px solid ${C.bdr}`,borderRadius:16,width:"100%",maxWidth:400,overflow:"hidden" }} className="fa">
+        <div style={{ padding:"16px 20px",borderBottom:`1px solid ${C.bdr}`,display:"flex",alignItems:"center",justifyContent:"space-between" }}>
+          <div style={{ fontFamily:C.display,fontSize:16,color:C.txt }}>Top up USDFC</div>
+          <button onClick={onClose} style={{ background:"transparent",border:"none",color:C.txt3,cursor:"pointer",fontSize:18,lineHeight:1 }}>×</button>
+        </div>
+
+        {phase==="form"&&(
+          <div style={{ padding:"20px" }}>
+            <div style={{ fontSize:10,fontFamily:C.mono,color:C.txt3,letterSpacing:"0.06em",marginBottom:10 }}>AMOUNT (USDFC)</div>
+            <div style={{ display:"flex",gap:6,marginBottom:10 }}>
+              {[5,10,25].map(n=>(
+                <button key={n} onClick={()=>{setAmount(n);setCustom("");}} style={{ flex:1,padding:"8px 0",borderRadius:8,border:`1px solid ${amount===n&&!custom?C.tealBdr:C.bdr}`,background:amount===n&&!custom?C.tealDim:"transparent",color:amount===n&&!custom?C.teal:C.txt2,fontSize:13,fontFamily:C.mono,cursor:"pointer",transition:"all 0.15s" }}>${n}</button>
+              ))}
+              <input placeholder="Custom" value={custom} onChange={e=>setCustom(e.target.value.replace(/[^0-9.]/g,""))} style={{ flex:1,padding:"8px 10px",borderRadius:8,border:`1px solid ${custom?C.tealBdr:C.bdr}`,background:custom?C.tealDim:"transparent",color:custom?C.teal:C.txt2,fontSize:13,fontFamily:C.mono,textAlign:"center" }}/>
+            </div>
+            <div style={{ height:1,background:C.bdr,margin:"16px 0" }}/>
+            <div style={{ fontSize:10,fontFamily:C.mono,color:C.txt3,letterSpacing:"0.06em",marginBottom:12 }}>PAYMENT METHOD</div>
+            <div style={{ display:"grid",gap:8 }}>
+              <input value={fmtCard(cardNum)} onChange={e=>setCardNum(e.target.value)} placeholder="Card number" style={{ padding:"9px 12px",background:C.surf2,border:`1px solid ${C.bdr}`,borderRadius:8,color:C.txt,fontSize:13,fontFamily:C.mono }}/>
+              <div style={{ display:"grid",gridTemplateColumns:"1fr 1fr",gap:8 }}>
+                <input value={fmtExp(expiry)} onChange={e=>setExpiry(e.target.value)} placeholder="MM/YY" style={{ padding:"9px 12px",background:C.surf2,border:`1px solid ${C.bdr}`,borderRadius:8,color:C.txt,fontSize:13,fontFamily:C.mono }}/>
+                <input value={cvc.replace(/\D/g,"").slice(0,4)} onChange={e=>setCvc(e.target.value)} placeholder="CVC" style={{ padding:"9px 12px",background:C.surf2,border:`1px solid ${C.bdr}`,borderRadius:8,color:C.txt,fontSize:13,fontFamily:C.mono }}/>
+              </div>
+            </div>
+            <div style={{ height:1,background:C.bdr,margin:"16px 0" }}/>
+            <div style={{ display:"flex",alignItems:"center",justifyContent:"space-between",marginBottom:autoOn?12:0 }}>
+              <div>
+                <div style={{ fontSize:12,color:C.txt,marginBottom:2 }}>Automatic top-up</div>
+                <div style={{ fontSize:11,color:C.txt2 }}>Top up when balance runs low</div>
+              </div>
+              <div onClick={()=>setAutoOn(s=>!s)} style={{ width:36,height:20,borderRadius:10,background:autoOn?C.teal:C.bdrHi,cursor:"pointer",position:"relative",transition:"background 0.2s",flexShrink:0 }}>
+                <div style={{ position:"absolute",top:2,left:autoOn?18:2,width:16,height:16,borderRadius:"50%",background:"white",transition:"left 0.2s" }}/>
+              </div>
+            </div>
+            {autoOn&&(
+              <div style={{ display:"grid",gridTemplateColumns:"1fr 1fr",gap:8 }} className="fa">
+                <div style={{ padding:"9px 12px",background:C.surf2,border:`1px solid ${C.bdr}`,borderRadius:8 }}>
+                  <div style={{ fontSize:9.5,fontFamily:C.mono,color:C.txt3,marginBottom:4 }}>TOP UP WHEN BELOW</div>
+                  <div style={{ display:"flex",alignItems:"center",gap:4 }}>
+                    <span style={{ fontFamily:C.mono,fontSize:11,color:C.txt2 }}>$</span>
+                    <input type="number" value={threshold} onChange={e=>setThreshold(+e.target.value)} style={{ fontFamily:C.mono,fontSize:13,color:C.txt,width:50 }}/>
+                    <span style={{ fontFamily:C.mono,fontSize:11,color:C.txt2 }}>USDFC</span>
+                  </div>
+                </div>
+                <div style={{ padding:"9px 12px",background:C.surf2,border:`1px solid ${C.bdr}`,borderRadius:8 }}>
+                  <div style={{ fontSize:9.5,fontFamily:C.mono,color:C.txt3,marginBottom:4 }}>ADD AMOUNT</div>
+                  <div style={{ display:"flex",alignItems:"center",gap:4 }}>
+                    <span style={{ fontFamily:C.mono,fontSize:11,color:C.txt2 }}>$</span>
+                    <input type="number" value={autoAmt} onChange={e=>setAutoAmt(+e.target.value)} style={{ fontFamily:C.mono,fontSize:13,color:C.txt,width:50 }}/>
+                    <span style={{ fontFamily:C.mono,fontSize:11,color:C.txt2 }}>USDFC</span>
+                  </div>
+                </div>
+              </div>
+            )}
+            <button onClick={handlePay} disabled={!cardNum||!expiry||!cvc||finalAmt<=0}
+              style={{ width:"100%",marginTop:16,padding:"11px 0",borderRadius:9,border:"none",background:(!cardNum||!expiry||!cvc||finalAmt<=0)?C.surf3:C.teal,color:(!cardNum||!expiry||!cvc||finalAmt<=0)?C.txt3:C.bg,fontSize:13,fontFamily:C.sans,fontWeight:500,cursor:(!cardNum||!expiry||!cvc)?"not-allowed":"pointer",transition:"all 0.2s" }}>
+              Pay ${finalAmt} USDFC
+            </button>
+            <div style={{ marginTop:8,fontSize:10,fontFamily:C.mono,color:C.txt3,textAlign:"center" }}>Settled on IPC Chain · sub-second finality</div>
+          </div>
+        )}
+
+        {phase==="processing"&&(
+          <div style={{ padding:"40px 20px",textAlign:"center" }} className="fa">
+            <div style={{ fontFamily:C.mono,fontSize:9,color:C.txt3,letterSpacing:"0.1em",marginBottom:10 }}>IPC CHAIN FINALITY</div>
+            <div style={{ fontFamily:C.display,fontSize:60,lineHeight:1,color:C.teal,marginBottom:12 }}>{f3t.toFixed(2)}s</div>
+            <div style={{ fontSize:12,color:C.txt2 }}>Settling on IPC Chain...</div>
+          </div>
+        )}
+
+        {phase==="confirmed"&&(
+          <div style={{ padding:"36px 20px",textAlign:"center" }} className="fa">
+            <div style={{ width:52,height:52,borderRadius:"50%",background:C.tealDim,border:`1px solid ${C.tealBdr}`,display:"flex",alignItems:"center",justifyContent:"center",margin:"0 auto 16px",fontSize:22,color:C.teal }}>✓</div>
+            <div style={{ fontFamily:C.display,fontSize:20,color:C.teal,marginBottom:6 }}>${finalAmt} USDFC added</div>
+            <div style={{ fontSize:12,color:C.txt2,marginBottom:4 }}>New balance: <span style={{ fontFamily:C.mono,color:C.teal }}>${wallet.balance.toFixed(2)}</span></div>
+            <div style={{ fontFamily:C.mono,fontSize:10,color:C.txt3,marginBottom:20 }}>Finalized in 0.80s · IPC Chain</div>
+            {autoOn&&<div style={{ fontSize:11,color:C.txt2,padding:"9px 12px",background:C.surf2,borderRadius:8,marginBottom:16,border:`1px solid ${C.bdr}` }}>Auto top-up active: top up ${autoAmt} when balance &lt; ${threshold}</div>}
+            <Btn onClick={onClose} variant="primary" size="lg">Done →</Btn>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<App/>);
+</script>
+</body>
+</html>

--- a/demos/sp-analysis/ipc_compute_demo.jsx
+++ b/demos/sp-analysis/ipc_compute_demo.jsx
@@ -1,0 +1,603 @@
+import { useState, useEffect, useRef } from "react";
+
+const FONTS = `
+  @import url('https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=DM+Sans:wght@300;400;500&family=DM+Mono:wght@400;500&display=swap');
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  @keyframes fadeUp   { from{opacity:0;transform:translateY(8px)} to{opacity:1;transform:translateY(0)} }
+  @keyframes pulse    { 0%,100%{opacity:1} 50%{opacity:0.35} }
+  @keyframes flowDash { to{stroke-dashoffset:-20} }
+  @keyframes nodePop  { 0%{transform:scale(1)} 50%{transform:scale(1.03)} 100%{transform:scale(1)} }
+  @keyframes scanLine { 0%{transform:translateY(-100%);opacity:0.6} 100%{transform:translateY(400%);opacity:0} }
+  .fa { animation: fadeUp 0.3s ease both; }
+`;
+
+const C = {
+  bg:"#070810", surf:"#0d0f1a", surf2:"#111421", surf3:"#161b2e",
+  bdr:"#1c2138", bdrHi:"#2a3258",
+  teal:"#00c9a7",   tealDim:"rgba(0,201,167,0.08)",   tealBdr:"rgba(0,201,167,0.22)",   tealGlow:"rgba(0,201,167,0.14)",
+  amber:"#f5a623",  amberDim:"rgba(245,166,35,0.08)", amberBdr:"rgba(245,166,35,0.22)", amberGlow:"rgba(245,166,35,0.12)",
+  violet:"#9b8cf8", violetDim:"rgba(155,140,248,0.08)",violetBdr:"rgba(155,140,248,0.22)",violetGlow:"rgba(155,140,248,0.10)",
+  blue:"#4d9de0",   blueDim:"rgba(77,157,224,0.08)",  blueBdr:"rgba(77,157,224,0.22)",
+  red:"#e05252",    redDim:"rgba(224,82,82,0.08)",    redBdr:"rgba(224,82,82,0.22)",
+  txt:"#dde3f0", txt2:"#6b7a99", txt3:"#323c58",
+  mono:'"DM Mono","Fira Code",monospace', display:'"Syne",sans-serif', sans:'"DM Sans",system-ui,sans-serif',
+};
+
+const SPS = [
+  { id:"f0116628",  score:106.99, uptime:96.2, deals:106,  power:6.69 },
+  { id:"f0149768",  score:105.92, uptime:95.8, deals:83,   power:2.00 },
+  { id:"f01393827", score:104.93, uptime:100,  deals:7,    power:0.98 },
+  { id:"f0134991",  score:104.55, uptime:89.2, deals:47,   power:6.63 },
+  { id:"f03339",    score:103.57, uptime:89.6, deals:941,  power:1.08 },
+  { id:"f065103",   score:103.50, uptime:88.8, deals:86,   power:2.16 },
+  { id:"f0230200",  score:103.46, uptime:92.3, deals:39,   power:0.72 },
+  { id:"f01690643", score:103.03, uptime:100,  deals:675,  power:0.34 },
+  { id:"f01694564", score:102.92, uptime:100,  deals:212,  power:0.31 },
+  { id:"f044160",   score:102.84, uptime:93.8, deals:1268, power:0.34 },
+  { id:"f01690774", score:102.82, uptime:100,  deals:706,  power:0.27 },
+  { id:"f018501",   score:102.80, uptime:94.9, deals:461,  power:0.19 },
+  { id:"f01652952", score:102.70, uptime:100,  deals:757,  power:0.23 },
+  { id:"f01690781", score:102.69, uptime:100,  deals:953,  power:0.23 },
+  { id:"f0121768",  score:102.66, uptime:90.4, deals:14,   power:5.05 },
+];
+
+const LOGS = [
+  "[14:32:01.203]  Container ipc-llm-worker:2.1 starting",
+  "[14:32:01.891]  CUDA device: NVIDIA A100 (40 GB)",
+  "[14:32:02.114]  Loading meta-llama/Llama-3.1-8B-Instruct",
+  "[14:32:04.732]  Model ready  2.6s  14.2B params",
+  "[14:32:04.733]  Job received: 0x4a3f...c91b  prompt: 1,024 tokens",
+  "[14:32:05.102]  Fetching Filrep API...",
+  "[14:32:05.889]  Retrieved 597 storage providers",
+  "[14:32:06.221]  Running reliability analysis...",
+  "[14:32:07.341]  Scored 597/597 providers",
+  "[14:32:07.342]  Top 15 identified  avg score: 103.8",
+  "[14:32:08.001]  Generating markdown report...",
+  "[14:32:09.221]  Output complete  2,847 tokens",
+  "[14:32:09.223]  Saved /output/report.md  (68.4 KB)  exit 0 ✓",
+];
+
+const PROMPT_SHORT = "You are a data analyst. Your goal is to identify the most reliable Filecoin Storage Providers — those with a strong track record of consistent uptime, sector maintenance, and deal fulfilment.\n\nSave your final report to report.md containing:\n- Brief methodology note\n- Ranked table of top 15 most reliable SPs\n- 2–3 paragraph summary of what distinguishes top performers\n\n[+ full Filrep dataset: 597 providers]";
+
+const VALIDATORS = [
+  { id:"v1", label:"val-1.ipc-fil.io", region:"us-east" },
+  { id:"v2", label:"val-2.ipc-fil.io", region:"eu-west", elected:true },
+  { id:"v3", label:"val-3.ipc-fil.io", region:"ap-south" },
+  { id:"v4", label:"val-4.ipc-fil.io", region:"us-west" },
+];
+
+const LAYERS = [
+  { id:0, label:"IPC Chain",   sub:"Contract · Job dispatch",   color:C.teal,   dim:C.tealDim,   bdr:C.tealBdr,   glow:C.tealGlow,
+    items:["Receives contract call","Validates tx","Dispatches job to compute","Stores job_id on-chain"] },
+  { id:1, label:"IPC Compute", sub:"Validator · Docker · LLM",  color:C.amber,  dim:C.amberDim,  bdr:C.amberBdr,  glow:C.amberGlow,
+    items:["Validator elected executor","Spins up Docker container","Runs LLM with prompt","Returns structured output"] },
+  { id:2, label:"IPC Output",  sub:"IPC Storage · Registry",    color:C.violet, dim:C.violetDim, bdr:C.violetBdr, glow:C.violetGlow,
+    items:["Report → IPC Storage (CID)","Scores → SPScoreRegistry","F3 finality confirmed","Queryable by any contract"] },
+];
+
+const NAV = ["Contract call","Validator execution","Outputs committed","On-chain registry","Consumer app"];
+
+/* ── ARCH DIAGRAM ─────────────────────────────────────── */
+function ArchDiagram({ scene }) {
+  const active = scene < 3 ? scene : -1;
+  const completed = new Set(Array.from({length: Math.min(scene, 3)}, (_,i) => i));
+  return (
+    <div style={{ marginBottom:14, padding:"12px 14px", background:C.surf, border:`1px solid ${C.bdr}`, borderRadius:12 }}>
+      <div style={{ fontSize:9, fontFamily:C.mono, color:C.txt3, letterSpacing:"0.1em", marginBottom:10 }}>IPC ARCHITECTURE</div>
+      <div style={{ display:"flex", alignItems:"center" }}>
+        {LAYERS.map((l,i) => {
+          const isActive = active === l.id;
+          const isDone   = completed.has(l.id) && active !== l.id;
+          const lit      = isActive || isDone;
+          const col      = lit ? l.color : C.txt3;
+          const flowNext = i < LAYERS.length - 1 && (completed.has(l.id) || active > l.id);
+          return (
+            <div key={l.id} style={{ display:"flex", alignItems:"center", flex:1 }}>
+              <div style={{ flex:1, padding:"9px 11px", borderRadius:10, border:`1px solid ${lit ? l.bdr : C.bdr}`, background: lit ? l.dim : "transparent", boxShadow: isActive ? `0 0 18px ${l.glow}` : "none", transition:"all 0.5s" }}>
+                <div style={{ display:"flex", alignItems:"center", gap:7, marginBottom:6 }}>
+                  <LayerDot id={l.id} color={col} active={lit} pulse={isActive} />
+                  <div>
+                    <div style={{ fontSize:11, fontWeight:500, color: lit ? col : C.txt2, transition:"color 0.5s" }}>{l.label}</div>
+                    <div style={{ fontSize:9, fontFamily:C.mono, color: lit ? col+"88" : C.txt3, marginTop:1 }}>{l.sub}</div>
+                  </div>
+                  {isDone && <div style={{ marginLeft:"auto", fontFamily:C.mono, fontSize:9, color:col }}>✓</div>}
+                  {isActive && <div style={{ marginLeft:"auto", width:5, height:5, borderRadius:"50%", background:col, animation:"pulse 1s ease-in-out infinite", flexShrink:0 }} />}
+                </div>
+                <div style={{ borderTop:`1px solid ${lit ? l.bdr : C.bdr}`, paddingTop:6 }}>
+                  {l.items.map((item,j) => (
+                    <div key={j} style={{ display:"flex", alignItems:"center", gap:5, marginBottom: j < l.items.length-1 ? 3 : 0 }}>
+                      <div style={{ width:3, height:3, borderRadius:"50%", background: lit ? col : C.txt3, opacity: lit ? 0.6 : 0.3, flexShrink:0, transition:"all 0.5s" }} />
+                      <span style={{ fontSize:9.5, color: lit ? C.txt2 : C.txt3, transition:"color 0.5s" }}>{item}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              {i < LAYERS.length - 1 && (
+                <div style={{ width:28, flexShrink:0, display:"flex", flexDirection:"column", alignItems:"center", gap:2 }}>
+                  <svg width="28" height="16" style={{ overflow:"visible" }}>
+                    <line x1="2" y1="8" x2="24" y2="8" stroke={flowNext ? LAYERS[i+1].color : C.bdr} strokeWidth={flowNext ? 1.5 : 1} strokeDasharray={flowNext ? "4 3" : "3 4"} style={{ transition:"stroke 0.5s", animation: flowNext ? "flowDash 0.55s linear infinite" : "none" }} />
+                    <polygon points="20,4 27,8 20,12" fill={flowNext ? LAYERS[i+1].color : C.bdr} style={{ transition:"fill 0.5s" }} />
+                  </svg>
+                  <span style={{ fontSize:8, fontFamily:C.mono, color: flowNext ? LAYERS[i+1].color+"77" : C.txt3, transition:"color 0.5s" }}>{i===0?"job":"output"}</span>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function LayerDot({ id, color, active, pulse }) {
+  const icons = [
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none"><polygon points="5,1 9,3.5 9,6.5 5,9 1,6.5 1,3.5" stroke={color} strokeWidth="1.2" fill="none"/><circle cx="5" cy="5" r="1.5" fill={color} opacity="0.7"/></svg>,
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none"><rect x="1" y="1" width="8" height="8" rx="1.5" stroke={color} strokeWidth="1.2" fill="none"/><path d="M3 5h4M5 3v4" stroke={color} strokeWidth="1.1" strokeLinecap="round"/></svg>,
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none"><rect x="1" y="3" width="8" height="5" rx="1.5" stroke={color} strokeWidth="1.2" fill="none"/><circle cx="3.5" cy="5.5" r="0.9" fill={color} opacity="0.7"/><path d="M5.5 5.5h2.5" stroke={color} strokeWidth="1" strokeLinecap="round"/><path d="M5.5 4h2.5" stroke={color} strokeWidth="0.7" strokeLinecap="round" opacity="0.5"/></svg>,
+  ];
+  return (
+    <div style={{ width:22, height:22, borderRadius:6, background:`${color}18`, border:`1px solid ${color}40`, display:"flex", alignItems:"center", justifyContent:"center", flexShrink:0, animation: pulse ? "pulse 1.4s ease-in-out infinite" : "none", transition:"all 0.5s" }}>
+      {icons[id]}
+    </div>
+  );
+}
+
+/* ── SHARED ───────────────────────────────────────────── */
+function Badge({ children, color=C.teal, style }) {
+  return <span style={{ fontFamily:C.mono, fontSize:10, padding:"2px 7px", borderRadius:4, border:`1px solid ${color}40`, background:`${color}12`, color, letterSpacing:"0.03em", ...style }}>{children}</span>;
+}
+function Btn({ children, onClick, style }) {
+  const [h,setH] = useState(false);
+  return <button onClick={onClick} onMouseEnter={()=>setH(true)} onMouseLeave={()=>setH(false)} style={{ fontFamily:C.sans, fontSize:12, padding:"7px 16px", borderRadius:8, border:`1px solid ${C.tealBdr}`, background: h?C.tealDim:"transparent", color:C.teal, cursor:"pointer", transition:"background 0.15s", ...style }}>{children}</button>;
+}
+function ScoreBar({ score }) {
+  const pct = Math.min((score - 100) / 8 * 100, 100);
+  const col = score >= 105 ? C.teal : score >= 103 ? C.amber : C.violet;
+  return (
+    <div style={{ display:"flex", alignItems:"center", gap:7 }}>
+      <div style={{ width:48, height:3, background:C.surf3, borderRadius:2, overflow:"hidden" }}>
+        <div style={{ height:"100%", background:col, width:pct+"%", borderRadius:2 }} />
+      </div>
+      <span style={{ fontFamily:C.mono, fontSize:11, fontWeight:500, color:col }}>{score.toFixed(2)}</span>
+    </div>
+  );
+}
+
+/* ── APP ──────────────────────────────────────────────── */
+export default function App() {
+  const [scene, setScene] = useState(0);
+  const [k, setK] = useState(0);
+  function go(i) { setScene(i); setK(n=>n+1); }
+  return (
+    <div style={{ background:C.bg, minHeight:"100vh", fontFamily:C.sans, color:C.txt, padding:"1.25rem" }}>
+      <style>{FONTS}</style>
+      <div style={{ display:"flex", gap:4, marginBottom:"1.25rem", flexWrap:"wrap" }}>
+        {NAV.map((l,i) => {
+          const active=scene===i, done=scene>i;
+          return <button key={i} onClick={()=>go(i)} style={{ padding:"5px 14px", fontSize:11, fontFamily:C.sans, borderRadius:20, cursor:"pointer", transition:"all 0.2s", border:active?`1px solid ${C.teal}`:done?`1px solid ${C.tealBdr}`:`1px solid ${C.bdr}`, background:active?C.tealDim:"transparent", color:active?C.teal:done?C.teal+"88":C.txt2 }}>{done?"✓ ":`${i+1}. `}{l}</button>;
+        })}
+      </div>
+      <ArchDiagram scene={scene} />
+      <div key={k} className="fa">
+        {scene===0 && <ContractCall next={()=>go(1)} />}
+        {scene===1 && <ValidatorExecution next={()=>go(2)} />}
+        {scene===2 && <OutputsCommitted next={()=>go(3)} />}
+        {scene===3 && <OnChainRegistry next={()=>go(4)} />}
+        {scene===4 && <ConsumerApp />}
+      </div>
+    </div>
+  );
+}
+
+/* ── SCENE 1: CONTRACT CALL ───────────────────────────── */
+function ContractCall({ next }) {
+  const [showPrompt, setShowPrompt] = useState(false);
+  const [txState, setTxState] = useState("idle");
+  const [txHash] = useState("0x4a3f8b2e...c91b7d3a");
+
+  function submit() {
+    if (txState !== "idle") return;
+    setTxState("submitting");
+    setTimeout(() => setTxState("submitted"), 1400);
+  }
+
+  return (
+    <div>
+      <div style={{ fontSize:12.5, color:C.txt2, lineHeight:1.75, marginBottom:14 }}>
+        A developer calls a single contract function on the IPC chain. The prompt and job parameters are encoded as calldata — the chain handles everything from here.
+      </div>
+      <div style={{ background:C.surf, border:`1px solid ${C.bdr}`, borderRadius:12, overflow:"hidden", marginBottom:12 }}>
+        <div style={{ padding:"9px 14px", background:C.surf2, borderBottom:`1px solid ${C.bdr}`, display:"flex", alignItems:"center", justifyContent:"space-between" }}>
+          <div style={{ display:"flex", alignItems:"center", gap:8 }}>
+            <div style={{ width:8, height:8, borderRadius:"50%", background:C.teal }} />
+            <span style={{ fontFamily:C.mono, fontSize:11, color:C.teal }}>SPAnalysisJob.sol</span>
+            <span style={{ fontFamily:C.mono, fontSize:10, color:C.txt3 }}>· IPC Chain · Filecoin Calibration</span>
+          </div>
+          <Badge color={C.txt2}>0x7f3c...d4a2</Badge>
+        </div>
+        <div style={{ padding:"14px 16px" }}>
+          <div style={{ fontFamily:C.mono, fontSize:12, color:C.teal, marginBottom:12 }}>AnalyseStorageProviders()</div>
+          <div style={{ display:"grid", gap:8, marginBottom:12 }}>
+            {[
+              ["job_type", '"llm_inference"', C.violet],
+              ["model",    '"meta-llama/Llama-3.1-8B-Instruct"', C.amber],
+              ["timeout",  "300", C.txt2],
+              ["callback", '"SPScoreRegistry.storeResults"', C.teal],
+            ].map(([k,v,col]) => (
+              <div key={k} style={{ display:"flex", gap:10, alignItems:"baseline" }}>
+                <span style={{ fontFamily:C.mono, fontSize:11, color:C.txt3, width:70, flexShrink:0 }}>{k}</span>
+                <span style={{ fontFamily:C.mono, fontSize:11, color:col }}>{v}</span>
+              </div>
+            ))}
+            <div style={{ borderTop:`1px solid ${C.bdr}`, paddingTop:10, marginTop:2 }}>
+              <div style={{ display:"flex", justifyContent:"space-between", alignItems:"center", marginBottom: showPrompt ? 8 : 0 }}>
+                <span style={{ fontFamily:C.mono, fontSize:11, color:C.txt3 }}>prompt</span>
+                <button onClick={()=>setShowPrompt(s=>!s)} style={{ fontFamily:C.mono, fontSize:10, color:C.amber, background:"transparent", border:`1px solid ${C.amberBdr}`, borderRadius:4, padding:"1px 7px", cursor:"pointer" }}>{showPrompt?"hide ↑":"view ↓"}</button>
+              </div>
+              {showPrompt && (
+                <pre style={{ fontFamily:C.mono, fontSize:10, color:C.txt2, background:C.surf2, borderRadius:8, padding:"10px 12px", lineHeight:1.75, whiteSpace:"pre-wrap", border:`1px solid ${C.bdr}`, marginTop:2 }} className="fa">{PROMPT_SHORT}</pre>
+              )}
+            </div>
+          </div>
+          {txState === "idle" && <Btn onClick={submit} style={{ width:"100%" }}>Submit transaction →</Btn>}
+          {txState === "submitting" && (
+            <div style={{ padding:"10px 14px", background:C.amberDim, border:`1px solid ${C.amberBdr}`, borderRadius:8, fontFamily:C.mono, fontSize:11, color:C.amber, display:"flex", alignItems:"center", gap:8 }} className="fa">
+              <div style={{ width:8, height:8, borderRadius:"50%", background:C.amber, animation:"pulse 0.7s ease-in-out infinite", flexShrink:0 }} />
+              Broadcasting to IPC chain...
+            </div>
+          )}
+          {txState === "submitted" && (
+            <div className="fa">
+              <div style={{ padding:"10px 14px", background:C.tealDim, border:`1px solid ${C.tealBdr}`, borderRadius:8, marginBottom:10 }}>
+                <div style={{ fontFamily:C.mono, fontSize:10, color:C.txt3, marginBottom:4 }}>TRANSACTION CONFIRMED</div>
+                <div style={{ fontFamily:C.mono, fontSize:11, color:C.teal, marginBottom:2 }}>tx: {txHash}</div>
+                <div style={{ fontFamily:C.mono, fontSize:11, color:C.txt2 }}>job_id: <span style={{ color:C.amber }}>0x4a3f...c91b</span> &nbsp;·&nbsp; block: <span style={{ color:C.teal }}>412,847</span></div>
+              </div>
+              <div style={{ display:"flex", justifyContent:"flex-end" }}><Btn onClick={next}>Watch validator execute →</Btn></div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── SCENE 2: VALIDATOR EXECUTION ─────────────────────── */
+function ValidatorExecution({ next }) {
+  const [phase, setPhase] = useState(0);
+  const [logLines, setLogLines] = useState([]);
+  const logRef = useRef(null);
+
+  useEffect(() => {
+    const t0 = setTimeout(() => setPhase(1), 600);
+    const t1 = setTimeout(() => setPhase(2), 1400);
+    const t2 = setTimeout(() => setPhase(3), 2000);
+    return () => { clearTimeout(t0); clearTimeout(t1); clearTimeout(t2); };
+  }, []);
+
+  useEffect(() => {
+    if (phase !== 3) return;
+    let i = 0;
+    const id = setInterval(() => {
+      if (i >= LOGS.length) { clearInterval(id); setPhase(4); return; }
+      setLogLines(p => [...p, LOGS[i]]);
+      i++;
+    }, 320);
+    return () => clearInterval(id);
+  }, [phase]);
+
+  useEffect(() => {
+    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
+  }, [logLines]);
+
+  return (
+    <div>
+      <div style={{ fontSize:12.5, color:C.txt2, lineHeight:1.75, marginBottom:14 }}>
+        The IPC chain elects a validator to execute the job. The elected validator spins up a Docker container with the LLM runtime and streams output back to the chain.
+      </div>
+      {/* Validator grid */}
+      <div style={{ display:"grid", gridTemplateColumns:"1fr 1fr", gap:8, marginBottom:12 }}>
+        {VALIDATORS.map(v => {
+          const elected = v.elected && phase >= 2;
+          const electing = v.elected && phase === 1;
+          const idle = !v.elected || phase < 1;
+          const col = elected ? C.amber : electing ? C.amber : C.txt3;
+          return (
+            <div key={v.id} style={{ padding:"10px 12px", borderRadius:10, border:`1px solid ${elected ? C.amberBdr : electing ? C.amberBdr : C.bdr}`, background: elected ? C.amberDim : "transparent", boxShadow: elected ? `0 0 18px ${C.amberGlow}` : "none", transition:"all 0.4s" }}>
+              <div style={{ display:"flex", alignItems:"center", gap:8 }}>
+                <div style={{ width:8, height:8, borderRadius:"50%", background: elected||electing ? C.amber : C.bdrHi, animation: electing ? "pulse 0.5s ease-in-out infinite" : "none", flexShrink:0, transition:"background 0.4s" }} />
+                <div style={{ flex:1 }}>
+                  <div style={{ fontFamily:C.mono, fontSize:11, color: col, transition:"color 0.4s" }}>{v.label}</div>
+                  <div style={{ fontFamily:C.mono, fontSize:9.5, color:C.txt3, marginTop:1 }}>{v.region}</div>
+                </div>
+                {elected && <Badge color={C.amber}>EXECUTOR</Badge>}
+                {!v.elected && phase >= 2 && <span style={{ fontFamily:C.mono, fontSize:9.5, color:C.txt3 }}>standby</span>}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Execution log */}
+      {phase >= 3 && (
+        <div style={{ background:C.surf, border:`1px solid ${C.amberBdr}`, borderRadius:12, overflow:"hidden", marginBottom:12 }} className="fa">
+          <div style={{ padding:"8px 12px", background:C.amberDim, borderBottom:`1px solid ${C.amberBdr}`, display:"flex", alignItems:"center", gap:8 }}>
+            <div style={{ width:7, height:7, borderRadius:"50%", background:C.amber, animation: phase===3?"pulse 0.8s ease-in-out infinite":"none" }} />
+            <span style={{ fontFamily:C.mono, fontSize:10, color:C.amber }}>val-2.ipc-fil.io</span>
+            <span style={{ fontFamily:C.mono, fontSize:10, color:C.txt3 }}>·</span>
+            <span style={{ fontFamily:C.mono, fontSize:10, color:C.txt3 }}>ipc-llm-worker:2.1</span>
+            {phase===4 && <Badge color={C.teal} style={{ marginLeft:"auto" }}>complete ✓</Badge>}
+          </div>
+          <div ref={logRef} style={{ padding:"10px 12px", maxHeight:190, overflowY:"auto", scrollBehavior:"smooth" }}>
+            {logLines.map((l,i) => (
+              <div key={i} style={{ fontFamily:C.mono, fontSize:10.5, lineHeight:1.85, color: i===logLines.length-1 ? C.teal : i > logLines.length-3 ? C.txt2 : C.txt3, transition:"color 0.4s" }}>{l}</div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {phase === 4 && (
+        <div style={{ display:"flex", justifyContent:"flex-end" }} className="fa">
+          <Btn onClick={next}>See outputs committed →</Btn>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── SCENE 3: OUTPUTS COMMITTED ───────────────────────── */
+function OutputsCommitted({ next }) {
+  const [storeDone, setStoreDone] = useState(false);
+  const [chainDone, setChainDone] = useState(false);
+  const [f3t, setF3t] = useState(0);
+  const [f3fin, setF3fin] = useState(false);
+
+  useEffect(() => {
+    setTimeout(() => setStoreDone(true), 1000);
+    setTimeout(() => setChainDone(true), 2200);
+  }, []);
+
+  useEffect(() => {
+    if (!chainDone) return;
+    let t = 0;
+    const id = setInterval(() => {
+      t = parseFloat(Math.min(t+0.1, 2.4).toFixed(1));
+      setF3t(t);
+      if (t >= 2.4) { clearInterval(id); setF3fin(true); }
+    }, 70);
+    return () => clearInterval(id);
+  }, [chainDone]);
+
+  return (
+    <div>
+      <div style={{ fontSize:12.5, color:C.txt2, lineHeight:1.75, marginBottom:14 }}>
+        Two outputs are committed in sequence. The full report goes to IPC Storage as a permanent content-addressed document. The scored SP data is written on-chain to the registry contract.
+      </div>
+      <div style={{ display:"grid", gridTemplateColumns:"1fr 1fr", gap:12, marginBottom:12 }}>
+
+        {/* IPC Storage */}
+        <div style={{ border:`1px solid ${storeDone ? C.violetBdr : C.bdr}`, borderRadius:12, padding:"12px 14px", background: storeDone ? C.violetDim : C.surf, transition:"all 0.5s", boxShadow: storeDone ? `0 0 18px ${C.violetGlow}` : "none" }}>
+          <div style={{ display:"flex", alignItems:"center", gap:7, marginBottom:10 }}>
+            <div style={{ width:8, height:8, borderRadius:"50%", background: storeDone ? C.violet : C.bdrHi, animation: !storeDone ? "pulse 0.8s ease-in-out infinite" : "none", transition:"background 0.5s", flexShrink:0 }} />
+            <span style={{ fontSize:11, fontWeight:500, color: storeDone ? C.violet : C.txt2, transition:"color 0.5s" }}>IPC Storage</span>
+          </div>
+          <pre style={{ fontFamily:C.mono, fontSize:10, color: storeDone ? C.txt2 : C.txt3, lineHeight:1.85, whiteSpace:"pre-wrap", transition:"color 0.5s" }}>{`POST report.md\nSize:     68.4 KB\nReplicas: 3/3`}</pre>
+          {storeDone && (
+            <div style={{ marginTop:8, paddingTop:8, borderTop:`1px solid ${C.violetBdr}` }} className="fa">
+              <div style={{ fontFamily:C.mono, fontSize:9.5, color:C.txt3, marginBottom:3 }}>CID</div>
+              <div style={{ fontFamily:C.mono, fontSize:10.5, color:C.violet }}>bafybeig7xq2m...r4p9wk</div>
+              <Badge color={C.violet} style={{ marginTop:6 }}>confirmed ✓</Badge>
+            </div>
+          )}
+        </div>
+
+        {/* On-chain registry */}
+        <div style={{ border:`1px solid ${chainDone ? C.tealBdr : C.bdr}`, borderRadius:12, padding:"12px 14px", background: chainDone ? C.tealDim : C.surf, transition:"all 0.5s", boxShadow: chainDone ? `0 0 18px ${C.tealGlow}` : "none" }}>
+          <div style={{ display:"flex", alignItems:"center", gap:7, marginBottom:10 }}>
+            <div style={{ width:8, height:8, borderRadius:"50%", background: chainDone ? C.teal : C.bdrHi, animation: storeDone && !chainDone ? "pulse 0.8s ease-in-out infinite" : "none", transition:"background 0.5s", flexShrink:0 }} />
+            <span style={{ fontSize:11, fontWeight:500, color: chainDone ? C.teal : C.txt2, transition:"color 0.5s" }}>SPScoreRegistry</span>
+          </div>
+          <pre style={{ fontFamily:C.mono, fontSize:10, color: chainDone ? C.txt2 : C.txt3, lineHeight:1.85, whiteSpace:"pre-wrap", transition:"color 0.5s" }}>{`storeResults({\n  f0116628:  106.99\n  f0149768:  105.92\n  f01393827: 104.93\n  ... +12 more\n})`}</pre>
+          {chainDone && (
+            <div style={{ marginTop:8, paddingTop:8, borderTop:`1px solid ${C.tealBdr}` }} className="fa">
+              <div style={{ display:"flex", alignItems:"center", gap:8, marginBottom:6 }}>
+                <span style={{ fontFamily:C.mono, fontSize:9.5, color:C.txt3 }}>F3 FINALITY</span>
+                <span style={{ fontFamily:C.display, fontSize:22, fontWeight:500, color:f3fin?C.teal:C.txt, transition:"color 0.4s", lineHeight:1 }}>{f3t.toFixed(1)}s</span>
+                {f3fin && <Badge>FINAL ✓</Badge>}
+              </div>
+              <div style={{ fontFamily:C.mono, fontSize:10, color:C.txt3 }}>block 412,848 · 15 providers written</div>
+            </div>
+          )}
+        </div>
+      </div>
+      {f3fin && (
+        <div style={{ display:"flex", justifyContent:"flex-end" }} className="fa">
+          <Btn onClick={next}>View on-chain registry →</Btn>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── SCENE 4: ON-CHAIN REGISTRY ───────────────────────── */
+function OnChainRegistry({ next }) {
+  const [queryVal, setQueryVal] = useState("");
+  const [queryResult, setQueryResult] = useState(null);
+  const [querying, setQuerying] = useState(false);
+
+  function runQuery() {
+    const id = queryVal.trim() || "f0116628";
+    setQuerying(true);
+    setQueryResult(null);
+    setTimeout(() => {
+      const sp = SPS.find(s => s.id === id) || SPS[0];
+      setQueryResult(sp);
+      setQuerying(false);
+    }, 800);
+  }
+
+  return (
+    <div>
+      <div style={{ fontSize:12.5, color:C.txt2, lineHeight:1.75, marginBottom:14 }}>
+        The registry is now live on-chain. Any contract or app can call <span style={{ fontFamily:C.mono, fontSize:11, color:C.teal }}>getScore()</span> or <span style={{ fontFamily:C.mono, fontSize:11, color:C.teal }}>getTopN()</span>. The evidence CID traces every score back to the full LLM analysis in IPC Storage.
+      </div>
+
+      {/* Table */}
+      <div style={{ background:C.surf, border:`1px solid ${C.bdr}`, borderRadius:12, overflow:"hidden", marginBottom:12 }}>
+        <div style={{ padding:"8px 12px", background:C.surf2, borderBottom:`1px solid ${C.bdr}`, display:"grid", gridTemplateColumns:"24px 1fr 110px 68px 68px 55px", gap:8 }}>
+          {["#","Provider ID","Score","Uptime","Deals","Power"].map(h => (
+            <span key={h} style={{ fontSize:9.5, fontFamily:C.mono, color:C.txt3, letterSpacing:"0.05em" }}>{h}</span>
+          ))}
+        </div>
+        {SPS.map((sp,i) => (
+          <div key={sp.id} style={{ padding:"7px 12px", borderBottom: i<SPS.length-1?`1px solid ${C.bdr}`:"none", display:"grid", gridTemplateColumns:"24px 1fr 110px 68px 68px 55px", gap:8, alignItems:"center", background: i<3 ? `${LAYERS[0].color}05` : "transparent" }}>
+            <span style={{ fontFamily:C.mono, fontSize:10, color:C.txt3 }}>#{i+1}</span>
+            <span style={{ fontFamily:C.mono, fontSize:11, color: i<3 ? C.teal : C.txt }}>{sp.id}</span>
+            <ScoreBar score={sp.score} />
+            <span style={{ fontFamily:C.mono, fontSize:10, color:C.txt2 }}>{sp.uptime.toFixed(1)}%</span>
+            <span style={{ fontFamily:C.mono, fontSize:10, color:C.txt2 }}>{sp.deals.toLocaleString()}</span>
+            <span style={{ fontFamily:C.mono, fontSize:10, color:C.txt3 }}>{sp.power} PiB</span>
+          </div>
+        ))}
+        <div style={{ padding:"8px 12px", borderTop:`1px solid ${C.bdr}`, fontFamily:C.mono, fontSize:10, color:C.txt3 }}>
+          evidence_cid: <span style={{ color:C.violet }}>bafybeig7xq2m...r4p9wk</span> &nbsp;·&nbsp; block 412,848 &nbsp;·&nbsp; job 0x4a3f...c91b
+        </div>
+      </div>
+
+      {/* Contract read demo */}
+      <div style={{ background:C.surf, border:`1px solid ${C.bdr}`, borderRadius:12, padding:"12px 14px", marginBottom:12 }}>
+        <div style={{ fontSize:10, fontFamily:C.mono, color:C.txt3, marginBottom:8 }}>CONTRACT READ — SPScoreRegistry.getScore()</div>
+        <div style={{ display:"flex", gap:8, alignItems:"center" }}>
+          <input value={queryVal} onChange={e=>setQueryVal(e.target.value)} placeholder="f0116628" style={{ flex:1, fontFamily:C.mono, fontSize:11, padding:"6px 10px", background:C.surf2, border:`1px solid ${C.bdr}`, borderRadius:7, color:C.txt, outline:"none" }} />
+          <Btn onClick={runQuery} style={{ flexShrink:0 }}>Query →</Btn>
+        </div>
+        {querying && (
+          <div style={{ marginTop:8, fontFamily:C.mono, fontSize:11, color:C.amber, display:"flex", alignItems:"center", gap:6 }} className="fa">
+            <div style={{ width:6, height:6, borderRadius:"50%", background:C.amber, animation:"pulse 0.7s ease-in-out infinite" }} />
+            Reading from IPC chain...
+          </div>
+        )}
+        {queryResult && !querying && (
+          <div style={{ marginTop:8, padding:"10px 12px", background:C.tealDim, border:`1px solid ${C.tealBdr}`, borderRadius:8 }} className="fa">
+            <pre style={{ fontFamily:C.mono, fontSize:11, color:C.teal, lineHeight:1.85, whiteSpace:"pre-wrap" }}>{`{\n  id:       "${queryResult.id}",\n  score:    ${queryResult.score},\n  uptime:   ${queryResult.uptime}%,\n  deals:    ${queryResult.deals},\n  power:    ${queryResult.power} PiB,\n  evidence: "bafybeig7xq2m...r4p9wk"\n}`}</pre>
+          </div>
+        )}
+      </div>
+
+      <div style={{ display:"flex", justifyContent:"flex-end" }}>
+        <Btn onClick={next}>See a consuming app →</Btn>
+      </div>
+    </div>
+  );
+}
+
+/* ── SCENE 5: CONSUMER APP ────────────────────────────── */
+function ConsumerApp() {
+  const [uploadState, setUploadState] = useState("idle");
+  const [providers, setProviders] = useState([]);
+  const [uploadPct, setUploadPct] = useState(0);
+  const [uploadDone, setUploadDone] = useState(false);
+
+  function startUpload() {
+    if (uploadState !== "idle") return;
+    setUploadState("routing");
+    setTimeout(() => {
+      setProviders(SPS.slice(0,3));
+      setUploadState("routed");
+      setTimeout(() => {
+        setUploadState("uploading");
+        let p = 0;
+        const id = setInterval(() => {
+          p = Math.min(p + 2, 100);
+          setUploadPct(p);
+          if (p >= 100) { clearInterval(id); setUploadDone(true); }
+        }, 45);
+      }, 900);
+    }, 1000);
+  }
+
+  return (
+    <div>
+      <div style={{ fontSize:12.5, color:C.txt2, lineHeight:1.75, marginBottom:14 }}>
+        Any app can now route storage decisions using the on-chain scores — without running its own analysis, without trusting a third party. The LLM ran once; the result is permanent infrastructure.
+      </div>
+
+      {/* App UI */}
+      <div style={{ background:C.surf, border:`1px solid ${C.bdr}`, borderRadius:12, overflow:"hidden", marginBottom:12 }}>
+        <div style={{ padding:"9px 14px", background:C.surf2, borderBottom:`1px solid ${C.bdr}`, display:"flex", alignItems:"center", gap:8 }}>
+          <div style={{ width:7, height:7, borderRadius:"50%", background:C.teal }} />
+          <span style={{ fontSize:11, fontFamily:C.mono, color:C.txt2 }}>storage-app · upload.js</span>
+        </div>
+        <div style={{ padding:"14px 16px" }}>
+          {/* File card */}
+          <div style={{ display:"flex", alignItems:"center", gap:12, padding:"10px 12px", background:C.surf2, borderRadius:9, border:`1px solid ${C.bdr}`, marginBottom:12 }}>
+            <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+              <rect x="3" y="2" width="18" height="24" rx="3" stroke={C.teal} strokeWidth="1.4" fill={C.tealDim}/>
+              <path d="M14 2v7h7" stroke={C.teal} strokeWidth="1.4" fill="none"/>
+              <rect x="7" y="13" width="10" height="1.2" rx="0.6" fill={C.teal} opacity="0.5"/>
+              <rect x="7" y="16.5" width="7" height="1.2" rx="0.6" fill={C.teal} opacity="0.3"/>
+            </svg>
+            <div style={{ flex:1 }}>
+              <div style={{ fontSize:12, fontWeight:500, color:C.txt }}>filecoin_datasets_2026Q1.tar.gz</div>
+              <div style={{ fontSize:11, color:C.txt2, marginTop:1 }}>2.4 GB &nbsp;·&nbsp; 14 files</div>
+            </div>
+            {uploadState === "idle" && <Btn onClick={startUpload}>Upload →</Btn>}
+            {uploadState !== "idle" && !uploadDone && <Badge color={C.amber}>{uploadState}</Badge>}
+            {uploadDone && <Badge>stored ✓</Badge>}
+          </div>
+
+          {/* Routing step */}
+          {uploadState !== "idle" && (
+            <div style={{ marginBottom: providers.length ? 10 : 0 }} className="fa">
+              <div style={{ fontFamily:C.mono, fontSize:10.5, color:C.txt3, marginBottom:6 }}>
+                <span style={{ color:C.teal }}>SPScoreRegistry</span>.getTopN(3) →
+              </div>
+              {providers.length === 0 && (
+                <div style={{ fontFamily:C.mono, fontSize:11, color:C.amber, display:"flex", alignItems:"center", gap:6 }}>
+                  <div style={{ width:6, height:6, borderRadius:"50%", background:C.amber, animation:"pulse 0.7s ease-in-out infinite" }} />
+                  Reading on-chain scores...
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Provider cards */}
+          {providers.length > 0 && (
+            <div style={{ display:"grid", gridTemplateColumns:"1fr 1fr 1fr", gap:8, marginBottom:12 }} className="fa">
+              {providers.map((sp,i) => (
+                <div key={sp.id} style={{ padding:"9px 11px", background:C.tealDim, border:`1px solid ${C.tealBdr}`, borderRadius:9 }}>
+                  <div style={{ fontFamily:C.mono, fontSize:10, color:C.teal, marginBottom:4 }}>{sp.id}</div>
+                  <div style={{ fontFamily:C.mono, fontSize:13, fontWeight:500, color:C.teal, marginBottom:2 }}>{sp.score.toFixed(2)}</div>
+                  <div style={{ fontFamily:C.mono, fontSize:9.5, color:C.txt3 }}>rank #{i+1}</div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Upload progress */}
+          {uploadState === "uploading" && (
+            <div className="fa">
+              <div style={{ display:"flex", justifyContent:"space-between", alignItems:"center", marginBottom:5 }}>
+                <span style={{ fontFamily:C.mono, fontSize:10.5, color:C.txt2 }}>Distributing to 3 providers</span>
+                <span style={{ fontFamily:C.mono, fontSize:11, color:C.teal }}>{uploadPct}%</span>
+              </div>
+              <div style={{ height:4, background:C.surf3, borderRadius:2, overflow:"hidden" }}>
+                <div style={{ height:"100%", background:C.teal, width:uploadPct+"%", borderRadius:2, transition:"width 0.05s linear" }} />
+              </div>
+            </div>
+          )}
+
+          {uploadDone && (
+            <div style={{ padding:"10px 14px", background:C.tealDim, border:`1px solid ${C.tealBdr}`, borderRadius:9, fontFamily:C.mono, fontSize:11, color:C.teal, marginTop:8 }} className="fa">
+              Stored across f0116628 · f0149768 · f01393827 &nbsp;·&nbsp; deal IDs on-chain ✓
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div style={{ padding:"11px 14px", background:C.surf2, borderRadius:10, borderLeft:`3px solid ${C.amber}`, fontSize:12, color:C.txt2, lineHeight:1.7 }}>
+        The LLM analysis ran once on IPC Compute. The scores are permanent on-chain state. Every app that uploads to Filecoin can now route to the best providers — for free, forever, with no API key and no trusted intermediary.
+      </div>
+    </div>
+  );
+}

--- a/demos/src/App.jsx
+++ b/demos/src/App.jsx
@@ -1,0 +1,56 @@
+import { useMemo, useState } from "react";
+import ReputationDemo from "../dev-reputation-mock/ipc_reputation_demo.jsx";
+import SPAnalysisDemo from "../sp-analysis/ipc_compute_demo.jsx";
+
+const DEMOS = {
+  reputation: {
+    label: "dev-reputation-mock",
+    component: ReputationDemo,
+  },
+  sp: {
+    label: "sp-analysis",
+    component: SPAnalysisDemo,
+  },
+};
+
+function getDemoFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("demo") || "reputation";
+}
+
+function setDemoInUrl(demo) {
+  const url = new URL(window.location.href);
+  url.searchParams.set("demo", demo);
+  window.history.replaceState(null, "", url.toString());
+}
+
+export default function App() {
+  const initialDemo = useMemo(() => {
+    const requested = getDemoFromUrl();
+    return DEMOS[requested] ? requested : "reputation";
+  }, []);
+  const [demoKey, setDemoKey] = useState(initialDemo);
+  const DemoComponent = DEMOS[demoKey].component;
+
+  return (
+    <div>
+      <div className="demo-switcher">
+        {Object.entries(DEMOS).map(([key, { label }]) => (
+          <button
+            key={key}
+            className={key === demoKey ? "active" : ""}
+            onClick={() => {
+              setDemoInUrl(key);
+              setDemoKey(key);
+            }}
+            type="button"
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <DemoComponent />
+    </div>
+  );
+}

--- a/demos/src/app.css
+++ b/demos/src/app.css
@@ -1,0 +1,40 @@
+html,
+body,
+#root {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  background: #070810;
+}
+
+button {
+  font: inherit;
+}
+
+.demo-switcher {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 9999;
+  display: flex;
+  gap: 6px;
+  padding: 6px;
+  border: 1px solid rgba(0, 201, 167, 0.25);
+  border-radius: 10px;
+  background: rgba(8, 11, 19, 0.8);
+  backdrop-filter: blur(6px);
+}
+
+.demo-switcher button {
+  border: 1px solid rgba(0, 201, 167, 0.35);
+  color: #00c9a7;
+  background: transparent;
+  border-radius: 8px;
+  padding: 5px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.demo-switcher button.active {
+  background: rgba(0, 201, 167, 0.15);
+}

--- a/demos/src/main.jsx
+++ b/demos/src/main.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.jsx";
+import "./app.css";
+
+createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/demos/vite.config.js
+++ b/demos/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: "127.0.0.1",
+    port: 5173,
+    open: true,
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk since changes are isolated to a new `demos/` package and do not affect production code paths; primary risk is repo bloat and dependency/Node version friction from adding Vite/React and a large lockfile.
> 
> **Overview**
> Adds a new `demos/` Vite + React app (with `pnpm` lockfile) to run offsite JSX demos locally via `pnpm dev`, including a top-right demo switcher and `/?demo=` URL selection.
> 
> Introduces two self-contained demo UIs: `dev-reputation-mock` (simulated reputation scoring pipeline with storage/on-chain verification flow) and `sp-analysis` (simulated IPC compute job lifecycle, output commit, registry query, and consumer routing), plus a standalone `sp-analysis-web/ipc_compute.html` version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dab097669f174f8e175d426a5023c1467cc35845. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->